### PR TITLE
chore(release): v0.10.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "15a212c30145f0880af11ef636aa12b8dc096d0c",
+  "baseline-sha": "62e976cce1f771262a2eccbf45b4491875347c7f",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.9.0",
-      "tag": "v0.9.0"
+      "version": "0.10.0",
+      "tag": "v0.10.0"
     },
     {
       "path": "editors/code",
-      "version": "0.9.0",
-      "tag": "arity-code-v0.9.0"
+      "version": "0.10.0",
+      "tag": "arity-code-v0.10.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.9.0",
-      "tag": "v0.9.0"
+      "version": "0.10.0",
+      "tag": "v0.10.0"
     },
     {
       "path": "editors/code",
-      "version": "0.9.0",
-      "tag": "arity-code-v0.9.0"
+      "version": "0.10.0",
+      "tag": "arity-code-v0.10.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/arity/compare/v0.9.0...v0.10.0) (2026-07-05)
+
+### Features
+- **parser:** markdown block starts from same-line tag value ([`62e976c`](https://github.com/jolars/arity/commit/62e976cce1f771262a2eccbf45b4491875347c7f))
+- **parser:** markdown HTML block from same-line tag value ([`f343419`](https://github.com/jolars/arity/commit/f34341964e3bf8a28e53a2bd3655cd8b3291b19d))
+- **parser:** markdown HTML block condition 7 ([`1d6c837`](https://github.com/jolars/arity/commit/1d6c83728add061538a25156768769412612c6c7))
+- **parser:** inline markdown HTML comment, PI, decl, CDATA ([`b1b08b9`](https://github.com/jolars/arity/commit/b1b08b91afd57755f29fc3f3f46088a56e9e1b2e))
+- **parser:** markdown HTML block conditions 2-5 under @md ([`04819f4`](https://github.com/jolars/arity/commit/04819f4e74e21e86c08ec91c66b55ce1def00514))
+
+### Bug Fixes
+- **formatter:** break associative binary chains uniformly ([`2c32f0a`](https://github.com/jolars/arity/commit/2c32f0afa21e615c0080d5f9f1d7a91252e5692c))
+- **lint:** sort rendered diagnostics by source offset ([`950d223`](https://github.com/jolars/arity/commit/950d2237cac77e1000d0244a0f74049bf7243fba))
+- **lint:** surface parse errors instead of swallowing them ([`9afb39f`](https://github.com/jolars/arity/commit/9afb39ffc4f655696febddf9621bbbb8e96dc00d))
+
 ## [0.9.0](https://github.com/jolars/arity/compare/v0.8.0...v0.9.0) (2026-07-04)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/arity/compare/arity-code-v0.9.0...arity-code-v0.10.0) (2026-07-05)
+
+### Dependencies
+- updated arity to v0.10.0
+
 ## [0.9.0](https://github.com/jolars/arity/compare/arity-code-v0.8.0...arity-code-v0.9.0) (2026-07-04)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.9.0",
-    "@arity-cli/linux-arm64-gnu": "0.9.0",
-    "@arity-cli/linux-x64-musl": "0.9.0",
-    "@arity-cli/linux-arm64-musl": "0.9.0",
-    "@arity-cli/darwin-x64": "0.9.0",
-    "@arity-cli/darwin-arm64": "0.9.0",
-    "@arity-cli/win32-x64": "0.9.0",
-    "@arity-cli/win32-arm64": "0.9.0"
+    "@arity-cli/linux-x64-gnu": "0.10.0",
+    "@arity-cli/linux-arm64-gnu": "0.10.0",
+    "@arity-cli/linux-x64-musl": "0.10.0",
+    "@arity-cli/linux-arm64-musl": "0.10.0",
+    "@arity-cli/darwin-x64": "0.10.0",
+    "@arity-cli/darwin-arm64": "0.10.0",
+    "@arity-cli/win32-x64": "0.10.0",
+    "@arity-cli/win32-arm64": "0.10.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.10.0](https://github.com/jolars/arity/compare/v0.9.0...v0.10.0) (2026-07-05)

### Features
- **parser:** markdown block starts from same-line tag value ([`62e976c`](https://github.com/jolars/arity/commit/62e976cce1f771262a2eccbf45b4491875347c7f))
- **parser:** markdown HTML block from same-line tag value ([`f343419`](https://github.com/jolars/arity/commit/f34341964e3bf8a28e53a2bd3655cd8b3291b19d))
- **parser:** markdown HTML block condition 7 ([`1d6c837`](https://github.com/jolars/arity/commit/1d6c83728add061538a25156768769412612c6c7))
- **parser:** inline markdown HTML comment, PI, decl, CDATA ([`b1b08b9`](https://github.com/jolars/arity/commit/b1b08b91afd57755f29fc3f3f46088a56e9e1b2e))
- **parser:** markdown HTML block conditions 2-5 under @md ([`04819f4`](https://github.com/jolars/arity/commit/04819f4e74e21e86c08ec91c66b55ce1def00514))

### Bug Fixes
- **formatter:** break associative binary chains uniformly ([`2c32f0a`](https://github.com/jolars/arity/commit/2c32f0afa21e615c0080d5f9f1d7a91252e5692c))
- **lint:** sort rendered diagnostics by source offset ([`950d223`](https://github.com/jolars/arity/commit/950d2237cac77e1000d0244a0f74049bf7243fba))
- **lint:** surface parse errors instead of swallowing them ([`9afb39f`](https://github.com/jolars/arity/commit/9afb39ffc4f655696febddf9621bbbb8e96dc00d))

## [editors/code: 0.10.0](https://github.com/jolars/arity/compare/arity-code-v0.9.0...arity-code-v0.10.0) (2026-07-05)

### Dependencies
- updated arity to v0.10.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).