### PR TITLE
test(formatter): pin rgl's if/else-in-call idempotence case

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,22 @@
   solved this by overriding biome's `place_comment`; arity's
   next-non-trivia-sibling walk already handles most cases.)
 
+- [ ] A roxygen `#'` comment inside an argument list fails to parse: each line
+  of the block is taken as its own argument, so the parser emits a cascade of
+  `expected ',' between arguments`. A plain `#` comment in the same position
+  parses fine, and R accepts the file. Found while triaging issue #72
+  (`dmurdoch/rgl`, `R/buffer.R`, the repo's only remaining
+  unparseable-and-skipped file):
+
+  ```r
+  x <- list(
+    a = 1,
+
+    #' roxy
+    b = 2
+  )
+  ```
+
 - [x] Incremental reparse (token/block) beneath `parsed_document`
   (`src/incremental.rs`)
 

--- a/tests/fixtures/formatter/if_call_argument_braces_at_indent/expected.R
+++ b/tests/fixtures/formatter/if_call_argument_braces_at_indent/expected.R
@@ -1,0 +1,14 @@
+f <- function() {
+  switch(coord, x = {
+    if (is.null(x)) {
+      x <- with(
+        ranges,
+        if (lower) {
+          x[1] - 0.075 * line * diff(x)
+        } else {
+          x[2] + 0.075 * line * diff(x)
+        }
+      )
+    }
+  })
+}

--- a/tests/fixtures/formatter/if_call_argument_braces_at_indent/input.R
+++ b/tests/fixtures/formatter/if_call_argument_braces_at_indent/input.R
@@ -1,0 +1,5 @@
+f <- function() {
+  switch(coord, x = {
+    if (is.null(x)) x <- with(ranges, if (lower) x[1] - 0.075 * line * diff(x) else x[2] + 0.075 * line * diff(x))
+  })
+}

--- a/tests/formatter.rs
+++ b/tests/formatter.rs
@@ -78,6 +78,7 @@ fn fixture_names() -> &'static [&'static str] {
         "assignment_rhs_breaks_before_lhs_subset_in_function",
         "assignment_subset_lhs_with_if_rhs",
         "if_value_position_braces_at_indent",
+        "if_call_argument_braces_at_indent",
         "if_else_block",
         "if_else_if_chain",
         "if_else_if_chain_long",

--- a/tests/snapshots/formatter__if_call_argument_braces_at_indent_formatted.snap
+++ b/tests/snapshots/formatter__if_call_argument_braces_at_indent_formatted.snap
@@ -1,0 +1,18 @@
+---
+source: tests/formatter.rs
+expression: formatted
+---
+f <- function() {
+  switch(coord, x = {
+    if (is.null(x)) {
+      x <- with(
+        ranges,
+        if (lower) {
+          x[1] - 0.075 * line * diff(x)
+        } else {
+          x[2] + 0.075 * line * diff(x)
+        }
+      )
+    }
+  })
+}


### PR DESCRIPTION
The idempotence failure reported for `dmurdoch/rgl` (issue #72) was an
if/else in call-argument position, deep enough that its flat width fit at
column 0 but not at its real indent: pass 1 emitted an 85-column line,
pass 2 broke it into braces. It stopped reproducing with the printer's
`fit_col` fix, but that fix's fixtures cover value position only, so add
the argument-position shape.

Also note the parser gap that leaves rgl's `R/buffer.R` unparseable: a
roxygen `#'` comment inside an argument list is taken as an argument.

Closes #72