### PR TITLE
chore(release): v0.13.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "d8d18b1edba760dae7c9daf8b138bc4a7c93679e",
+  "baseline-sha": "27adc2358f417914167cecd61d1276524a15bdaf",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.12.0",
-      "tag": "v0.12.0"
+      "version": "0.13.0",
+      "tag": "v0.13.0"
     },
     {
       "path": "editors/code",
-      "version": "0.12.0",
-      "tag": "arity-code-v0.12.0"
+      "version": "0.13.0",
+      "tag": "arity-code-v0.13.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.12.0",
-      "tag": "v0.12.0"
+      "version": "0.13.0",
+      "tag": "v0.13.0"
     },
     {
       "path": "editors/code",
-      "version": "0.12.0",
-      "tag": "arity-code-v0.12.0"
+      "version": "0.13.0",
+      "tag": "arity-code-v0.13.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/arity/compare/v0.12.0...v0.13.0) (2026-07-20)
+
+### Features
+- **cli:** add `--force-exclude` for explicit paths ([`0b600ca`](https://github.com/jolars/arity/commit/0b600cadfbc9913c2178937b0162f457e6f50574))
+- **parser:** link-reference definitions parse at the block level ([`86b4a9d`](https://github.com/jolars/arity/commit/86b4a9d54638a55b592bf3db442e5c21c7f13143))
+- **parser:** reference-image resolution parity ([`3504005`](https://github.com/jolars/arity/commit/3504005432de9949bcdee0b54811353e87334f97))
+- **parser:** autolink span wins over the bracket carve ([`787bcbb`](https://github.com/jolars/arity/commit/787bcbbeff79ee519b100b8261799e94ac985d69))
+- **parser:** refmap-aware reference-link chain pairing ([`bf519eb`](https://github.com/jolars/arity/commit/bf519ebff63f6d899cdcf9ff12e7350d25a4df6c))
+- **parser:** escaped open bracket is link-label content ([`7a03ad1`](https://github.com/jolars/arity/commit/7a03ad1076acafdf517d3db24588d28f64a39a7c))
+- **parser:** invalid link-ref labels never define or link ([`ebc4dd4`](https://github.com/jolars/arity/commit/ebc4dd4761f051c4795f010d70fe2fc3fb14fec9))
+- **parser:** cmark-parity link-ref label normalization ([`e0893d2`](https://github.com/jolars/arity/commit/e0893d23382288b9888b1dd4c6879d123dc899fd))
+- **parser:** cmark-parity inline link destinations ([`27f7b5e`](https://github.com/jolars/arity/commit/27f7b5eda483f0dc9fb2b6c560fb4441ddf31ad6))
+- **parser:** block quote laziness state and xml_text flatten ([`e5f03aa`](https://github.com/jolars/arity/commit/e5f03aa01018b681e492e7da645c0fa2998f4808))
+- **parser:** block quote folds into a markdown list item ([`3a37044`](https://github.com/jolars/arity/commit/3a37044ae1226d796842ac8f418759951a24ca0d))
+- **parser:** collapsed reference links under roxygen @md ([`6bc059e`](https://github.com/jolars/arity/commit/6bc059eca11ee3acbb2fda0f25ebf31c419c6aac))
+- **parser:** tilde code fences and CommonMark closer matching ([`06b0b46`](https://github.com/jolars/arity/commit/06b0b46ea0e47be1cd3502cd0f4c6f07ceea692e))
+
 ## [0.12.0](https://github.com/jolars/arity/compare/v0.11.0...v0.12.0) (2026-07-11)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -323,15 +323,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -345,9 +345,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -368,9 +368,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -384,9 +384,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "ciborium"
@@ -455,7 +455,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -616,7 +616,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -675,7 +675,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1035,11 +1035,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1048,14 +1049,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1243,9 +1254,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1288,18 +1299,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1336,7 +1347,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1424,7 +1435,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1433,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -1512,7 +1523,7 @@ checksum = "8b26cb1c61fc424f7ff36e0606491429f58d1738bb0917cd999d680baae0c52c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1557,14 +1568,14 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1575,13 +1586,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1601,9 +1612,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -1677,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1688,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1705,7 +1716,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1754,22 +1765,22 @@ checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1981,14 +1992,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2114,9 +2125,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "writeable"
@@ -2143,7 +2154,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2164,7 +2175,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2184,7 +2195,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2224,11 +2235,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.13.0](https://github.com/jolars/arity/compare/arity-code-v0.12.0...arity-code-v0.13.0) (2026-07-20)
+
+### Dependencies
+- updated arity to v0.13.0
+
 ## [0.12.0](https://github.com/jolars/arity/compare/arity-code-v0.11.0...arity-code-v0.12.0) (2026-07-11)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.12.0",
-    "@arity-cli/linux-arm64-gnu": "0.12.0",
-    "@arity-cli/linux-x64-musl": "0.12.0",
-    "@arity-cli/linux-arm64-musl": "0.12.0",
-    "@arity-cli/darwin-x64": "0.12.0",
-    "@arity-cli/darwin-arm64": "0.12.0",
-    "@arity-cli/win32-x64": "0.12.0",
-    "@arity-cli/win32-arm64": "0.12.0"
+    "@arity-cli/linux-x64-gnu": "0.13.0",
+    "@arity-cli/linux-arm64-gnu": "0.13.0",
+    "@arity-cli/linux-x64-musl": "0.13.0",
+    "@arity-cli/linux-arm64-musl": "0.13.0",
+    "@arity-cli/darwin-x64": "0.13.0",
+    "@arity-cli/darwin-arm64": "0.13.0",
+    "@arity-cli/win32-x64": "0.13.0",
+    "@arity-cli/win32-arm64": "0.13.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.13.0](https://github.com/jolars/arity/compare/v0.12.0...v0.13.0) (2026-07-20)

### Features
- **cli:** add `--force-exclude` for explicit paths ([`0b600ca`](https://github.com/jolars/arity/commit/0b600cadfbc9913c2178937b0162f457e6f50574))
- **parser:** link-reference definitions parse at the block level ([`86b4a9d`](https://github.com/jolars/arity/commit/86b4a9d54638a55b592bf3db442e5c21c7f13143))
- **parser:** reference-image resolution parity ([`3504005`](https://github.com/jolars/arity/commit/3504005432de9949bcdee0b54811353e87334f97))
- **parser:** autolink span wins over the bracket carve ([`787bcbb`](https://github.com/jolars/arity/commit/787bcbbeff79ee519b100b8261799e94ac985d69))
- **parser:** refmap-aware reference-link chain pairing ([`bf519eb`](https://github.com/jolars/arity/commit/bf519ebff63f6d899cdcf9ff12e7350d25a4df6c))
- **parser:** escaped open bracket is link-label content ([`7a03ad1`](https://github.com/jolars/arity/commit/7a03ad1076acafdf517d3db24588d28f64a39a7c))
- **parser:** invalid link-ref labels never define or link ([`ebc4dd4`](https://github.com/jolars/arity/commit/ebc4dd4761f051c4795f010d70fe2fc3fb14fec9))
- **parser:** cmark-parity link-ref label normalization ([`e0893d2`](https://github.com/jolars/arity/commit/e0893d23382288b9888b1dd4c6879d123dc899fd))
- **parser:** cmark-parity inline link destinations ([`27f7b5e`](https://github.com/jolars/arity/commit/27f7b5eda483f0dc9fb2b6c560fb4441ddf31ad6))
- **parser:** block quote laziness state and xml_text flatten ([`e5f03aa`](https://github.com/jolars/arity/commit/e5f03aa01018b681e492e7da645c0fa2998f4808))
- **parser:** block quote folds into a markdown list item ([`3a37044`](https://github.com/jolars/arity/commit/3a37044ae1226d796842ac8f418759951a24ca0d))
- **parser:** collapsed reference links under roxygen @md ([`6bc059e`](https://github.com/jolars/arity/commit/6bc059eca11ee3acbb2fda0f25ebf31c419c6aac))
- **parser:** tilde code fences and CommonMark closer matching ([`06b0b46`](https://github.com/jolars/arity/commit/06b0b46ea0e47be1cd3502cd0f4c6f07ceea692e))

## [editors/code: 0.13.0](https://github.com/jolars/arity/compare/arity-code-v0.12.0...arity-code-v0.13.0) (2026-07-20)

### Dependencies
- updated arity to v0.13.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).