### PR TITLE
chore(release): v0.11.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "62e976cce1f771262a2eccbf45b4491875347c7f",
+  "baseline-sha": "bddd07bee82b47e531e5f8e7d2161098cafd3282",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
     },
     {
       "path": "editors/code",
-      "version": "0.10.0",
-      "tag": "arity-code-v0.10.0"
+      "version": "0.11.0",
+      "tag": "arity-code-v0.11.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
     },
     {
       "path": "editors/code",
-      "version": "0.10.0",
-      "tag": "arity-code-v0.10.0"
+      "version": "0.11.0",
+      "tag": "arity-code-v0.11.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/arity/compare/v0.10.0...v0.11.0) (2026-07-08)
+
+### Features
+- **linter:** add string-boundary and fixed-regex rules ([`bddd07b`](https://github.com/jolars/arity/commit/bddd07bee82b47e531e5f8e7d2161098cafd3282))
+- **linter:** add crossprod rule for %*% with t() ([`de48640`](https://github.com/jolars/arity/commit/de486400a234f5094508010629e08ca36fcac1c5))
+- **parser:** fold blank-separated list item paragraphs ([`92772ce`](https://github.com/jolars/arity/commit/92772ce78c18051b5a394dfe95ff373056a5a1a7))
+- **parser:** split roxygen md lists on no-blank marker-type change ([`f65195d`](https://github.com/jolars/arity/commit/f65195d9223d9b3494e7ae600fa8d9944a073273))
+- **lsp:** add document color support ([`3f8b048`](https://github.com/jolars/arity/commit/3f8b0486526ceea67d67b902ef30636bfa13a493))
+- **lsp:** add selection ranges ([`43dd077`](https://github.com/jolars/arity/commit/43dd07717152161aefab34097cf68b051dd43681))
+- **lsp:** add roxygen skeleton code action ([`8cac459`](https://github.com/jolars/arity/commit/8cac459d0b16d8a26b321a003b0ac7b792a76b74))
+- **lsp:** add type hierarchy for S4/R6/RefClass ([`b4c3133`](https://github.com/jolars/arity/commit/b4c313363e5f06c13540998f34b654c8f0a2f1c3))
+- **lsp:** add document link support ([`b0f5a92`](https://github.com/jolars/arity/commit/b0f5a92911cdffa443f821e1fe3c89e47c4253be))
+- **roxygen:** project sticky brace-less RCODE/VERB swallow ([`917fca5`](https://github.com/jolars/arity/commit/917fca558cb2294aa8c878b328d7010cc6a1203f))
+- **roxygen:** project brace-less `\item` as UNKNOWN node ([`0b3f1cf`](https://github.com/jolars/arity/commit/0b3f1cf5a9a2dfee85408bda426b486df4bfba74))
+- **roxygen:** group bare braces in md heading titles as LIST ([`a479f00`](https://github.com/jolars/arity/commit/a479f0057ce5b6726ce1b87ba0db2035d890ca38))
+- **roxygen:** group bare braces in macro args as Rd LIST ([`1143364`](https://github.com/jolars/arity/commit/1143364985f7671d502279f687cf0d89c54dea9f))
+- **config:** honor excludes in LSP, sibling, and index walks ([`66e7680`](https://github.com/jolars/arity/commit/66e76805f4659a918e050b251e0595e4e46c0d16))
+- **parser:** reparse non-braced top-level statements ([`81124a5`](https://github.com/jolars/arity/commit/81124a53c199d726bb73d2af68ab6009c20ef36f))
+- **roxygen:** project md bare brace groups as Rd LIST ([`9edfcfa`](https://github.com/jolars/arity/commit/9edfcfa4ec97485c90275361e8ffa575c6b0ebc5))
+- **roxygen:** project bare prose brace groups as Rd LIST ([`0e2cbd7`](https://github.com/jolars/arity/commit/0e2cbd76e230a21fe3bee18430e1ccf27820fce7))
+- **parser:** gate in-arg macro carve on backslash parity ([`b5fa27f`](https://github.com/jolars/arity/commit/b5fa27f4e35ad2a429ff4842073da8ea083b2a44))
+- **roxygen:** resolve Rd-string escapes in macro args ([`8d08c7a`](https://github.com/jolars/arity/commit/8d08c7ab8a423b52327f6676d6d4cf84439b48af))
+- **roxygen:** render md escaped braces bare in TEXT ([`146da14`](https://github.com/jolars/arity/commit/146da14cb17669e0852bdd47d47f03dafb6e6da6))
+- **roxygen:** drop brace-less known Rd macros in projection ([`3eba086`](https://github.com/jolars/arity/commit/3eba086499f11536868833afe00d359c7da9c050))
+- **parser:** parity-gate Rd macro carves on backslash runs ([`ba1a9e0`](https://github.com/jolars/arity/commit/ba1a9e0bc93f56497774450d915994d2b8da7793))
+- **parser:** resolve multi-line code spans in the inline pass ([`c3575f5`](https://github.com/jolars/arity/commit/c3575f552777ab01ef2068ce41c44eb98d001e3e))
+- **parser:** resolve multi-line inline HTML in the inline pass ([`62ca1f3`](https://github.com/jolars/arity/commit/62ca1f34e78d3bc8a26f40a0a675b41bd04208af))
+- **parser:** merge blank-separated same-type markdown lists ([`164d519`](https://github.com/jolars/arity/commit/164d51922e70f181bf6ea3c8a8005b697cbcc783))
+- **parser:** fold lazy continuations into markdown list items ([`54f56f9`](https://github.com/jolars/arity/commit/54f56f9695a366c693936b387ac17e07a0e7c017))
+- **linter:** add roxygen documentation rules ([`167ae38`](https://github.com/jolars/arity/commit/167ae3853a1709e7f1d26e89b64bc989bd2b0742))
+- **ast:** add roxygen tag and prose accessors ([`792ec6b`](https://github.com/jolars/arity/commit/792ec6b4f2cb8c9cd31a7cb9406437dac638d73d))
+- **parser:** block quote, thematic break from tag value ([`ff3f647`](https://github.com/jolars/arity/commit/ff3f647bc52f82a756a91a95b3c9afe4159c6198))
+
+### Bug Fixes
+- **formatter:** indent nested operand of binary chain ([`ef14a99`](https://github.com/jolars/arity/commit/ef14a99d8755f587b7b0a3f9aa954192fcf34837))
+- **roxygen:** keep md section on trailing \% swallow ([`4425971`](https://github.com/jolars/arity/commit/4425971db505387458e70b5a21b1bf21032465db))
+- **roxygen:** resolve multi-backslash md brace runs at cmark stage ([`756aacd`](https://github.com/jolars/arity/commit/756aacde2c753c1a911195f8804dcb2820913794))
+- **roxygen:** keep fragile-macro escaped braces in md drop scan ([`0674bc7`](https://github.com/jolars/arity/commit/0674bc7f3bb5c44c7a1670f5b0211b64392c2411))
+- **roxygen:** scan raw text for md-off rdComplete drop ([`f291ab1`](https://github.com/jolars/arity/commit/f291ab13cc059a90384ae3cd1626003dd3e894d9))
+- **formatter:** bail folded roxygen tags on structured lines ([`b251e40`](https://github.com/jolars/arity/commit/b251e40b5128a0bfe6d393ac6010a9fbfedc8ff7))
+- **formatter:** reflow roxygen prose containing pipes ([`6b17cad`](https://github.com/jolars/arity/commit/6b17cad8dda09cec9039cea8780232b28f8df613))
+
 ## [0.10.0](https://github.com/jolars/arity/compare/v0.9.0...v0.10.0) (2026-07-05)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -367,9 +367,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -577,18 +577,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1449,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
@@ -2120,18 +2120,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/arity/compare/arity-code-v0.10.0...arity-code-v0.11.0) (2026-07-08)
+
+### Dependencies
+- updated arity to v0.11.0
+
 ## [0.10.0](https://github.com/jolars/arity/compare/arity-code-v0.9.0...arity-code-v0.10.0) (2026-07-05)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.10.0",
-    "@arity-cli/linux-arm64-gnu": "0.10.0",
-    "@arity-cli/linux-x64-musl": "0.10.0",
-    "@arity-cli/linux-arm64-musl": "0.10.0",
-    "@arity-cli/darwin-x64": "0.10.0",
-    "@arity-cli/darwin-arm64": "0.10.0",
-    "@arity-cli/win32-x64": "0.10.0",
-    "@arity-cli/win32-arm64": "0.10.0"
+    "@arity-cli/linux-x64-gnu": "0.11.0",
+    "@arity-cli/linux-arm64-gnu": "0.11.0",
+    "@arity-cli/linux-x64-musl": "0.11.0",
+    "@arity-cli/linux-arm64-musl": "0.11.0",
+    "@arity-cli/darwin-x64": "0.11.0",
+    "@arity-cli/darwin-arm64": "0.11.0",
+    "@arity-cli/win32-x64": "0.11.0",
+    "@arity-cli/win32-arm64": "0.11.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.11.0](https://github.com/jolars/arity/compare/v0.10.0...v0.11.0) (2026-07-08)

### Features
- **linter:** add string-boundary and fixed-regex rules ([`bddd07b`](https://github.com/jolars/arity/commit/bddd07bee82b47e531e5f8e7d2161098cafd3282))
- **linter:** add crossprod rule for %*% with t() ([`de48640`](https://github.com/jolars/arity/commit/de486400a234f5094508010629e08ca36fcac1c5))
- **parser:** fold blank-separated list item paragraphs ([`92772ce`](https://github.com/jolars/arity/commit/92772ce78c18051b5a394dfe95ff373056a5a1a7))
- **parser:** split roxygen md lists on no-blank marker-type change ([`f65195d`](https://github.com/jolars/arity/commit/f65195d9223d9b3494e7ae600fa8d9944a073273))
- **lsp:** add document color support ([`3f8b048`](https://github.com/jolars/arity/commit/3f8b0486526ceea67d67b902ef30636bfa13a493))
- **lsp:** add selection ranges ([`43dd077`](https://github.com/jolars/arity/commit/43dd07717152161aefab34097cf68b051dd43681))
- **lsp:** add roxygen skeleton code action ([`8cac459`](https://github.com/jolars/arity/commit/8cac459d0b16d8a26b321a003b0ac7b792a76b74))
- **lsp:** add type hierarchy for S4/R6/RefClass ([`b4c3133`](https://github.com/jolars/arity/commit/b4c313363e5f06c13540998f34b654c8f0a2f1c3))
- **lsp:** add document link support ([`b0f5a92`](https://github.com/jolars/arity/commit/b0f5a92911cdffa443f821e1fe3c89e47c4253be))
- **roxygen:** project sticky brace-less RCODE/VERB swallow ([`917fca5`](https://github.com/jolars/arity/commit/917fca558cb2294aa8c878b328d7010cc6a1203f))
- **roxygen:** project brace-less `\item` as UNKNOWN node ([`0b3f1cf`](https://github.com/jolars/arity/commit/0b3f1cf5a9a2dfee85408bda426b486df4bfba74))
- **roxygen:** group bare braces in md heading titles as LIST ([`a479f00`](https://github.com/jolars/arity/commit/a479f0057ce5b6726ce1b87ba0db2035d890ca38))
- **roxygen:** group bare braces in macro args as Rd LIST ([`1143364`](https://github.com/jolars/arity/commit/1143364985f7671d502279f687cf0d89c54dea9f))
- **config:** honor excludes in LSP, sibling, and index walks ([`66e7680`](https://github.com/jolars/arity/commit/66e76805f4659a918e050b251e0595e4e46c0d16))
- **parser:** reparse non-braced top-level statements ([`81124a5`](https://github.com/jolars/arity/commit/81124a53c199d726bb73d2af68ab6009c20ef36f))
- **roxygen:** project md bare brace groups as Rd LIST ([`9edfcfa`](https://github.com/jolars/arity/commit/9edfcfa4ec97485c90275361e8ffa575c6b0ebc5))
- **roxygen:** project bare prose brace groups as Rd LIST ([`0e2cbd7`](https://github.com/jolars/arity/commit/0e2cbd76e230a21fe3bee18430e1ccf27820fce7))
- **parser:** gate in-arg macro carve on backslash parity ([`b5fa27f`](https://github.com/jolars/arity/commit/b5fa27f4e35ad2a429ff4842073da8ea083b2a44))
- **roxygen:** resolve Rd-string escapes in macro args ([`8d08c7a`](https://github.com/jolars/arity/commit/8d08c7ab8a423b52327f6676d6d4cf84439b48af))
- **roxygen:** render md escaped braces bare in TEXT ([`146da14`](https://github.com/jolars/arity/commit/146da14cb17669e0852bdd47d47f03dafb6e6da6))
- **roxygen:** drop brace-less known Rd macros in projection ([`3eba086`](https://github.com/jolars/arity/commit/3eba086499f11536868833afe00d359c7da9c050))
- **parser:** parity-gate Rd macro carves on backslash runs ([`ba1a9e0`](https://github.com/jolars/arity/commit/ba1a9e0bc93f56497774450d915994d2b8da7793))
- **parser:** resolve multi-line code spans in the inline pass ([`c3575f5`](https://github.com/jolars/arity/commit/c3575f552777ab01ef2068ce41c44eb98d001e3e))
- **parser:** resolve multi-line inline HTML in the inline pass ([`62ca1f3`](https://github.com/jolars/arity/commit/62ca1f34e78d3bc8a26f40a0a675b41bd04208af))
- **parser:** merge blank-separated same-type markdown lists ([`164d519`](https://github.com/jolars/arity/commit/164d51922e70f181bf6ea3c8a8005b697cbcc783))
- **parser:** fold lazy continuations into markdown list items ([`54f56f9`](https://github.com/jolars/arity/commit/54f56f9695a366c693936b387ac17e07a0e7c017))
- **linter:** add roxygen documentation rules ([`167ae38`](https://github.com/jolars/arity/commit/167ae3853a1709e7f1d26e89b64bc989bd2b0742))
- **ast:** add roxygen tag and prose accessors ([`792ec6b`](https://github.com/jolars/arity/commit/792ec6b4f2cb8c9cd31a7cb9406437dac638d73d))
- **parser:** block quote, thematic break from tag value ([`ff3f647`](https://github.com/jolars/arity/commit/ff3f647bc52f82a756a91a95b3c9afe4159c6198))

### Bug Fixes
- **formatter:** indent nested operand of binary chain ([`ef14a99`](https://github.com/jolars/arity/commit/ef14a99d8755f587b7b0a3f9aa954192fcf34837))
- **roxygen:** keep md section on trailing \% swallow ([`4425971`](https://github.com/jolars/arity/commit/4425971db505387458e70b5a21b1bf21032465db))
- **roxygen:** resolve multi-backslash md brace runs at cmark stage ([`756aacd`](https://github.com/jolars/arity/commit/756aacde2c753c1a911195f8804dcb2820913794))
- **roxygen:** keep fragile-macro escaped braces in md drop scan ([`0674bc7`](https://github.com/jolars/arity/commit/0674bc7f3bb5c44c7a1670f5b0211b64392c2411))
- **roxygen:** scan raw text for md-off rdComplete drop ([`f291ab1`](https://github.com/jolars/arity/commit/f291ab13cc059a90384ae3cd1626003dd3e894d9))
- **formatter:** bail folded roxygen tags on structured lines ([`b251e40`](https://github.com/jolars/arity/commit/b251e40b5128a0bfe6d393ac6010a9fbfedc8ff7))
- **formatter:** reflow roxygen prose containing pipes ([`6b17cad`](https://github.com/jolars/arity/commit/6b17cad8dda09cec9039cea8780232b28f8df613))

## [editors/code: 0.11.0](https://github.com/jolars/arity/compare/arity-code-v0.10.0...arity-code-v0.11.0) (2026-07-08)

### Dependencies
- updated arity to v0.11.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).