### PR TITLE
chore(release): v0.5.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ea0658b3d386fd24f0df528b3784384a14e3eeaa",
+  "baseline-sha": "7f578d2a159e82285edf7f52d8648987accb2cbc",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.4.0",
-      "tag": "v0.4.0"
+      "version": "0.5.0",
+      "tag": "v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.4.0",
-      "tag": "arity-code-v0.4.0"
+      "version": "0.5.0",
+      "tag": "arity-code-v0.5.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.4.0",
-      "tag": "v0.4.0"
+      "version": "0.5.0",
+      "tag": "v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.4.0",
-      "tag": "arity-code-v0.4.0"
+      "version": "0.5.0",
+      "tag": "arity-code-v0.5.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/arity/compare/v0.4.0...v0.5.0) (2026-06-18)
+
+### Features
+- **lsp:** add semantic tokens (full) ([`7f578d2`](https://github.com/jolars/arity/commit/7f578d2a159e82285edf7f52d8648987accb2cbc))
+- **lsp:** rename binding-only reads instead of refusing (B2.4) ([`b4643d8`](https://github.com/jolars/arity/commit/b4643d8a6a74cc794c19947e106ca403e37c29be))
+- **lsp:** add workspace/symbol fuzzy name search ([`56ba0dc`](https://github.com/jolars/arity/commit/56ba0dc8325814c15d3edf1862fd833a289e52bb))
+- **lint:** wire CLI --select/--ignore flags ([`a3f7844`](https://github.com/jolars/arity/commit/a3f7844cd2102b76b58604d71b07a55579e11631))
+- **lint:** add resolves_to_base namespace-confirmation helper ([`2bfb17f`](https://github.com/jolars/arity/commit/2bfb17fc54f1c2a9448d23c9aa191d141784526a))
+- **lint:** add §I1 matchers and first Phase 1 rule batch ([`e39e6ba`](https://github.com/jolars/arity/commit/e39e6ba3311cb3a54ab1332c49252a46067cef0d))
+- **lsp:** narrow dynamic-source refusal in cross-file rename ([`93f601b`](https://github.com/jolars/arity/commit/93f601b16fb1fc912a2a6782fbe4997e7445618c))
+- **index:** add opt-in downloadable CRAN symbol sidecar ([`84da1fb`](https://github.com/jolars/arity/commit/84da1fb13ef8cf3b8cb6625e0d38634eb100975f))
+- **lsp:** add signature help ([`85efe66`](https://github.com/jolars/arity/commit/85efe66f9caa5917285bb9f6a3697b532a6e4b57))
+- **lsp:** add completion ([`59d01fa`](https://github.com/jolars/arity/commit/59d01fa4fa763c108b0d3af78f3dc9a3f3f66826))
+- **lsp:** add folding range support ([`824ab9d`](https://github.com/jolars/arity/commit/824ab9d013106e43e0c229cb7ce38179d50d0556))
+- **lsp:** add file rename support ([`81f4752`](https://github.com/jolars/arity/commit/81f47523b7429fcd0ed08886b2aea83141d4d61f))
+- **lsp:** load-order resolution for cross-file rename/references ([`617ccb0`](https://github.com/jolars/arity/commit/617ccb0bb6dc36693db51e9f0ee65264a71eb9fe))
+- **lsp:** scope-aware cross-file rename and references ([`1aa7f8c`](https://github.com/jolars/arity/commit/1aa7f8c01ee32f5fc656ecca358b456f87f0e0e6))
+- **lsp:** cross-file symbol rename ([`3b12b12`](https://github.com/jolars/arity/commit/3b12b12f386dd5d5273fe5c461460424d60dec8b))
+- **cli:** add diff print to `--check` ([`16ebdf3`](https://github.com/jolars/arity/commit/16ebdf311411fa1a867b292a43feb735e8d9d50c))
+
+### Bug Fixes
+- **lsp:** bind reader body reads to final scope (B2.4) ([`0f367d5`](https://github.com/jolars/arity/commit/0f367d5f257533282bbcf0b8934978159d2e62d0))
+- **project:** classify source() path relativity host-independently ([`751406e`](https://github.com/jolars/arity/commit/751406eb44a1a4425090cb08cf250e9ef06ca4a1))
+- **semantic:** don't record reserved constants as reads ([`9848162`](https://github.com/jolars/arity/commit/98481622f1e82b9429b36692b42bd460944378ef))
+- **index:** probe .libPaths() for launcher-injected libraries ([`ed729f1`](https://github.com/jolars/arity/commit/ed729f1eed8489811e1a7288cecda5995ca8f765))
+- **linter:** only flag shadowed-builtin on call-position reads ([`fca8ef7`](https://github.com/jolars/arity/commit/fca8ef708757db4363a17036d11e0a0ea0e14a43))
+- **formatter:** don't break out `[[` unnecessarily ([`81543c8`](https://github.com/jolars/arity/commit/81543c846d92636986923003851116f0e1d4f786))
+- **ci:** default cran-symbols window to 30 days ([`c581c4b`](https://github.com/jolars/arity/commit/c581c4b90939ad949db7b66e24acae8d2e4e1788))
+- format trailing comments after binary and pipe operators ([`e9d41b2`](https://github.com/jolars/arity/commit/e9d41b29d42a8efb2fe4c1ecdd7449706058a8a6)), closes [#29](https://github.com/jolars/arity/issues/29) and [#30](https://github.com/jolars/arity/issues/30)
+- **parser:** lex ...-prefixed names as one identifier ([`c3a42b2`](https://github.com/jolars/arity/commit/c3a42b2bbfba73d2c809df5ec97067ed272b2575))
+- **parser:** lex dot-leading numeric literals ([`e5923fa`](https://github.com/jolars/arity/commit/e5923fa0a1e308e05c669846d0d747a286a9e8e8)), closes [#27](https://github.com/jolars/arity/issues/27)
+- **formatter:** format := (walrus) assignment operator ([`e80a0fc`](https://github.com/jolars/arity/commit/e80a0fc25d1c579d6641abcba6d92597cf182254)), closes [#26](https://github.com/jolars/arity/issues/26), [#28](https://github.com/jolars/arity/issues/28), [#31](https://github.com/jolars/arity/issues/31), and [#32](https://github.com/jolars/arity/issues/32)
+- **formatter:** break over-width if condition onto its own line ([`0b26da6`](https://github.com/jolars/arity/commit/0b26da6afa0f21794a2b49f5c33abd398dcfd77e))
+- **formatter:** don't break `[[` group ([`89e3eb7`](https://github.com/jolars/arity/commit/89e3eb7b3eed1bdc828ad2dd13d7077c9bb12f30))
+- **parser:** parse function parameter defaults as expressions ([`5cd36e1`](https://github.com/jolars/arity/commit/5cd36e119a06af8ab4de1d4ab63d42babc80b92d))
+- **parser:** lex backtick-quoted and bare-dot names ([`2a6252a`](https://github.com/jolars/arity/commit/2a6252ab2ab1fb080453af5b0616eff4240cf0a7))
+- **linter:** eliminate unused-binding false positives ([`c941fcb`](https://github.com/jolars/arity/commit/c941fcb9d638920b5dbfb1e1b19ef57f280bf922))
+
+### Performance Improvements
+- **incremental:** make workspace_project pure via PackageGraph input ([`0409a6a`](https://github.com/jolars/arity/commit/0409a6aca8515c218532c85f99a003b5d0618d2d))
+
 ## [0.4.0](https://github.com/jolars/arity/compare/v0.3.0...v0.4.0) (2026-06-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,14 +143,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arity"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -334,9 +328,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -361,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -469,7 +463,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -610,7 +604,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -649,7 +643,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -724,12 +718,6 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -756,15 +744,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -808,9 +794,6 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
 
 [[package]]
 name = "hashbrown"
@@ -818,7 +801,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -829,7 +812,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -930,12 +913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,8 +957,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -998,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e165935eba36cb526af8389effd2005a741adcbb6ed32106cc68e3f7b92960"
+checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
 dependencies = [
  "memoffset",
 ]
@@ -1056,14 +1031,8 @@ checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1252,16 +1221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1511,7 +1470,7 @@ checksum = "943f70e101fb3bd599960e79e719e70d85142730e5b45f3269246086ed218562"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -1529,12 +1488,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1563,7 +1516,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1587,7 +1540,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1683,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1700,7 +1653,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1710,7 +1663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1890,12 +1843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,71 +1904,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2152,100 +2047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,7 +2071,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2291,7 +2092,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2311,7 +2112,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2351,7 +2152,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 readme = "README.md"
 description = "An LSP, formatter, and linter for R"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/arity/compare/arity-code-v0.4.0...arity-code-v0.5.0) (2026-06-18)
+
+### Dependencies
+- updated arity to v0.5.0
+
 ## [0.4.0](https://github.com/jolars/arity/compare/arity-code-v0.3.0...arity-code-v0.4.0) (2026-06-12)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.4.0",
-    "@arity-cli/linux-arm64-gnu": "0.4.0",
-    "@arity-cli/linux-x64-musl": "0.4.0",
-    "@arity-cli/linux-arm64-musl": "0.4.0",
-    "@arity-cli/darwin-x64": "0.4.0",
-    "@arity-cli/darwin-arm64": "0.4.0",
-    "@arity-cli/win32-x64": "0.4.0",
-    "@arity-cli/win32-arm64": "0.4.0"
+    "@arity-cli/linux-x64-gnu": "0.5.0",
+    "@arity-cli/linux-arm64-gnu": "0.5.0",
+    "@arity-cli/linux-x64-musl": "0.5.0",
+    "@arity-cli/linux-arm64-musl": "0.5.0",
+    "@arity-cli/darwin-x64": "0.5.0",
+    "@arity-cli/darwin-arm64": "0.5.0",
+    "@arity-cli/win32-x64": "0.5.0",
+    "@arity-cli/win32-arm64": "0.5.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.5.0](https://github.com/jolars/arity/compare/v0.4.0...v0.5.0) (2026-06-18)

### Features
- **lsp:** add semantic tokens (full) ([`7f578d2`](https://github.com/jolars/arity/commit/7f578d2a159e82285edf7f52d8648987accb2cbc))
- **lsp:** rename binding-only reads instead of refusing (B2.4) ([`b4643d8`](https://github.com/jolars/arity/commit/b4643d8a6a74cc794c19947e106ca403e37c29be))
- **lsp:** add workspace/symbol fuzzy name search ([`56ba0dc`](https://github.com/jolars/arity/commit/56ba0dc8325814c15d3edf1862fd833a289e52bb))
- **lint:** wire CLI --select/--ignore flags ([`a3f7844`](https://github.com/jolars/arity/commit/a3f7844cd2102b76b58604d71b07a55579e11631))
- **lint:** add resolves_to_base namespace-confirmation helper ([`2bfb17f`](https://github.com/jolars/arity/commit/2bfb17fc54f1c2a9448d23c9aa191d141784526a))
- **lint:** add §I1 matchers and first Phase 1 rule batch ([`e39e6ba`](https://github.com/jolars/arity/commit/e39e6ba3311cb3a54ab1332c49252a46067cef0d))
- **lsp:** narrow dynamic-source refusal in cross-file rename ([`93f601b`](https://github.com/jolars/arity/commit/93f601b16fb1fc912a2a6782fbe4997e7445618c))
- **index:** add opt-in downloadable CRAN symbol sidecar ([`84da1fb`](https://github.com/jolars/arity/commit/84da1fb13ef8cf3b8cb6625e0d38634eb100975f))
- **lsp:** add signature help ([`85efe66`](https://github.com/jolars/arity/commit/85efe66f9caa5917285bb9f6a3697b532a6e4b57))
- **lsp:** add completion ([`59d01fa`](https://github.com/jolars/arity/commit/59d01fa4fa763c108b0d3af78f3dc9a3f3f66826))
- **lsp:** add folding range support ([`824ab9d`](https://github.com/jolars/arity/commit/824ab9d013106e43e0c229cb7ce38179d50d0556))
- **lsp:** add file rename support ([`81f4752`](https://github.com/jolars/arity/commit/81f47523b7429fcd0ed08886b2aea83141d4d61f))
- **lsp:** load-order resolution for cross-file rename/references ([`617ccb0`](https://github.com/jolars/arity/commit/617ccb0bb6dc36693db51e9f0ee65264a71eb9fe))
- **lsp:** scope-aware cross-file rename and references ([`1aa7f8c`](https://github.com/jolars/arity/commit/1aa7f8c01ee32f5fc656ecca358b456f87f0e0e6))
- **lsp:** cross-file symbol rename ([`3b12b12`](https://github.com/jolars/arity/commit/3b12b12f386dd5d5273fe5c461460424d60dec8b))
- **cli:** add diff print to `--check` ([`16ebdf3`](https://github.com/jolars/arity/commit/16ebdf311411fa1a867b292a43feb735e8d9d50c))

### Bug Fixes
- **lsp:** bind reader body reads to final scope (B2.4) ([`0f367d5`](https://github.com/jolars/arity/commit/0f367d5f257533282bbcf0b8934978159d2e62d0))
- **project:** classify source() path relativity host-independently ([`751406e`](https://github.com/jolars/arity/commit/751406eb44a1a4425090cb08cf250e9ef06ca4a1))
- **semantic:** don't record reserved constants as reads ([`9848162`](https://github.com/jolars/arity/commit/98481622f1e82b9429b36692b42bd460944378ef))
- **index:** probe .libPaths() for launcher-injected libraries ([`ed729f1`](https://github.com/jolars/arity/commit/ed729f1eed8489811e1a7288cecda5995ca8f765))
- **linter:** only flag shadowed-builtin on call-position reads ([`fca8ef7`](https://github.com/jolars/arity/commit/fca8ef708757db4363a17036d11e0a0ea0e14a43))
- **formatter:** don't break out `[[` unnecessarily ([`81543c8`](https://github.com/jolars/arity/commit/81543c846d92636986923003851116f0e1d4f786))
- **ci:** default cran-symbols window to 30 days ([`c581c4b`](https://github.com/jolars/arity/commit/c581c4b90939ad949db7b66e24acae8d2e4e1788))
- format trailing comments after binary and pipe operators ([`e9d41b2`](https://github.com/jolars/arity/commit/e9d41b29d42a8efb2fe4c1ecdd7449706058a8a6)), closes [#29](https://github.com/jolars/arity/issues/29) and [#30](https://github.com/jolars/arity/issues/30)
- **parser:** lex ...-prefixed names as one identifier ([`c3a42b2`](https://github.com/jolars/arity/commit/c3a42b2bbfba73d2c809df5ec97067ed272b2575))
- **parser:** lex dot-leading numeric literals ([`e5923fa`](https://github.com/jolars/arity/commit/e5923fa0a1e308e05c669846d0d747a286a9e8e8)), closes [#27](https://github.com/jolars/arity/issues/27)
- **formatter:** format := (walrus) assignment operator ([`e80a0fc`](https://github.com/jolars/arity/commit/e80a0fc25d1c579d6641abcba6d92597cf182254)), closes [#26](https://github.com/jolars/arity/issues/26), [#28](https://github.com/jolars/arity/issues/28), [#31](https://github.com/jolars/arity/issues/31), and [#32](https://github.com/jolars/arity/issues/32)
- **formatter:** break over-width if condition onto its own line ([`0b26da6`](https://github.com/jolars/arity/commit/0b26da6afa0f21794a2b49f5c33abd398dcfd77e))
- **formatter:** don't break `[[` group ([`89e3eb7`](https://github.com/jolars/arity/commit/89e3eb7b3eed1bdc828ad2dd13d7077c9bb12f30))
- **parser:** parse function parameter defaults as expressions ([`5cd36e1`](https://github.com/jolars/arity/commit/5cd36e119a06af8ab4de1d4ab63d42babc80b92d))
- **parser:** lex backtick-quoted and bare-dot names ([`2a6252a`](https://github.com/jolars/arity/commit/2a6252ab2ab1fb080453af5b0616eff4240cf0a7))
- **linter:** eliminate unused-binding false positives ([`c941fcb`](https://github.com/jolars/arity/commit/c941fcb9d638920b5dbfb1e1b19ef57f280bf922))

### Performance Improvements
- **incremental:** make workspace_project pure via PackageGraph input ([`0409a6a`](https://github.com/jolars/arity/commit/0409a6aca8515c218532c85f99a003b5d0618d2d))

## [editors/code: 0.5.0](https://github.com/jolars/arity/compare/arity-code-v0.4.0...arity-code-v0.5.0) (2026-06-18)

### Dependencies
- updated arity to v0.5.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).