### PR TITLE
chore(release): v0.6.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7f578d2a159e82285edf7f52d8648987accb2cbc",
+  "baseline-sha": "7ca4fd17dc1fe501145fe580f3e1c7e16098baac",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.5.0",
-      "tag": "v0.5.0"
+      "version": "0.6.0",
+      "tag": "v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.5.0",
-      "tag": "arity-code-v0.5.0"
+      "version": "0.6.0",
+      "tag": "arity-code-v0.6.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.5.0",
-      "tag": "v0.5.0"
+      "version": "0.6.0",
+      "tag": "v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.5.0",
-      "tag": "arity-code-v0.5.0"
+      "version": "0.6.0",
+      "tag": "arity-code-v0.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/arity/compare/v0.5.0...v0.6.0) (2026-06-22)
+
+### Features
+- **cli:** add global --color, --quiet, --verbose flags ([`1bef2ae`](https://github.com/jolars/arity/commit/1bef2ae5a673533705f4e6a78cd750e8bf7d5951))
+- **cli:** add completions and init subcommands ([`ea055bc`](https://github.com/jolars/arity/commit/ea055bcae6b235f78163b37923d43e799ad15137))
+- **cli:** lint reads stdin, drop no-op --check flag ([`5237c95`](https://github.com/jolars/arity/commit/5237c957a4f73ab4c8fb0e2bb130b590eb0d8d2b))
+- **config:** add top-level exclude/default-exclude file filtering ([`8a3c661`](https://github.com/jolars/arity/commit/8a3c6615da9352c55480f8a4dfc95e70fd691e67))
+- **config:** add format.line-ending (auto/lf/crlf/native) ([`033937a`](https://github.com/jolars/arity/commit/033937a05e4b77ce5ba091cac3bbbd75fcaa3508))
+- **linter:** add unreachable-code rule (after return()/stop()) ([`52eb74b`](https://github.com/jolars/arity/commit/52eb74b2381c014cd6c74009e90937307448bb56))
+- **linter:** add any-duplicated rule (any(duplicated(x)) -> anyDuplicated(x) > 0) ([`e3d6348`](https://github.com/jolars/arity/commit/e3d63484fac7ca37f785e88946fac3ab658a8bfe))
+- **linter:** add any-is-na rule (any(is.na(x)) -> anyNA(x)) ([`3d8590d`](https://github.com/jolars/arity/commit/3d8590d8e32e57c2a76cfb17aa3b83f1d02ea6e9))
+- **linter:** add comparison-negation and outer-negation rules ([`caeda1a`](https://github.com/jolars/arity/commit/caeda1a83337dd0e8fcc412efd11abbae002fdd4))
+- **roxygen:** format embedded R in @examples bodies ([`8715ad4`](https://github.com/jolars/arity/commit/8715ad4c32a8bae37c87cb4e9f3789d6052540b6))
+- **roxygen:** hanging-indent reflow of tag prose ([`8e52c62`](https://github.com/jolars/arity/commit/8e52c62103ae6f7ed326e7947ab7b2250059c116))
+- **roxygen:** reflow prose to line width ([`b5e92c5`](https://github.com/jolars/arity/commit/b5e92c59c239a3bd5c8c87598e7ad251e6b1926e))
+- **linter:** add vector-logic rule (&/| -> &&/|| in conditions) ([`2e74063`](https://github.com/jolars/arity/commit/2e74063337ea09f77c657e51824794dadc09d80f))
+- **linter:** add repeat rule (while (TRUE) -> repeat) ([`93cff91`](https://github.com/jolars/arity/commit/93cff91a15bf5964a8b77744bc40197db5eb62e8))
+- **formatter:** normalize roxygen marker + single space ([`52b96f6`](https://github.com/jolars/arity/commit/52b96f67cca167a81ef8aad653d8148b6ccc47de))
+- **parser:** parse roxygen doc comments into the CST ([`23fe61f`](https://github.com/jolars/arity/commit/23fe61f634398d499539ed61ed292e8413696022))
+- **linter:** generate rule docs from rule metadata ([`e8ef3db`](https://github.com/jolars/arity/commit/e8ef3dba090acb6d2b9bf89fa969f829633f676e))
+- **lsp:** add pull diagnostics support ([`e8da220`](https://github.com/jolars/arity/commit/e8da220f84a5210095e85d2efdc6c579d0c5b531))
+- **lsp:** add call hierarchy support ([`24d52f3`](https://github.com/jolars/arity/commit/24d52f3acfa2e02c750ee18324996b1a5db77ed1))
+- **lint:** add true-false-symbol rule ([`1a37cfa`](https://github.com/jolars/arity/commit/1a37cfa96be2952653c482b5bbf09b3058d039f6))
+
+### Bug Fixes
+- **formatter:** preserve trailing blank lines in roxygen examples ([`7ca4fd1`](https://github.com/jolars/arity/commit/7ca4fd17dc1fe501145fe580f3e1c7e16098baac))
+- **parser:** bind unary `!` looser than comparison operators ([`a386bc4`](https://github.com/jolars/arity/commit/a386bc4489aaf3bb6f7357e09b9add8cdaadc41a))
+- **formatter:** handle comments in if/while conditions ([`5ba6f02`](https://github.com/jolars/arity/commit/5ba6f02ee2af6a6e3e01f9176bef8f315089c39f)), fixes [#37](https://github.com/jolars/arity/issues/37)
+
 ## [0.5.0](https://github.com/jolars/arity/compare/v0.4.0...v0.5.0) (2026-06-18)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -367,9 +367,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -595,6 +595,38 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1012,10 +1044,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1025,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1242,6 +1275,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1255,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1591,12 +1625,12 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol_str"
-version = "0.3.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
  "borsh",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -1699,6 +1733,26 @@ name = "thin-vec"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/arity/compare/arity-code-v0.5.0...arity-code-v0.6.0) (2026-06-22)
+
+### Dependencies
+- updated arity to v0.6.0
+
 ## [0.5.0](https://github.com/jolars/arity/compare/arity-code-v0.4.0...arity-code-v0.5.0) (2026-06-18)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.5.0",
-    "@arity-cli/linux-arm64-gnu": "0.5.0",
-    "@arity-cli/linux-x64-musl": "0.5.0",
-    "@arity-cli/linux-arm64-musl": "0.5.0",
-    "@arity-cli/darwin-x64": "0.5.0",
-    "@arity-cli/darwin-arm64": "0.5.0",
-    "@arity-cli/win32-x64": "0.5.0",
-    "@arity-cli/win32-arm64": "0.5.0"
+    "@arity-cli/linux-x64-gnu": "0.6.0",
+    "@arity-cli/linux-arm64-gnu": "0.6.0",
+    "@arity-cli/linux-x64-musl": "0.6.0",
+    "@arity-cli/linux-arm64-musl": "0.6.0",
+    "@arity-cli/darwin-x64": "0.6.0",
+    "@arity-cli/darwin-arm64": "0.6.0",
+    "@arity-cli/win32-x64": "0.6.0",
+    "@arity-cli/win32-arm64": "0.6.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.6.0](https://github.com/jolars/arity/compare/v0.5.0...v0.6.0) (2026-06-22)

### Features
- **cli:** add global --color, --quiet, --verbose flags ([`1bef2ae`](https://github.com/jolars/arity/commit/1bef2ae5a673533705f4e6a78cd750e8bf7d5951))
- **cli:** add completions and init subcommands ([`ea055bc`](https://github.com/jolars/arity/commit/ea055bcae6b235f78163b37923d43e799ad15137))
- **cli:** lint reads stdin, drop no-op --check flag ([`5237c95`](https://github.com/jolars/arity/commit/5237c957a4f73ab4c8fb0e2bb130b590eb0d8d2b))
- **config:** add top-level exclude/default-exclude file filtering ([`8a3c661`](https://github.com/jolars/arity/commit/8a3c6615da9352c55480f8a4dfc95e70fd691e67))
- **config:** add format.line-ending (auto/lf/crlf/native) ([`033937a`](https://github.com/jolars/arity/commit/033937a05e4b77ce5ba091cac3bbbd75fcaa3508))
- **linter:** add unreachable-code rule (after return()/stop()) ([`52eb74b`](https://github.com/jolars/arity/commit/52eb74b2381c014cd6c74009e90937307448bb56))
- **linter:** add any-duplicated rule (any(duplicated(x)) -> anyDuplicated(x) > 0) ([`e3d6348`](https://github.com/jolars/arity/commit/e3d63484fac7ca37f785e88946fac3ab658a8bfe))
- **linter:** add any-is-na rule (any(is.na(x)) -> anyNA(x)) ([`3d8590d`](https://github.com/jolars/arity/commit/3d8590d8e32e57c2a76cfb17aa3b83f1d02ea6e9))
- **linter:** add comparison-negation and outer-negation rules ([`caeda1a`](https://github.com/jolars/arity/commit/caeda1a83337dd0e8fcc412efd11abbae002fdd4))
- **roxygen:** format embedded R in @examples bodies ([`8715ad4`](https://github.com/jolars/arity/commit/8715ad4c32a8bae37c87cb4e9f3789d6052540b6))
- **roxygen:** hanging-indent reflow of tag prose ([`8e52c62`](https://github.com/jolars/arity/commit/8e52c62103ae6f7ed326e7947ab7b2250059c116))
- **roxygen:** reflow prose to line width ([`b5e92c5`](https://github.com/jolars/arity/commit/b5e92c59c239a3bd5c8c87598e7ad251e6b1926e))
- **linter:** add vector-logic rule (&/| -> &&/|| in conditions) ([`2e74063`](https://github.com/jolars/arity/commit/2e74063337ea09f77c657e51824794dadc09d80f))
- **linter:** add repeat rule (while (TRUE) -> repeat) ([`93cff91`](https://github.com/jolars/arity/commit/93cff91a15bf5964a8b77744bc40197db5eb62e8))
- **formatter:** normalize roxygen marker + single space ([`52b96f6`](https://github.com/jolars/arity/commit/52b96f67cca167a81ef8aad653d8148b6ccc47de))
- **parser:** parse roxygen doc comments into the CST ([`23fe61f`](https://github.com/jolars/arity/commit/23fe61f634398d499539ed61ed292e8413696022))
- **linter:** generate rule docs from rule metadata ([`e8ef3db`](https://github.com/jolars/arity/commit/e8ef3dba090acb6d2b9bf89fa969f829633f676e))
- **lsp:** add pull diagnostics support ([`e8da220`](https://github.com/jolars/arity/commit/e8da220f84a5210095e85d2efdc6c579d0c5b531))
- **lsp:** add call hierarchy support ([`24d52f3`](https://github.com/jolars/arity/commit/24d52f3acfa2e02c750ee18324996b1a5db77ed1))
- **lint:** add true-false-symbol rule ([`1a37cfa`](https://github.com/jolars/arity/commit/1a37cfa96be2952653c482b5bbf09b3058d039f6))

### Bug Fixes
- **formatter:** preserve trailing blank lines in roxygen examples ([`7ca4fd1`](https://github.com/jolars/arity/commit/7ca4fd17dc1fe501145fe580f3e1c7e16098baac))
- **parser:** bind unary `!` looser than comparison operators ([`a386bc4`](https://github.com/jolars/arity/commit/a386bc4489aaf3bb6f7357e09b9add8cdaadc41a))
- **formatter:** handle comments in if/while conditions ([`5ba6f02`](https://github.com/jolars/arity/commit/5ba6f02ee2af6a6e3e01f9176bef8f315089c39f)), fixes [#37](https://github.com/jolars/arity/issues/37)

## [editors/code: 0.6.0](https://github.com/jolars/arity/compare/arity-code-v0.5.0...arity-code-v0.6.0) (2026-06-22)

### Dependencies
- updated arity to v0.6.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).