### PR TITLE
fix(config): tolerate a missing anchor in discovery

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -304,11 +304,12 @@ impl Config {
     /// first match or at a directory that contains a `.git` entry (repo root),
     /// whichever comes first. Returns `None` if neither is found before the
     /// filesystem root.
+    ///
+    /// `start` need not exist on disk — see [`deepest_existing_ancestor`].
     pub fn discover(start: &Path) -> Result<Option<(PathBuf, Self)>, ConfigError> {
-        let canonical = start.canonicalize().map_err(|source| ConfigError::Io {
-            path: start.to_path_buf(),
-            source,
-        })?;
+        let Some(canonical) = deepest_existing_ancestor(start) else {
+            return Ok(None);
+        };
         for dir in canonical.ancestors() {
             let candidate = dir.join(CONFIG_FILE_NAME);
             if candidate.is_file() {
@@ -361,6 +362,21 @@ impl Config {
         patterns.extend(extra.iter().cloned());
         ExcludeFilter::new(root, &patterns)
     }
+}
+
+/// The deepest ancestor of `start` (itself included) that exists on disk, in
+/// canonical form, or `None` when none is reachable.
+///
+/// Discovery must tolerate an anchor that isn't on disk: the LSP anchors on the
+/// parent directory of the buffer being edited, which may never have been
+/// created (an unsaved buffer, a directory removed while a file in it is open,
+/// or a path like `C:\tmp` that simply isn't there on Windows). Skipping the
+/// missing tail loses nothing, because discovery only ever reads *from*
+/// directories and a directory that doesn't exist can hold neither an
+/// `arity.toml` nor a `.git`. An unreachable tree is likewise not an error —
+/// there is no config to read, which is exactly what `None` reports.
+fn deepest_existing_ancestor(start: &Path) -> Option<PathBuf> {
+    start.ancestors().find_map(|dir| dir.canonicalize().ok())
 }
 
 fn validate_width(field: &'static str, value: u32, path: Option<&Path>) -> Result<(), ConfigError> {
@@ -761,6 +777,48 @@ mod tests {
         let (path, config) = Config::discover(&nested).expect("discover").expect("found");
         assert_eq!(path, repo.canonicalize().unwrap().join(CONFIG_FILE_NAME));
         assert_eq!(config.format.line_width, 70);
+    }
+
+    /// A missing anchor is not an error: the LSP anchors discovery on the
+    /// directory of the buffer being edited, which need not exist on disk (an
+    /// unsaved buffer, a directory deleted while open, or simply `C:\tmp`).
+    /// Discovery still walks the ancestors that *do* exist.
+    #[test]
+    fn discover_tolerates_a_missing_anchor_directory() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            "[format]\nline-width = 70\n",
+        )
+        .unwrap();
+        let missing = dir.path().join("no").join("such").join("dir");
+        assert!(!missing.exists(), "fixture directory must not exist");
+
+        let (path, config) = Config::discover(&missing)
+            .expect("discovery must not fail on a missing anchor")
+            .expect("an existing ancestor still supplies the config");
+        assert_eq!(
+            path,
+            dir.path().canonicalize().unwrap().join(CONFIG_FILE_NAME)
+        );
+        assert_eq!(config.format.line_width, 70);
+    }
+
+    /// The same, with nothing to find: a missing anchor under no config at all
+    /// reports "no config" rather than an IO error.
+    #[test]
+    fn discover_on_a_missing_anchor_without_config_returns_none() {
+        let dir = tempdir().unwrap();
+        // A `.git` at the temp root bounds the walk so an arity.toml in a real
+        // ancestor of the temp dir can't leak into the assertion.
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        let missing = dir.path().join("no").join("such").join("dir");
+
+        assert!(
+            Config::discover(&missing)
+                .expect("discovery must not fail on a missing anchor")
+                .is_none()
+        );
     }
 
     #[test]

--- a/tests/lsp_protocol.rs
+++ b/tests/lsp_protocol.rs
@@ -34,6 +34,19 @@ fn doc_uri() -> &'static str {
     }
 }
 
+/// A file URI whose *parent directory does not exist* on disk. Config
+/// discovery anchors on that directory, so this is the shape that used to make
+/// `textDocument/formatting` answer `null` (an editor buffer in a directory
+/// that was never created, or was deleted while open). On the Windows CI
+/// runners `C:\tmp` is itself missing, which is how this first surfaced.
+fn missing_dir_uri() -> &'static str {
+    if cfg!(windows) {
+        "file:///C:/arity-no-such-dir-9f3a/lsp_protocol_test.R"
+    } else {
+        "file:///arity-no-such-dir-9f3a/lsp_protocol_test.R"
+    }
+}
+
 /// Drives the client end of an in-memory connection against a real `serve`
 /// loop running on a background thread.
 struct Harness {
@@ -280,6 +293,38 @@ fn did_open_then_formatting_request_responds() {
         edits[0].get("newText").and_then(Value::as_str),
         Some("x <- 1\n"),
         "reformatted text"
+    );
+    h.shutdown();
+}
+
+#[test]
+fn formatting_works_when_the_documents_directory_is_missing() {
+    // Regression: config discovery canonicalized its anchor directory, so a
+    // buffer whose parent directory doesn't exist made `resolve_settings` fail
+    // and `textDocument/formatting` silently answer `null`. Discovery must
+    // degrade to "no config file found" (default settings) instead.
+    let mut h = Harness::start_push();
+    let uri = missing_dir_uri();
+    h.did_open(uri, "x<-1\n", 1);
+
+    let id = h.request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": uri },
+            "options": { "tabSize": 2, "insertSpaces": true }
+        }),
+    );
+    let resp = h.recv_response(&id);
+    let result = resp
+        .response_result
+        .expect("formatting succeeded with a result");
+    let edits = result
+        .as_array()
+        .expect("formatting returns an array of edits, not null");
+    assert_eq!(
+        edits[0].get("newText").and_then(Value::as_str),
+        Some("x <- 1\n"),
+        "reformatted text: {edits:#?}"
     );
     h.shutdown();
 }


### PR DESCRIPTION
`Config::discover` canonicalized its anchor directory and turned a
`NotFound` into a hard `ConfigError::Io`. The LSP anchors discovery on
the parent directory of the buffer being edited, which need not exist on
disk, so `resolve_settings` failed and `on_formatting` answered `null`.

This is why the Windows CI job was red: the protocol tests open a
document under `C:\tmp`, which isn't present on the runners. Three tests
failed — `did_open_then_formatting_request_responds` directly, plus
`cancel_request_returns_request_cancelled` and
`stale_read_returns_content_modified`, whose ordering assumptions need
the read to actually reach the read pool rather than short-circuit.

Discovery now walks up to the deepest ancestor that exists and searches
from there. A missing tail can hold neither an `arity.toml` nor a
`.git`, so nothing is lost, and an unreachable tree reports "no config"
instead of an error. A malformed `arity.toml` still errors loudly.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019jGhbwVe5iwU1mh6Yi2d9x