### PR TITLE
chore(release): v0.3.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "921ad333c19d649ffcee2436624d86661759bf69",
+  "baseline-sha": "0678e53e6e77e3a79889035f2a83a58c181bbfc6",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.2.0",
-      "tag": "v0.2.0"
+      "version": "0.3.0",
+      "tag": "v0.3.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "0.3.0",
+      "tag": "arity-code-v0.3.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.2.0",
-      "tag": "v0.2.0"
+      "version": "0.3.0",
+      "tag": "v0.3.0"
+    },
+    {
+      "path": "editors/code",
+      "version": "0.3.0",
+      "tag": "arity-code-v0.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/arity/compare/v0.2.0...v0.3.0) (2026-06-12)
+
+### Features
+- add VS Code / Open VSX extension ([`4501ec4`](https://github.com/jolars/arity/commit/4501ec4119b949518874024b1b2f8fbbb19cb8e6))
+- **lsp:** index default R packages for hover ([`3bf0927`](https://github.com/jolars/arity/commit/3bf0927d666ade67aca70502583b91848f703f2a))
+- build man pages and completion and cli docs ([`660d947`](https://github.com/jolars/arity/commit/660d9475f246ebf75e625e1de37f955a1075df7f))
+
 ## [0.2.0](https://github.com/jolars/arity/compare/v0.1.0...v0.2.0) (2026-06-12)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arity"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -364,9 +364,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 readme = "README.md"
 description = "An LSP, formatter, and linter for R"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/arity/compare/arity-code-v0.2.0...arity-code-v0.3.0) (2026-06-12)
+
+### Features
+- add VS Code / Open VSX extension ([`4501ec4`](https://github.com/jolars/arity/commit/4501ec4119b949518874024b1b2f8fbbb19cb8e6))
+
+### Dependencies
+- updated arity to v0.3.0
+
 All notable changes to the Arity VS Code extension are documented here.
 
 ## 0.2.0

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",
@@ -63,7 +63,11 @@
       "properties": {
         "arity.executableStrategy": {
           "type": "string",
-          "enum": ["bundled", "environment", "path"],
+          "enum": [
+            "bundled",
+            "environment",
+            "path"
+          ],
           "enumDescriptions": [
             "Use the binary bundled inside the extension; fall back to downloading from GitHub if none is bundled or `arity.version`/`arity.releaseTag` is set explicitly (default).",
             "Look for `arity` on the system PATH.",
@@ -73,7 +77,10 @@
           "markdownDescription": "Strategy used to locate the `arity` executable for the language server."
         },
         "arity.executablePath": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "default": null,
           "markdownDescription": "Path to the `arity` executable. Only used when `arity.executableStrategy` is set to `path`."
         },
@@ -94,38 +101,61 @@
         },
         "arity.serverArgs": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Additional command-line arguments passed after `arity lsp`."
         },
         "arity.serverEnv": {
           "type": "object",
-          "additionalProperties": {"type": "string"},
+          "additionalProperties": {
+            "type": "string"
+          },
           "default": {},
           "description": "Environment variables merged into the Arity language server process."
         },
         "arity.extraPath": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Extra PATH entries prepended for the Arity language server process."
         },
         "arity.logLevel": {
-          "type": ["string", "null"],
-          "enum": [null, "off", "error", "warn", "info", "debug", "trace"],
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
           "default": null,
           "markdownDescription": "Log level for the Arity language server. Maps to the `RUST_LOG` environment variable. Leave unset to use the server's default. If `arity.serverEnv.RUST_LOG` is also set, it takes precedence."
         },
         "arity.trace.server": {
           "type": "string",
-          "enum": ["off", "messages", "verbose"],
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
           "default": "off",
           "description": "Trace communication between VS Code and the Arity language server."
         }
       }
     },
     "configurationDefaults": {
-      "[r]": {"editor.defaultFormatter": "jolars.arity"}
+      "[r]": {
+        "editor.defaultFormatter": "jolars.arity"
+      }
     },
     "commands": [
       {


### PR DESCRIPTION
## [arity: 0.3.0](https://github.com/jolars/arity/compare/v0.2.0...v0.3.0) (2026-06-12)

### Features
- add VS Code / Open VSX extension ([`4501ec4`](https://github.com/jolars/arity/commit/4501ec4119b949518874024b1b2f8fbbb19cb8e6))
- **lsp:** index default R packages for hover ([`3bf0927`](https://github.com/jolars/arity/commit/3bf0927d666ade67aca70502583b91848f703f2a))
- build man pages and completion and cli docs ([`660d947`](https://github.com/jolars/arity/commit/660d9475f246ebf75e625e1de37f955a1075df7f))

## [editors/code: 0.3.0](https://github.com/jolars/arity/compare/arity-code-v0.2.0...arity-code-v0.3.0) (2026-06-12)

### Features
- add VS Code / Open VSX extension ([`4501ec4`](https://github.com/jolars/arity/commit/4501ec4119b949518874024b1b2f8fbbb19cb8e6))

### Dependencies
- updated arity to v0.3.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).