### PR TITLE
chore(release): v0.15.0 (+1 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,28 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "9e32821b862e94df5c97ac048e7ad8789df87ecc",
+  "baseline-sha": "b620c58bab56738f2ce7101be711e04629fe543d",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
     },
     {
       "path": "editors/code",
-      "version": "0.14.0",
-      "tag": "arity-code-v0.14.0"
+      "version": "0.15.0",
+      "tag": "arity-code-v0.15.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.14.0",
-      "tag": "v0.14.0"
+      "version": "0.15.0",
+      "tag": "v0.15.0"
     },
     {
       "path": "editors/code",
-      "version": "0.14.0",
-      "tag": "arity-code-v0.14.0"
+      "version": "0.15.0",
+      "tag": "arity-code-v0.15.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/arity/compare/v0.14.0...v0.15.0) (2026-08-05)
+
+### Features
+- **build:** add installation scripts ([`b620c58`](https://github.com/jolars/arity/commit/b620c58bab56738f2ce7101be711e04629fe543d))
+- **linter:** mask model-frame args in `undefined-symbol` ([`1fef3ea`](https://github.com/jolars/arity/commit/1fef3ea9bfa649f49e0c241b14b43ddc963e28b5))
+- **lsp:** make nested functions call-hierarchy items ([`5e3eb7f`](https://github.com/jolars/arity/commit/5e3eb7f9c447accbf64f82fe7a8db7aa5d2afc32))
+- **lsp:** trigger signature help on `=` ([`1021a4b`](https://github.com/jolars/arity/commit/1021a4b39733fa99e3cd84cbe19c398e5491f094))
+- **linter:** add `unnecessary-nesting` rule ([`501f451`](https://github.com/jolars/arity/commit/501f4510056c42ca353e0a72519394ee222e9137))
+- **lint:** add implicit-assignment rule ([`64a3f5e`](https://github.com/jolars/arity/commit/64a3f5e2928ede3f736e501a9101fda29935ddb5))
+- **lint:** add empty-assignment rule ([`77efa97`](https://github.com/jolars/arity/commit/77efa97b898b8310aa81b280dad2a5f6ab9d228c))
+- **lsp:** thread precise edits into span mapping ([`09101b9`](https://github.com/jolars/arity/commit/09101b9788a2d5c72379d007ffc2bb98efa6db96))
+- **lsp:** thread precise edits into incremental reparse ([`78ce7d1`](https://github.com/jolars/arity/commit/78ce7d17cdf00fb385012cd639f907e1a78e64f7))
+- **lsp:** use incremental text document sync ([`0e4b9ce`](https://github.com/jolars/arity/commit/0e4b9ce828c138b08177c3083a967658b462190d))
+- **linter:** cut undefined-symbol FPs from opaque binders ([`e1e5264`](https://github.com/jolars/arity/commit/e1e5264454ac757a5798f2241f307475534cd578))
+- **linter:** add `coalesce` rule ([`b7ac1d9`](https://github.com/jolars/arity/commit/b7ac1d93ba3a7cdcbd24142ed7153d0b2a9824e3))
+- **linter:** add browser rule ([`fe7a5ba`](https://github.com/jolars/arity/commit/fe7a5ba78216d62c053d97cd5e64db2d26a2cb0b))
+- **linter:** add if-always-true rule ([`96c136a`](https://github.com/jolars/arity/commit/96c136a30881ac8545c42d545b89975fd9ae5bb6))
+- **semantic:** add per-region control-flow graph ([`a912b3c`](https://github.com/jolars/arity/commit/a912b3cf2eaae0713cd96f969961a140d205b12b))
+- **lsp:** sharpen references/rename off def-use edges ([`6204c54`](https://github.com/jolars/arity/commit/6204c54493f808feade25380b0b48e8405df246b))
+- **format:** cache already-formatted files for --check ([`acc46fc`](https://github.com/jolars/arity/commit/acc46fcdb1bf1d075b98692f9c33708859db1b9f))
+- **lsp:** content-derived pull resultId ([`f7ecb99`](https://github.com/jolars/arity/commit/f7ecb992790e8167b8fd128df38c819f3f84a1ec))
+- **lsp:** negotiate positionEncoding (UTF-8) ([`7a9af95`](https://github.com/jolars/arity/commit/7a9af95f7441ce2f3baebc4aa5362a40e6bc84e3))
+- **lsp:** work-done progress for background jobs ([`12fa210`](https://github.com/jolars/arity/commit/12fa2106000b8c0d85894e941f8286b3fcf997c4))
+- **lsp:** static `$`/`@` completion + label details ([`a5b72b8`](https://github.com/jolars/arity/commit/a5b72b8839c63beb926719eefdc857d4c4445627))
+
+### Bug Fixes
+- **npm:** fall back to musl when glibc build fails ([`f45beb7`](https://github.com/jolars/arity/commit/f45beb75e17ef2ecedfcd2fc23e533d0f45a13ea))
+- **linter:** withhold unused-binding fix on chain ([`b3d42f6`](https://github.com/jolars/arity/commit/b3d42f6a29decafac8280d0360b3a539eedfa9c9))
+- **linter:** cut unused-binding FPs from lazy reads ([`17dbaf8`](https://github.com/jolars/arity/commit/17dbaf88a881436e6f540bf97b7dacbf877991d1))
+- **linter:** skip non-UTF-8 files instead of aborting ([`89bacc4`](https://github.com/jolars/arity/commit/89bacc42f77629cd929c254ae75b642b148bdc32))
+- **formatter:** handle mid-line roxygen as trailing comment ([`41140fa`](https://github.com/jolars/arity/commit/41140fa8556a4e44eff427473aa1312cb6f8899a))
+- **formatter:** flatten binary chains with lhs-trailing comment ([`ab99d52`](https://github.com/jolars/arity/commit/ab99d52994826ede43e953718ae41d4299fae9f1))
+- **formatter:** handle roxygen comment on assignment rhs ([`0e29c0e`](https://github.com/jolars/arity/commit/0e29c0e610fedbf7329d373db408cb6b6a0ae30e)), closes [#89](https://github.com/jolars/arity/issues/89)
+- **formatter:** handle comment trailing binary lhs ([`6953947`](https://github.com/jolars/arity/commit/6953947140e65ef60dcc219a604ff72aab5be31d))
+- **parser:** left-associate extract ops with postfix ([`29c7416`](https://github.com/jolars/arity/commit/29c74166e019bc1e33eeb7a50715823be7419796))
+- **linter:** resolve for-body reads in enclosing frame ([`023cc57`](https://github.com/jolars/arity/commit/023cc5703282e6050db7d4055094ad0864fe9c0c))
+- **linter:** close three undefined-symbol gaps ([`9b4634d`](https://github.com/jolars/arity/commit/9b4634d483f190385ce5a3537010a5b77aa3577f))
+- **parser:** group loose roxygen in arg lists ([`f22b0e6`](https://github.com/jolars/arity/commit/f22b0e6234d816d905dda122e57f68dc1548373f))
+- **parser:** continue exprs across newlines in brackets ([`c603475`](https://github.com/jolars/arity/commit/c603475ddd48fa52d08048f8b9cb18ffbd45323b))
+- **lexer:** accept all raw string delimiter forms ([`178dca1`](https://github.com/jolars/arity/commit/178dca184b6878cb70db29979b793c652efade76))
+- **parser:** continue expr across trailing comment in brackets ([`31b23ea`](https://github.com/jolars/arity/commit/31b23eaeeac938aac3f37ec9f5c85d4618d479ce))
+
 ## [0.14.0](https://github.com/jolars/arity/compare/v0.13.0...v0.14.0) (2026-07-30)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "air_r_parser",
  "annotate-snippets",
@@ -170,7 +170,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
- "similar 3.1.1",
+ "similar 3.1.2",
  "smol_str",
  "tempfile",
  "toml",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -815,9 +815,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1018,12 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -1164,15 +1161,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mimalloc"
@@ -1398,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1519,9 +1507,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "salsa"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14fdadbf856222e731756d7fdbdf193a7abf8fdab009bb45f48671a42719a84"
+checksum = "cf0e374215cd2db2b5c75d7b3a99cb0cc052c0595335dfdefc03d4eb08f4aa81"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
@@ -1545,19 +1533,19 @@ dependencies = [
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d7dc08ba69b9aedfa61dfc4d65548ae42c0d8b90bbd62cd121776920841bcf"
+checksum = "85f4b7d4405540bbd6d4ffa52d4322d983f3781954d3073067ac1bdb028459b3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5c48c5a4a53a6e2be9762f56566f1325d4394c011c00b3ea86ba2d13411e71"
+checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1662,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.0](https://github.com/jolars/arity/compare/arity-code-v0.14.0...arity-code-v0.15.0) (2026-08-05)
+
+### Dependencies
+- updated arity to v0.15.0
+
 ## [0.14.0](https://github.com/jolars/arity/compare/arity-code-v0.13.0...arity-code-v0.14.0) (2026-07-30)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.14.0",
-    "@arity-cli/linux-arm64-gnu": "0.14.0",
-    "@arity-cli/linux-x64-musl": "0.14.0",
-    "@arity-cli/linux-arm64-musl": "0.14.0",
-    "@arity-cli/darwin-x64": "0.14.0",
-    "@arity-cli/darwin-arm64": "0.14.0",
-    "@arity-cli/win32-x64": "0.14.0",
-    "@arity-cli/win32-arm64": "0.14.0"
+    "@arity-cli/linux-x64-gnu": "0.15.0",
+    "@arity-cli/linux-arm64-gnu": "0.15.0",
+    "@arity-cli/linux-x64-musl": "0.15.0",
+    "@arity-cli/linux-arm64-musl": "0.15.0",
+    "@arity-cli/darwin-x64": "0.15.0",
+    "@arity-cli/darwin-arm64": "0.15.0",
+    "@arity-cli/win32-x64": "0.15.0",
+    "@arity-cli/win32-arm64": "0.15.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.15.0](https://github.com/jolars/arity/compare/v0.14.0...v0.15.0) (2026-08-05)

### Features
- **build:** add installation scripts ([`b620c58`](https://github.com/jolars/arity/commit/b620c58bab56738f2ce7101be711e04629fe543d))
- **linter:** mask model-frame args in `undefined-symbol` ([`1fef3ea`](https://github.com/jolars/arity/commit/1fef3ea9bfa649f49e0c241b14b43ddc963e28b5))
- **lsp:** make nested functions call-hierarchy items ([`5e3eb7f`](https://github.com/jolars/arity/commit/5e3eb7f9c447accbf64f82fe7a8db7aa5d2afc32))
- **lsp:** trigger signature help on `=` ([`1021a4b`](https://github.com/jolars/arity/commit/1021a4b39733fa99e3cd84cbe19c398e5491f094))
- **linter:** add `unnecessary-nesting` rule ([`501f451`](https://github.com/jolars/arity/commit/501f4510056c42ca353e0a72519394ee222e9137))
- **lint:** add implicit-assignment rule ([`64a3f5e`](https://github.com/jolars/arity/commit/64a3f5e2928ede3f736e501a9101fda29935ddb5))
- **lint:** add empty-assignment rule ([`77efa97`](https://github.com/jolars/arity/commit/77efa97b898b8310aa81b280dad2a5f6ab9d228c))
- **lsp:** thread precise edits into span mapping ([`09101b9`](https://github.com/jolars/arity/commit/09101b9788a2d5c72379d007ffc2bb98efa6db96))
- **lsp:** thread precise edits into incremental reparse ([`78ce7d1`](https://github.com/jolars/arity/commit/78ce7d17cdf00fb385012cd639f907e1a78e64f7))
- **lsp:** use incremental text document sync ([`0e4b9ce`](https://github.com/jolars/arity/commit/0e4b9ce828c138b08177c3083a967658b462190d))
- **linter:** cut undefined-symbol FPs from opaque binders ([`e1e5264`](https://github.com/jolars/arity/commit/e1e5264454ac757a5798f2241f307475534cd578))
- **linter:** add `coalesce` rule ([`b7ac1d9`](https://github.com/jolars/arity/commit/b7ac1d93ba3a7cdcbd24142ed7153d0b2a9824e3))
- **linter:** add browser rule ([`fe7a5ba`](https://github.com/jolars/arity/commit/fe7a5ba78216d62c053d97cd5e64db2d26a2cb0b))
- **linter:** add if-always-true rule ([`96c136a`](https://github.com/jolars/arity/commit/96c136a30881ac8545c42d545b89975fd9ae5bb6))
- **semantic:** add per-region control-flow graph ([`a912b3c`](https://github.com/jolars/arity/commit/a912b3cf2eaae0713cd96f969961a140d205b12b))
- **lsp:** sharpen references/rename off def-use edges ([`6204c54`](https://github.com/jolars/arity/commit/6204c54493f808feade25380b0b48e8405df246b))
- **format:** cache already-formatted files for --check ([`acc46fc`](https://github.com/jolars/arity/commit/acc46fcdb1bf1d075b98692f9c33708859db1b9f))
- **lsp:** content-derived pull resultId ([`f7ecb99`](https://github.com/jolars/arity/commit/f7ecb992790e8167b8fd128df38c819f3f84a1ec))
- **lsp:** negotiate positionEncoding (UTF-8) ([`7a9af95`](https://github.com/jolars/arity/commit/7a9af95f7441ce2f3baebc4aa5362a40e6bc84e3))
- **lsp:** work-done progress for background jobs ([`12fa210`](https://github.com/jolars/arity/commit/12fa2106000b8c0d85894e941f8286b3fcf997c4))
- **lsp:** static `$`/`@` completion + label details ([`a5b72b8`](https://github.com/jolars/arity/commit/a5b72b8839c63beb926719eefdc857d4c4445627))

### Bug Fixes
- **npm:** fall back to musl when glibc build fails ([`f45beb7`](https://github.com/jolars/arity/commit/f45beb75e17ef2ecedfcd2fc23e533d0f45a13ea))
- **linter:** withhold unused-binding fix on chain ([`b3d42f6`](https://github.com/jolars/arity/commit/b3d42f6a29decafac8280d0360b3a539eedfa9c9))
- **linter:** cut unused-binding FPs from lazy reads ([`17dbaf8`](https://github.com/jolars/arity/commit/17dbaf88a881436e6f540bf97b7dacbf877991d1))
- **linter:** skip non-UTF-8 files instead of aborting ([`89bacc4`](https://github.com/jolars/arity/commit/89bacc42f77629cd929c254ae75b642b148bdc32))
- **formatter:** handle mid-line roxygen as trailing comment ([`41140fa`](https://github.com/jolars/arity/commit/41140fa8556a4e44eff427473aa1312cb6f8899a))
- **formatter:** flatten binary chains with lhs-trailing comment ([`ab99d52`](https://github.com/jolars/arity/commit/ab99d52994826ede43e953718ae41d4299fae9f1))
- **formatter:** handle roxygen comment on assignment rhs ([`0e29c0e`](https://github.com/jolars/arity/commit/0e29c0e610fedbf7329d373db408cb6b6a0ae30e)), closes [#89](https://github.com/jolars/arity/issues/89)
- **formatter:** handle comment trailing binary lhs ([`6953947`](https://github.com/jolars/arity/commit/6953947140e65ef60dcc219a604ff72aab5be31d))
- **parser:** left-associate extract ops with postfix ([`29c7416`](https://github.com/jolars/arity/commit/29c74166e019bc1e33eeb7a50715823be7419796))
- **linter:** resolve for-body reads in enclosing frame ([`023cc57`](https://github.com/jolars/arity/commit/023cc5703282e6050db7d4055094ad0864fe9c0c))
- **linter:** close three undefined-symbol gaps ([`9b4634d`](https://github.com/jolars/arity/commit/9b4634d483f190385ce5a3537010a5b77aa3577f))
- **parser:** group loose roxygen in arg lists ([`f22b0e6`](https://github.com/jolars/arity/commit/f22b0e6234d816d905dda122e57f68dc1548373f))
- **parser:** continue exprs across newlines in brackets ([`c603475`](https://github.com/jolars/arity/commit/c603475ddd48fa52d08048f8b9cb18ffbd45323b))
- **lexer:** accept all raw string delimiter forms ([`178dca1`](https://github.com/jolars/arity/commit/178dca184b6878cb70db29979b793c652efade76))
- **parser:** continue expr across trailing comment in brackets ([`31b23ea`](https://github.com/jolars/arity/commit/31b23eaeeac938aac3f37ec9f5c85d4618d479ce))

## [editors/code: 0.15.0](https://github.com/jolars/arity/compare/arity-code-v0.14.0...arity-code-v0.15.0) (2026-08-05)

### Dependencies
- updated arity to v0.15.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).