### PR TITLE
chore(release): v0.4.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "0678e53e6e77e3a79889035f2a83a58c181bbfc6",
+  "baseline-sha": "ea0658b3d386fd24f0df528b3784384a14e3eeaa",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.3.0",
-      "tag": "v0.3.0"
+      "version": "0.4.0",
+      "tag": "v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.3.0",
-      "tag": "arity-code-v0.3.0"
+      "version": "0.4.0",
+      "tag": "arity-code-v0.4.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.3.0",
-      "tag": "v0.3.0"
+      "version": "0.4.0",
+      "tag": "v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.3.0",
-      "tag": "arity-code-v0.3.0"
+      "version": "0.4.0",
+      "tag": "arity-code-v0.4.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/arity/compare/v0.3.0...v0.4.0) (2026-06-12)
+
+### Features
+- add npm distribution (arity-cli) ([`ea0658b`](https://github.com/jolars/arity/commit/ea0658b3d386fd24f0df528b3784384a14e3eeaa))
+
 ## [0.3.0](https://github.com/jolars/arity/compare/v0.2.0...v0.3.0) (2026-06-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arity"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 readme = "README.md"
 description = "An LSP, formatter, and linter for R"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/arity/compare/arity-code-v0.3.0...arity-code-v0.4.0) (2026-06-12)
+
+### Dependencies
+- updated arity to v0.4.0
+
 ## [0.3.0](https://github.com/jolars/arity/compare/arity-code-v0.2.0...arity-code-v0.3.0) (2026-06-12)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.3.0",
-    "@arity-cli/linux-arm64-gnu": "0.3.0",
-    "@arity-cli/linux-x64-musl": "0.3.0",
-    "@arity-cli/linux-arm64-musl": "0.3.0",
-    "@arity-cli/darwin-x64": "0.3.0",
-    "@arity-cli/darwin-arm64": "0.3.0",
-    "@arity-cli/win32-x64": "0.3.0",
-    "@arity-cli/win32-arm64": "0.3.0"
+    "@arity-cli/linux-x64-gnu": "0.4.0",
+    "@arity-cli/linux-arm64-gnu": "0.4.0",
+    "@arity-cli/linux-x64-musl": "0.4.0",
+    "@arity-cli/linux-arm64-musl": "0.4.0",
+    "@arity-cli/darwin-x64": "0.4.0",
+    "@arity-cli/darwin-arm64": "0.4.0",
+    "@arity-cli/win32-x64": "0.4.0",
+    "@arity-cli/win32-arm64": "0.4.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.4.0](https://github.com/jolars/arity/compare/v0.3.0...v0.4.0) (2026-06-12)

### Features
- add npm distribution (arity-cli) ([`ea0658b`](https://github.com/jolars/arity/commit/ea0658b3d386fd24f0df528b3784384a14e3eeaa))

## [editors/code: 0.4.0](https://github.com/jolars/arity/compare/arity-code-v0.3.0...arity-code-v0.4.0) (2026-06-12)

### Dependencies
- updated arity to v0.4.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).