### PR TITLE
chore(release): v0.12.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "bddd07bee82b47e531e5f8e7d2161098cafd3282",
+  "baseline-sha": "d8d18b1edba760dae7c9daf8b138bc4a7c93679e",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.11.0",
-      "tag": "v0.11.0"
+      "version": "0.12.0",
+      "tag": "v0.12.0"
     },
     {
       "path": "editors/code",
-      "version": "0.11.0",
-      "tag": "arity-code-v0.11.0"
+      "version": "0.12.0",
+      "tag": "arity-code-v0.12.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.11.0",
-      "tag": "v0.11.0"
+      "version": "0.12.0",
+      "tag": "v0.12.0"
     },
     {
       "path": "editors/code",
-      "version": "0.11.0",
-      "tag": "arity-code-v0.11.0"
+      "version": "0.12.0",
+      "tag": "arity-code-v0.12.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/arity/compare/v0.11.0...v0.12.0) (2026-07-11)
+
+### Features
+- **lint:** add `is-numeric` and `class-equals` rules ([`b3c8443`](https://github.com/jolars/arity/commit/b3c84434ac7568e92381707fc6c12e1c7b261ad9))
+- **lint:** add `seq` rule ([`d3cf745`](https://github.com/jolars/arity/commit/d3cf74576e01da7d25c03b6eb1f39ae0c5a6c202))
+- **lint:** add `nzchar` rule ([`e903216`](https://github.com/jolars/arity/commit/e903216f7eb164660401a40d0d262a90d1c34e58))
+- **lint:** add `lengths` rule ([`94b8f67`](https://github.com/jolars/arity/commit/94b8f677c6a984f7c6bb512cccfa1cc160a56a9a))
+- **bench:** add linter and project benchmarks ([`9852172`](https://github.com/jolars/arity/commit/98521720335845c2a9e45b1f3ec67a5754147a6c))
+- **roxygen:** split fenced code body into per-line VERBs ([`5f27595`](https://github.com/jolars/arity/commit/5f27595f9763d4cb062a52113eb65ba1942741d8))
+- **parser:** resolve user-defined markdown image refs ([`aa59fd4`](https://github.com/jolars/arity/commit/aa59fd4e3bd1c277ff417456552fd58678ea0bf9))
+- **docs:** add benchmark page with plots ([`e17bcf9`](https://github.com/jolars/arity/commit/e17bcf9592948d259fa72f7cfcd273470138f511))
+- **parser:** resolve shortcut and reference markdown images ([`9c0f625`](https://github.com/jolars/arity/commit/9c0f6251ab6862443abf0cf19156b03d275613e4))
+- **parser:** drop section on trailing-backslash link dest ([`355f6c8`](https://github.com/jolars/arity/commit/355f6c8b4b6501857fa5dd3388e9bed688b1dbde))
+- **parser:** reject invalid inline link destinations ([`3054434`](https://github.com/jolars/arity/commit/30544340cd9d7c28b1395a7e00c354b6fc6b2889))
+- **roxygen:** drop inline link title from href destination ([`b34e06d`](https://github.com/jolars/arity/commit/b34e06d7f32aa47352af8163142098528f4a12c1))
+- **parser:** fold setext underline into block quote lazily ([`2d40e13`](https://github.com/jolars/arity/commit/2d40e1331588c4bc5bdb644f592a7830ac849b00))
+- **parser:** fold block Rd macro into list item under `@md` ([`27caa31`](https://github.com/jolars/arity/commit/27caa31ca65aa236297588afbade01a25b181226))
+- **parser:** fold GFM table into list item under `@md` ([`5cb6589`](https://github.com/jolars/arity/commit/5cb6589a675f3ff6344ca2b5e879c8b70a5eba6f))
+- **rindex:** harvest lazy-data symbols ([`5f35fab`](https://github.com/jolars/arity/commit/5f35fabfa72713a1a285f82ca5e5bcd77c5cee30))
+- **ast:** add Expr union and HasArgList trait ([`6c11cf5`](https://github.com/jolars/arity/commit/6c11cf5926754a1f8ccb82c0b2c88b95eed84683))
+- **ast:** add AstToken layer and complete node wrappers ([`9167928`](https://github.com/jolars/arity/commit/9167928a6b6a3c5ac844c65dbfcec095cc42eaf6))
+- **parser:** fold indented code block into list item ([`c22ae83`](https://github.com/jolars/arity/commit/c22ae834fbc3e4f3c4b253a9fa1196f619a59eb7))
+- **parser:** fold fenced code block into list item ([`bf274b3`](https://github.com/jolars/arity/commit/bf274b37e4a436d242bb367a88eb9e6d18d43455))
+
+### Bug Fixes
+- **parser:** make operator lexing UTF-8-safe ([`2e5e9d9`](https://github.com/jolars/arity/commit/2e5e9d99fdffdaf59b48bb5d625e25ad9d8d1ea7))
+- **roxygen:** don't markdown-process code-tag bodies under @md ([`ceb0dba`](https://github.com/jolars/arity/commit/ceb0dba9e150f63693d7f3dbbbf5ef5612107624))
+- **parser:** flag stray closing delimiter at top level ([`51f3023`](https://github.com/jolars/arity/commit/51f30235f06c6eea7ad3addb592f0185b2b927dc))
+- **formatter:** honor line-ending in format_range ([`5800f16`](https://github.com/jolars/arity/commit/5800f1677a6609aed47f2673c1d6c6fd4f680257))
+
+### Performance Improvements
+- use mimalloc as the global allocator ([`fb60bf0`](https://github.com/jolars/arity/commit/fb60bf0b7aa2030c608578ccd257bb7527754240))
+- **lint:** parallelize project lint over salsa db clones ([`820ca43`](https://github.com/jolars/arity/commit/820ca43be869dfc2fc6ab5723a3c3e688d538dce))
+- **rindex:** load lint index names-only and in parallel ([`915bd80`](https://github.com/jolars/arity/commit/915bd807f2d38d100de1db26a075ac73a97e1605))
+- **semantic:** index scope bindings by name ([`bccb478`](https://github.com/jolars/arity/commit/bccb4780d08ae9fddceada97d255b1311b1d2538))
+- **project:** bucket top-level events in one model pass ([`c9f668a`](https://github.com/jolars/arity/commit/c9f668a6d0c1f78d812b467a11014254a877321f))
+- **lint:** render pretty snippets from a line window ([`11a4558`](https://github.com/jolars/arity/commit/11a4558c530ca47ebaa3100e44fd8981791ae991))
+
 ## [0.11.0](https://github.com/jolars/arity/compare/v0.10.0...v0.11.0) (2026-07-08)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1035,9 +1035,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -2139,18 +2139,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/arity/compare/arity-code-v0.11.0...arity-code-v0.12.0) (2026-07-11)
+
+### Dependencies
+- updated arity to v0.12.0
+
 ## [0.11.0](https://github.com/jolars/arity/compare/arity-code-v0.10.0...arity-code-v0.11.0) (2026-07-08)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.11.0",
-    "@arity-cli/linux-arm64-gnu": "0.11.0",
-    "@arity-cli/linux-x64-musl": "0.11.0",
-    "@arity-cli/linux-arm64-musl": "0.11.0",
-    "@arity-cli/darwin-x64": "0.11.0",
-    "@arity-cli/darwin-arm64": "0.11.0",
-    "@arity-cli/win32-x64": "0.11.0",
-    "@arity-cli/win32-arm64": "0.11.0"
+    "@arity-cli/linux-x64-gnu": "0.12.0",
+    "@arity-cli/linux-arm64-gnu": "0.12.0",
+    "@arity-cli/linux-x64-musl": "0.12.0",
+    "@arity-cli/linux-arm64-musl": "0.12.0",
+    "@arity-cli/darwin-x64": "0.12.0",
+    "@arity-cli/darwin-arm64": "0.12.0",
+    "@arity-cli/win32-x64": "0.12.0",
+    "@arity-cli/win32-arm64": "0.12.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.12.0](https://github.com/jolars/arity/compare/v0.11.0...v0.12.0) (2026-07-11)

### Features
- **lint:** add `is-numeric` and `class-equals` rules ([`b3c8443`](https://github.com/jolars/arity/commit/b3c84434ac7568e92381707fc6c12e1c7b261ad9))
- **lint:** add `seq` rule ([`d3cf745`](https://github.com/jolars/arity/commit/d3cf74576e01da7d25c03b6eb1f39ae0c5a6c202))
- **lint:** add `nzchar` rule ([`e903216`](https://github.com/jolars/arity/commit/e903216f7eb164660401a40d0d262a90d1c34e58))
- **lint:** add `lengths` rule ([`94b8f67`](https://github.com/jolars/arity/commit/94b8f677c6a984f7c6bb512cccfa1cc160a56a9a))
- **bench:** add linter and project benchmarks ([`9852172`](https://github.com/jolars/arity/commit/98521720335845c2a9e45b1f3ec67a5754147a6c))
- **roxygen:** split fenced code body into per-line VERBs ([`5f27595`](https://github.com/jolars/arity/commit/5f27595f9763d4cb062a52113eb65ba1942741d8))
- **parser:** resolve user-defined markdown image refs ([`aa59fd4`](https://github.com/jolars/arity/commit/aa59fd4e3bd1c277ff417456552fd58678ea0bf9))
- **docs:** add benchmark page with plots ([`e17bcf9`](https://github.com/jolars/arity/commit/e17bcf9592948d259fa72f7cfcd273470138f511))
- **parser:** resolve shortcut and reference markdown images ([`9c0f625`](https://github.com/jolars/arity/commit/9c0f6251ab6862443abf0cf19156b03d275613e4))
- **parser:** drop section on trailing-backslash link dest ([`355f6c8`](https://github.com/jolars/arity/commit/355f6c8b4b6501857fa5dd3388e9bed688b1dbde))
- **parser:** reject invalid inline link destinations ([`3054434`](https://github.com/jolars/arity/commit/30544340cd9d7c28b1395a7e00c354b6fc6b2889))
- **roxygen:** drop inline link title from href destination ([`b34e06d`](https://github.com/jolars/arity/commit/b34e06d7f32aa47352af8163142098528f4a12c1))
- **parser:** fold setext underline into block quote lazily ([`2d40e13`](https://github.com/jolars/arity/commit/2d40e1331588c4bc5bdb644f592a7830ac849b00))
- **parser:** fold block Rd macro into list item under `@md` ([`27caa31`](https://github.com/jolars/arity/commit/27caa31ca65aa236297588afbade01a25b181226))
- **parser:** fold GFM table into list item under `@md` ([`5cb6589`](https://github.com/jolars/arity/commit/5cb6589a675f3ff6344ca2b5e879c8b70a5eba6f))
- **rindex:** harvest lazy-data symbols ([`5f35fab`](https://github.com/jolars/arity/commit/5f35fabfa72713a1a285f82ca5e5bcd77c5cee30))
- **ast:** add Expr union and HasArgList trait ([`6c11cf5`](https://github.com/jolars/arity/commit/6c11cf5926754a1f8ccb82c0b2c88b95eed84683))
- **ast:** add AstToken layer and complete node wrappers ([`9167928`](https://github.com/jolars/arity/commit/9167928a6b6a3c5ac844c65dbfcec095cc42eaf6))
- **parser:** fold indented code block into list item ([`c22ae83`](https://github.com/jolars/arity/commit/c22ae834fbc3e4f3c4b253a9fa1196f619a59eb7))
- **parser:** fold fenced code block into list item ([`bf274b3`](https://github.com/jolars/arity/commit/bf274b37e4a436d242bb367a88eb9e6d18d43455))

### Bug Fixes
- **parser:** make operator lexing UTF-8-safe ([`2e5e9d9`](https://github.com/jolars/arity/commit/2e5e9d99fdffdaf59b48bb5d625e25ad9d8d1ea7))
- **roxygen:** don't markdown-process code-tag bodies under @md ([`ceb0dba`](https://github.com/jolars/arity/commit/ceb0dba9e150f63693d7f3dbbbf5ef5612107624))
- **parser:** flag stray closing delimiter at top level ([`51f3023`](https://github.com/jolars/arity/commit/51f30235f06c6eea7ad3addb592f0185b2b927dc))
- **formatter:** honor line-ending in format_range ([`5800f16`](https://github.com/jolars/arity/commit/5800f1677a6609aed47f2673c1d6c6fd4f680257))

### Performance Improvements
- use mimalloc as the global allocator ([`fb60bf0`](https://github.com/jolars/arity/commit/fb60bf0b7aa2030c608578ccd257bb7527754240))
- **lint:** parallelize project lint over salsa db clones ([`820ca43`](https://github.com/jolars/arity/commit/820ca43be869dfc2fc6ab5723a3c3e688d538dce))
- **rindex:** load lint index names-only and in parallel ([`915bd80`](https://github.com/jolars/arity/commit/915bd807f2d38d100de1db26a075ac73a97e1605))
- **semantic:** index scope bindings by name ([`bccb478`](https://github.com/jolars/arity/commit/bccb4780d08ae9fddceada97d255b1311b1d2538))
- **project:** bucket top-level events in one model pass ([`c9f668a`](https://github.com/jolars/arity/commit/c9f668a6d0c1f78d812b467a11014254a877321f))
- **lint:** render pretty snippets from a line window ([`11a4558`](https://github.com/jolars/arity/commit/11a4558c530ca47ebaa3100e44fd8981791ae991))

## [editors/code: 0.12.0](https://github.com/jolars/arity/compare/arity-code-v0.11.0...arity-code-v0.12.0) (2026-07-11)

### Dependencies
- updated arity to v0.12.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).