### PR TITLE
chore(release): v0.14.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "27adc2358f417914167cecd61d1276524a15bdaf",
+  "baseline-sha": "9e32821b862e94df5c97ac048e7ad8789df87ecc",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "editors/code",
-      "version": "0.13.0",
-      "tag": "arity-code-v0.13.0"
+      "version": "0.14.0",
+      "tag": "arity-code-v0.14.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.13.0",
-      "tag": "v0.13.0"
+      "version": "0.14.0",
+      "tag": "v0.14.0"
     },
     {
       "path": "editors/code",
-      "version": "0.13.0",
-      "tag": "arity-code-v0.13.0"
+      "version": "0.14.0",
+      "tag": "arity-code-v0.14.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/arity/compare/v0.13.0...v0.14.0) (2026-07-30)
+
+### Features
+- **semantic:** add def-use reverse index ([`89c8ab4`](https://github.com/jolars/arity/commit/89c8ab48846394722da018d2a53253fda91a38df))
+- **lsp:** react to on-disk changes via didChangeWatchedFiles ([`3fa343b`](https://github.com/jolars/arity/commit/3fa343b5f42f7bdd48fe685cd853ae4ec419799d))
+- **ci:** add smoke-test-triage skill, sharpen corpus scan (#80) ([`bb8906e`](https://github.com/jolars/arity/commit/bb8906e7459621857c606b5cdd1bd2ee5b2bfdad))
+- **lsp:** add request cancellation and stale-read gating ([`9f0d51a`](https://github.com/jolars/arity/commit/9f0d51a28782d9e3d6f28f8fa4b91131c322d474))
+- **lsp:** guard threads against handler panics ([`1b0e329`](https://github.com/jolars/arity/commit/1b0e3292ffe5fcb36160e7f71b4acee0085d6c3c))
+- **formatter:** treat trailing comments as zero-width ([`cd38a47`](https://github.com/jolars/arity/commit/cd38a473d0a1bf9284a6c9733c1c5be11720866d))
+- **roxygen:** merge same-`@name` blocks into one topic ([`31df16a`](https://github.com/jolars/arity/commit/31df16ac9b45940bc39c5eed53e1038d7b04c378))
+- **roxygen:** drop blocks past the last top-level expr ([`a7a264b`](https://github.com/jolars/arity/commit/a7a264bc9593d6fb30dc41b2345213b042cee8ed))
+- **roxygen:** knitr chunk fence class carries the language ([`85fbb37`](https://github.com/jolars/arity/commit/85fbb37102e5897b6bc4cb218c70384fd398e574))
+- **roxygen:** newline ends unquoted html attribute value ([`af07249`](https://github.com/jolars/arity/commit/af07249ad3e2e3ef80eb64e9291b6f066d1c0c81))
+- **roxygen:** demote md image after odd backslash run ([`579414b`](https://github.com/jolars/arity/commit/579414b7918a7a95a52056f56b70c370e80f355f))
+- **roxygen:** inline-link destination crosses soft breaks ([`78b7f79`](https://github.com/jolars/arity/commit/78b7f793828316e59d346ef9bac7d9e177710024))
+- **roxygen:** raw fence info string can drop the section ([`ef21a51`](https://github.com/jolars/arity/commit/ef21a51006212fa1c76f5bef788cb66ce1fa77cd))
+- **roxygen:** demote md macro after odd backslash run ([`85cc88d`](https://github.com/jolars/arity/commit/85cc88d086680952cf21b4e759ef1a55b8204ea0))
+- **roxygen:** block-level reparse of leaked linkref defs ([`ab90044`](https://github.com/jolars/arity/commit/ab9004470b613826ebe40fb9fdd885d97da3e9f5))
+- **roxygen:** escaped-close link labels and markdown leak parsing ([`41df574`](https://github.com/jolars/arity/commit/41df574b3f49b8e074eb016893cbee82a6b1aa6d))
+- **roxygen:** link-ref defs inside block quotes ([`27dbbe3`](https://github.com/jolars/arity/commit/27dbbe3f35400a1612eb11a2f45da0fb18f270fb))
+- **roxygen:** same-line HTML block in a list item ([`122b450`](https://github.com/jolars/arity/commit/122b4504c7c6ed2acafbffbd163d7f5d1b679765))
+- **roxygen:** field-edge Unicode trim and fence-info entities ([`2fdc85c`](https://github.com/jolars/arity/commit/2fdc85cbf745842c9db29d258498fdcc7fe98062))
+- **roxygen:** setext column gate and per-piece rdComplete drop ([`8e095f5`](https://github.com/jolars/arity/commit/8e095f52d3b5f2d6ab153bde33659969d5c5adf6))
+- **roxygen:** thematic-break block edges ([`c6c011d`](https://github.com/jolars/arity/commit/c6c011d36c018690a76c502650e9ddb1debfb708))
+- **roxygen:** code-span backtick runs and `\verb` fallback ([`965049e`](https://github.com/jolars/arity/commit/965049e2fa016dd546e95fd58fe384138ec5d28b))
+- **roxygen:** consume link-ref defs inside list items ([`25400f6`](https://github.com/jolars/arity/commit/25400f6d86b905dd28ba16e641f5716a1bfbe70e))
+- **parser:** same-line code fence in a list item ([`e51a6c9`](https://github.com/jolars/arity/commit/e51a6c9bf4b9f376cfdafb2ed45e692d169f951b))
+- **roxygen:** strip setext-title link defs, field-wide refmap ([`3f197dd`](https://github.com/jolars/arity/commit/3f197ddec820495d9324d9c5eac5ca53a21ad758))
+- **roxygen:** model roxygen2's trailing-empty-heading raw fallback ([`4e2bb91`](https://github.com/jolars/arity/commit/4e2bb91095d518e716ee593dc309ec9e79e9088b))
+- **parser:** expand tabs to 4-column stops in roxygen markdown ([`df95b3a`](https://github.com/jolars/arity/commit/df95b3a51410210d985d3506c89e5252ff93af1c))
+- **parser:** headings inside list items with in-list H1 hoist ([`82e8c32`](https://github.com/jolars/arity/commit/82e8c32fda265b3eed94285d64b949a5b5b72fc6))
+- **parser:** block quote opening on a list-marker line ([`6fb3838`](https://github.com/jolars/arity/commit/6fb3838c77090e7109ee576a3eae7c26fba348b7))
+- **parser:** list-item content-indent start conditions ([`56c1aec`](https://github.com/jolars/arity/commit/56c1aeca51cd8234f6bccc9c4a0555b6cf1177f4))
+- **parser:** nest same-line consecutive list markers ([`531664b`](https://github.com/jolars/arity/commit/531664bf3b7cdcfca4a40cd774317372cfd024f8))
+- **parser:** list siblings pair by CommonMark indent window ([`aa8f33f`](https://github.com/jolars/arity/commit/aa8f33fc7361847673c08c98dec2f6cd334bf083))
+- **lint:** add `sort` rule ([`de7de18`](https://github.com/jolars/arity/commit/de7de18b518b69571fd34795ae39f3cf688de042))
+
+### Bug Fixes
+- **formatter:** don't let a paren's trailing comment eat the ')' ([`5df242d`](https://github.com/jolars/arity/commit/5df242dd3c864062c23808da14a8315bdbbc669d))
+- **formatter:** don't let an if-branch trailing comment force a break ([`86846c4`](https://github.com/jolars/arity/commit/86846c45cbd09a96706ef76d853d8e470cb5419b)), closes [#70](https://github.com/jolars/arity/issues/70)
+- **parser:** don't bind an operator to a comment atom ([`4856f9d`](https://github.com/jolars/arity/commit/4856f9d830a591ff6c729c548fb1c22c6d4a05b2)), closes [#71](https://github.com/jolars/arity/issues/71)
+- **formatter:** brace both if branches when a comment braces one ([`d65d573`](https://github.com/jolars/arity/commit/d65d573c763560dac850c52d1db41ea83db9b4ac)), closes [#73](https://github.com/jolars/arity/issues/73)
+- **formatter:** lay out a comment before an assignment RHS ([`0f722b3`](https://github.com/jolars/arity/commit/0f722b3658f7bff5761393af67145b37b0660afb))
+- **formatter:** measure breaks at the real column (#82) ([`82e83fe`](https://github.com/jolars/arity/commit/82e83fe8b15618cd10acbe5de968fc9c8808320d)), closes [#67](https://github.com/jolars/arity/issues/67)
+- **config:** tolerate a missing anchor in discovery (#81) ([`c627e2f`](https://github.com/jolars/arity/commit/c627e2f3cbc4ab0331241efcea42f9bb5433a4ec))
+- **parser:** reject juxtaposed statements, fix two lexer gaps (#79) ([`e98b877`](https://github.com/jolars/arity/commit/e98b8770a9e5189157a5813c767f1b64417cf1fb)), closes [#68](https://github.com/jolars/arity/issues/68)
+- guard force-exclude paths by `has_root` ([`0a87100`](https://github.com/jolars/arity/commit/0a871002604c1b70e277ad6c397eddfd36109978))
+
 ## [0.13.0](https://github.com/jolars/arity/compare/v0.12.0...v0.13.0) (2026-07-20)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -368,9 +368,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -455,7 +455,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -630,13 +630,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -647,9 +647,9 @@ checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -1035,9 +1035,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -1568,7 +1568,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1592,7 +1592,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1699,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1759,9 +1759,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
@@ -1780,7 +1780,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1805,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -2160,18 +2160,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.14.0](https://github.com/jolars/arity/compare/arity-code-v0.13.0...arity-code-v0.14.0) (2026-07-30)
+
+### Dependencies
+- updated arity to v0.14.0
+
 ## [0.13.0](https://github.com/jolars/arity/compare/arity-code-v0.12.0...arity-code-v0.13.0) (2026-07-20)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.13.0",
-    "@arity-cli/linux-arm64-gnu": "0.13.0",
-    "@arity-cli/linux-x64-musl": "0.13.0",
-    "@arity-cli/linux-arm64-musl": "0.13.0",
-    "@arity-cli/darwin-x64": "0.13.0",
-    "@arity-cli/darwin-arm64": "0.13.0",
-    "@arity-cli/win32-x64": "0.13.0",
-    "@arity-cli/win32-arm64": "0.13.0"
+    "@arity-cli/linux-x64-gnu": "0.14.0",
+    "@arity-cli/linux-arm64-gnu": "0.14.0",
+    "@arity-cli/linux-x64-musl": "0.14.0",
+    "@arity-cli/linux-arm64-musl": "0.14.0",
+    "@arity-cli/darwin-x64": "0.14.0",
+    "@arity-cli/darwin-arm64": "0.14.0",
+    "@arity-cli/win32-x64": "0.14.0",
+    "@arity-cli/win32-arm64": "0.14.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.14.0](https://github.com/jolars/arity/compare/v0.13.0...v0.14.0) (2026-07-30)

### Features
- **semantic:** add def-use reverse index ([`89c8ab4`](https://github.com/jolars/arity/commit/89c8ab48846394722da018d2a53253fda91a38df))
- **lsp:** react to on-disk changes via didChangeWatchedFiles ([`3fa343b`](https://github.com/jolars/arity/commit/3fa343b5f42f7bdd48fe685cd853ae4ec419799d))
- **ci:** add smoke-test-triage skill, sharpen corpus scan (#80) ([`bb8906e`](https://github.com/jolars/arity/commit/bb8906e7459621857c606b5cdd1bd2ee5b2bfdad))
- **lsp:** add request cancellation and stale-read gating ([`9f0d51a`](https://github.com/jolars/arity/commit/9f0d51a28782d9e3d6f28f8fa4b91131c322d474))
- **lsp:** guard threads against handler panics ([`1b0e329`](https://github.com/jolars/arity/commit/1b0e3292ffe5fcb36160e7f71b4acee0085d6c3c))
- **formatter:** treat trailing comments as zero-width ([`cd38a47`](https://github.com/jolars/arity/commit/cd38a473d0a1bf9284a6c9733c1c5be11720866d))
- **roxygen:** merge same-`@name` blocks into one topic ([`31df16a`](https://github.com/jolars/arity/commit/31df16ac9b45940bc39c5eed53e1038d7b04c378))
- **roxygen:** drop blocks past the last top-level expr ([`a7a264b`](https://github.com/jolars/arity/commit/a7a264bc9593d6fb30dc41b2345213b042cee8ed))
- **roxygen:** knitr chunk fence class carries the language ([`85fbb37`](https://github.com/jolars/arity/commit/85fbb37102e5897b6bc4cb218c70384fd398e574))
- **roxygen:** newline ends unquoted html attribute value ([`af07249`](https://github.com/jolars/arity/commit/af07249ad3e2e3ef80eb64e9291b6f066d1c0c81))
- **roxygen:** demote md image after odd backslash run ([`579414b`](https://github.com/jolars/arity/commit/579414b7918a7a95a52056f56b70c370e80f355f))
- **roxygen:** inline-link destination crosses soft breaks ([`78b7f79`](https://github.com/jolars/arity/commit/78b7f793828316e59d346ef9bac7d9e177710024))
- **roxygen:** raw fence info string can drop the section ([`ef21a51`](https://github.com/jolars/arity/commit/ef21a51006212fa1c76f5bef788cb66ce1fa77cd))
- **roxygen:** demote md macro after odd backslash run ([`85cc88d`](https://github.com/jolars/arity/commit/85cc88d086680952cf21b4e759ef1a55b8204ea0))
- **roxygen:** block-level reparse of leaked linkref defs ([`ab90044`](https://github.com/jolars/arity/commit/ab9004470b613826ebe40fb9fdd885d97da3e9f5))
- **roxygen:** escaped-close link labels and markdown leak parsing ([`41df574`](https://github.com/jolars/arity/commit/41df574b3f49b8e074eb016893cbee82a6b1aa6d))
- **roxygen:** link-ref defs inside block quotes ([`27dbbe3`](https://github.com/jolars/arity/commit/27dbbe3f35400a1612eb11a2f45da0fb18f270fb))
- **roxygen:** same-line HTML block in a list item ([`122b450`](https://github.com/jolars/arity/commit/122b4504c7c6ed2acafbffbd163d7f5d1b679765))
- **roxygen:** field-edge Unicode trim and fence-info entities ([`2fdc85c`](https://github.com/jolars/arity/commit/2fdc85cbf745842c9db29d258498fdcc7fe98062))
- **roxygen:** setext column gate and per-piece rdComplete drop ([`8e095f5`](https://github.com/jolars/arity/commit/8e095f52d3b5f2d6ab153bde33659969d5c5adf6))
- **roxygen:** thematic-break block edges ([`c6c011d`](https://github.com/jolars/arity/commit/c6c011d36c018690a76c502650e9ddb1debfb708))
- **roxygen:** code-span backtick runs and `\verb` fallback ([`965049e`](https://github.com/jolars/arity/commit/965049e2fa016dd546e95fd58fe384138ec5d28b))
- **roxygen:** consume link-ref defs inside list items ([`25400f6`](https://github.com/jolars/arity/commit/25400f6d86b905dd28ba16e641f5716a1bfbe70e))
- **parser:** same-line code fence in a list item ([`e51a6c9`](https://github.com/jolars/arity/commit/e51a6c9bf4b9f376cfdafb2ed45e692d169f951b))
- **roxygen:** strip setext-title link defs, field-wide refmap ([`3f197dd`](https://github.com/jolars/arity/commit/3f197ddec820495d9324d9c5eac5ca53a21ad758))
- **roxygen:** model roxygen2's trailing-empty-heading raw fallback ([`4e2bb91`](https://github.com/jolars/arity/commit/4e2bb91095d518e716ee593dc309ec9e79e9088b))
- **parser:** expand tabs to 4-column stops in roxygen markdown ([`df95b3a`](https://github.com/jolars/arity/commit/df95b3a51410210d985d3506c89e5252ff93af1c))
- **parser:** headings inside list items with in-list H1 hoist ([`82e8c32`](https://github.com/jolars/arity/commit/82e8c32fda265b3eed94285d64b949a5b5b72fc6))
- **parser:** block quote opening on a list-marker line ([`6fb3838`](https://github.com/jolars/arity/commit/6fb3838c77090e7109ee576a3eae7c26fba348b7))
- **parser:** list-item content-indent start conditions ([`56c1aec`](https://github.com/jolars/arity/commit/56c1aeca51cd8234f6bccc9c4a0555b6cf1177f4))
- **parser:** nest same-line consecutive list markers ([`531664b`](https://github.com/jolars/arity/commit/531664bf3b7cdcfca4a40cd774317372cfd024f8))
- **parser:** list siblings pair by CommonMark indent window ([`aa8f33f`](https://github.com/jolars/arity/commit/aa8f33fc7361847673c08c98dec2f6cd334bf083))
- **lint:** add `sort` rule ([`de7de18`](https://github.com/jolars/arity/commit/de7de18b518b69571fd34795ae39f3cf688de042))

### Bug Fixes
- **formatter:** don't let a paren's trailing comment eat the ')' ([`5df242d`](https://github.com/jolars/arity/commit/5df242dd3c864062c23808da14a8315bdbbc669d))
- **formatter:** don't let an if-branch trailing comment force a break ([`86846c4`](https://github.com/jolars/arity/commit/86846c45cbd09a96706ef76d853d8e470cb5419b)), closes [#70](https://github.com/jolars/arity/issues/70)
- **parser:** don't bind an operator to a comment atom ([`4856f9d`](https://github.com/jolars/arity/commit/4856f9d830a591ff6c729c548fb1c22c6d4a05b2)), closes [#71](https://github.com/jolars/arity/issues/71)
- **formatter:** brace both if branches when a comment braces one ([`d65d573`](https://github.com/jolars/arity/commit/d65d573c763560dac850c52d1db41ea83db9b4ac)), closes [#73](https://github.com/jolars/arity/issues/73)
- **formatter:** lay out a comment before an assignment RHS ([`0f722b3`](https://github.com/jolars/arity/commit/0f722b3658f7bff5761393af67145b37b0660afb))
- **formatter:** measure breaks at the real column (#82) ([`82e83fe`](https://github.com/jolars/arity/commit/82e83fe8b15618cd10acbe5de968fc9c8808320d)), closes [#67](https://github.com/jolars/arity/issues/67)
- **config:** tolerate a missing anchor in discovery (#81) ([`c627e2f`](https://github.com/jolars/arity/commit/c627e2f3cbc4ab0331241efcea42f9bb5433a4ec))
- **parser:** reject juxtaposed statements, fix two lexer gaps (#79) ([`e98b877`](https://github.com/jolars/arity/commit/e98b8770a9e5189157a5813c767f1b64417cf1fb)), closes [#68](https://github.com/jolars/arity/issues/68)
- guard force-exclude paths by `has_root` ([`0a87100`](https://github.com/jolars/arity/commit/0a871002604c1b70e277ad6c397eddfd36109978))

## [editors/code: 0.14.0](https://github.com/jolars/arity/compare/arity-code-v0.13.0...arity-code-v0.14.0) (2026-07-30)

### Dependencies
- updated arity to v0.14.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).