### PR TITLE
chore(release): v0.9.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "8410550b8befd4b0daf427b47729cf4162b3824e",
+  "baseline-sha": "15a212c30145f0880af11ef636aa12b8dc096d0c",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.8.0",
-      "tag": "v0.8.0"
+      "version": "0.9.0",
+      "tag": "v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "0.8.0",
-      "tag": "arity-code-v0.8.0"
+      "version": "0.9.0",
+      "tag": "arity-code-v0.9.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.8.0",
-      "tag": "v0.8.0"
+      "version": "0.9.0",
+      "tag": "v0.9.0"
     },
     {
       "path": "editors/code",
-      "version": "0.8.0",
-      "tag": "arity-code-v0.8.0"
+      "version": "0.9.0",
+      "tag": "arity-code-v0.9.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/arity/compare/v0.8.0...v0.9.0) (2026-07-04)
+
+### Features
+- **parser:** markdown HTML block condition 1 under @md ([`dcc35a2`](https://github.com/jolars/arity/commit/dcc35a279e49c891a72141436ccb423b0a3c0b3f))
+- **parser:** markdown indented code blocks under @md ([`9308021`](https://github.com/jolars/arity/commit/93080214f532360535948abc14d7df331ec68b63))
+- **parser:** setext heading from same-line tag value ([`6725dbe`](https://github.com/jolars/arity/commit/6725dbe4046b22a14fba0543bec11c17e7c34fba))
+- **parser:** fold block-quote lazy continuation lines ([`d3d5583`](https://github.com/jolars/arity/commit/d3d5583b55e4ba9f1e1394f92ee14251478ccd22))
+
 ## [0.8.0](https://github.com/jolars/arity/compare/v0.7.0...v0.8.0) (2026-07-02)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -287,7 +287,7 @@ dependencies = [
  "biome_text_edit",
  "biome_text_size",
  "hashbrown 0.15.5",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
 ]
 
@@ -598,9 +598,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -608,12 +608,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -1266,7 +1265,6 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -1397,9 +1395,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1472,7 +1470,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "rayon",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "salsa-macro-rules",
  "salsa-macros",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.0](https://github.com/jolars/arity/compare/arity-code-v0.8.0...arity-code-v0.9.0) (2026-07-04)
+
+### Dependencies
+- updated arity to v0.9.0
+
 ## [0.8.0](https://github.com/jolars/arity/compare/arity-code-v0.7.0...arity-code-v0.8.0) (2026-07-02)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.8.0",
-    "@arity-cli/linux-arm64-gnu": "0.8.0",
-    "@arity-cli/linux-x64-musl": "0.8.0",
-    "@arity-cli/linux-arm64-musl": "0.8.0",
-    "@arity-cli/darwin-x64": "0.8.0",
-    "@arity-cli/darwin-arm64": "0.8.0",
-    "@arity-cli/win32-x64": "0.8.0",
-    "@arity-cli/win32-arm64": "0.8.0"
+    "@arity-cli/linux-x64-gnu": "0.9.0",
+    "@arity-cli/linux-arm64-gnu": "0.9.0",
+    "@arity-cli/linux-x64-musl": "0.9.0",
+    "@arity-cli/linux-arm64-musl": "0.9.0",
+    "@arity-cli/darwin-x64": "0.9.0",
+    "@arity-cli/darwin-arm64": "0.9.0",
+    "@arity-cli/win32-x64": "0.9.0",
+    "@arity-cli/win32-arm64": "0.9.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.9.0](https://github.com/jolars/arity/compare/v0.8.0...v0.9.0) (2026-07-04)

### Features
- **parser:** markdown HTML block condition 1 under @md ([`dcc35a2`](https://github.com/jolars/arity/commit/dcc35a279e49c891a72141436ccb423b0a3c0b3f))
- **parser:** markdown indented code blocks under @md ([`9308021`](https://github.com/jolars/arity/commit/93080214f532360535948abc14d7df331ec68b63))
- **parser:** setext heading from same-line tag value ([`6725dbe`](https://github.com/jolars/arity/commit/6725dbe4046b22a14fba0543bec11c17e7c34fba))
- **parser:** fold block-quote lazy continuation lines ([`d3d5583`](https://github.com/jolars/arity/commit/d3d5583b55e4ba9f1e1394f92ee14251478ccd22))

## [editors/code: 0.9.0](https://github.com/jolars/arity/compare/arity-code-v0.8.0...arity-code-v0.9.0) (2026-07-04)

### Dependencies
- updated arity to v0.9.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).