### PR TITLE
chore(release): v0.16.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,28 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "b620c58bab56738f2ce7101be711e04629fe543d",
+  "baseline-sha": "5e53edaa2fe020b15e016626f2ae732751739aa4",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.15.0",
-      "tag": "v0.15.0"
+      "version": "0.16.0",
+      "tag": "v0.16.0"
+    },
+    {
+      "path": "crates/arity-formatter",
+      "version": "0.2.0",
+      "tag": "arity-formatter-v0.2.0"
+    },
+    {
+      "path": "crates/arity-parser",
+      "version": "0.2.0",
+      "tag": "arity-parser-v0.2.0"
     },
     {
       "path": "editors/code",
-      "version": "0.15.0",
-      "tag": "arity-code-v0.15.0"
+      "version": "0.16.0",
+      "tag": "arity-code-v0.16.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.15.0",
-      "tag": "v0.15.0"
+      "version": "0.16.0",
+      "tag": "v0.16.0"
+    },
+    {
+      "path": "crates/arity-formatter",
+      "version": "0.2.0",
+      "tag": "arity-formatter-v0.2.0"
+    },
+    {
+      "path": "crates/arity-parser",
+      "version": "0.2.0",
+      "tag": "arity-parser-v0.2.0"
     },
     {
       "path": "editors/code",
-      "version": "0.15.0",
-      "tag": "arity-code-v0.15.0"
+      "version": "0.16.0",
+      "tag": "arity-code-v0.16.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/arity/compare/v0.15.0...v0.16.0) (2026-08-06)
+
+### Features
+- **lsp:** thread roxygen markdown default through salsa and lint ([`6bd4801`](https://github.com/jolars/arity/commit/6bd4801a2804e8c01f59f25689589142edf8d2ab))
+- **format:** honor package roxygen markdown default ([`5606f61`](https://github.com/jolars/arity/commit/5606f61ec5326469643902c7ae793050d8d4442a))
+- **project:** discover roxygen markdown default statically ([`be86db1`](https://github.com/jolars/arity/commit/be86db1af2fb8d20f9af016acd1c15b0f192d5df))
+- **rindex:** opt-in `search()`-diff attach probe ([`deecf3e`](https://github.com/jolars/arity/commit/deecf3e74496dea03788bb904cf88e7e00862791))
+- **rindex:** capture attach sets at harvest ([`4c6e7d8`](https://github.com/jolars/arity/commit/4c6e7d89ee9362930e027a1f8fe033dcf70b2238))
+- **lint:** gate undefined-symbol on harvested attach sets ([`ed92f87`](https://github.com/jolars/arity/commit/ed92f8769a3f435394a0215ef88be32d899a2d1d))
+- **rindex:** resolve members from harvested attach sets ([`492cfd0`](https://github.com/jolars/arity/commit/492cfd05db1798d13758735e7e68d902f0f04e04))
+- **rindex:** add `attaches` to the index schema ([`731c4db`](https://github.com/jolars/arity/commit/731c4db8fcf62770b5cf28435f89c0a1871ac141))
+- **formatter:** re-export `rowan` for embedders ([`81a8d02`](https://github.com/jolars/arity/commit/81a8d028ef7522dd3c7cc1ccc710b584bd9f3bb7))
+- **formatter:** options-taking `format_with_options` entry ([`76ab583`](https://github.com/jolars/arity/commit/76ab583c1f07efb504995a8e2578f9791513c9ea))
+- **formatter:** add serde and schema features ([`341e173`](https://github.com/jolars/arity/commit/341e173a76dbef8d5aa998b716d8f2262b4ed603))
+- **parser:** caller-set roxygen markdown default ([`6367b0b`](https://github.com/jolars/arity/commit/6367b0bc291504fe6073edba31da486ea95a0c47)), closes [#94](https://github.com/jolars/arity/issues/94)
+
+### Bug Fixes
+- **lsp:** expand meta-package members in `packages_to_build` ([`a5b7466`](https://github.com/jolars/arity/commit/a5b7466d015dee11d6830b7f87369e26db5896f7))
+- **linter:** simulate R argument matching for model-frame calls ([`7eb78e0`](https://github.com/jolars/arity/commit/7eb78e096d9c53d187666e410c4a3a2f93f2a563))
+
+### Dependencies
+- updated crates/arity-formatter to v0.2.0
+- updated crates/arity-parser to v0.2.0
+
 ## [0.15.0](https://github.com/jolars/arity/compare/v0.14.0...v0.15.0) (2026-08-05)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arity-parser",
  "insta",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -492,9 +492,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
+checksum = "64f383fe92a826d3b1a3c18e0cb791bef22948931b4909f6781adea466ede5e8"
 dependencies = [
  "clap",
  "roff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.1.0" }
-arity-parser = { path = "crates/arity-parser", version = "0.1.0" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.2.0" }
+arity-parser = { path = "crates/arity-parser", version = "0.2.0" }
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.5"
 crossbeam-channel = "0.5"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/arity/compare/arity-formatter-v0.1.0...arity-formatter-v0.2.0) (2026-08-06)
+
+### Features
+- **formatter:** re-export `rowan` for embedders ([`81a8d02`](https://github.com/jolars/arity/commit/81a8d028ef7522dd3c7cc1ccc710b584bd9f3bb7))
+- **format:** honor package roxygen markdown default ([`5606f61`](https://github.com/jolars/arity/commit/5606f61ec5326469643902c7ae793050d8d4442a))
+- **formatter:** options-taking `format_with_options` entry ([`76ab583`](https://github.com/jolars/arity/commit/76ab583c1f07efb504995a8e2578f9791513c9ea))
+- **formatter:** add serde and schema features ([`341e173`](https://github.com/jolars/arity/commit/341e173a76dbef8d5aa998b716d8f2262b4ed603))
+
+### Dependencies
+- updated crates/arity-parser to v0.2.0

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.1.0" }
+arity-parser = { path = "../arity-parser", version = "0.2.0" }
 rowan = "0.16.1"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/arity/compare/arity-parser-v0.1.0...arity-parser-v0.2.0) (2026-08-06)
+
+### Features
+- **parser:** caller-set roxygen markdown default ([`6367b0b`](https://github.com/jolars/arity/commit/6367b0bc291504fe6073edba31da486ea95a0c47)), closes [#94](https://github.com/jolars/arity/issues/94)

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.16.0](https://github.com/jolars/arity/compare/arity-code-v0.15.0...arity-code-v0.16.0) (2026-08-06)
+
+### Dependencies
+- updated arity to v0.16.0
+
 ## [0.15.0](https://github.com/jolars/arity/compare/arity-code-v0.14.0...arity-code-v0.15.0) (2026-08-05)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
     "r",
@@ -28,13 +28,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.15.0",
-    "@arity-cli/linux-arm64-gnu": "0.15.0",
-    "@arity-cli/linux-x64-musl": "0.15.0",
-    "@arity-cli/linux-arm64-musl": "0.15.0",
-    "@arity-cli/darwin-x64": "0.15.0",
-    "@arity-cli/darwin-arm64": "0.15.0",
-    "@arity-cli/win32-x64": "0.15.0",
-    "@arity-cli/win32-arm64": "0.15.0"
+    "@arity-cli/linux-x64-gnu": "0.16.0",
+    "@arity-cli/linux-arm64-gnu": "0.16.0",
+    "@arity-cli/linux-x64-musl": "0.16.0",
+    "@arity-cli/linux-arm64-musl": "0.16.0",
+    "@arity-cli/darwin-x64": "0.16.0",
+    "@arity-cli/darwin-arm64": "0.16.0",
+    "@arity-cli/win32-x64": "0.16.0",
+    "@arity-cli/win32-arm64": "0.16.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.16.0](https://github.com/jolars/arity/compare/v0.15.0...v0.16.0) (2026-08-06)

### Features
- **lsp:** thread roxygen markdown default through salsa and lint ([`6bd4801`](https://github.com/jolars/arity/commit/6bd4801a2804e8c01f59f25689589142edf8d2ab))
- **format:** honor package roxygen markdown default ([`5606f61`](https://github.com/jolars/arity/commit/5606f61ec5326469643902c7ae793050d8d4442a))
- **project:** discover roxygen markdown default statically ([`be86db1`](https://github.com/jolars/arity/commit/be86db1af2fb8d20f9af016acd1c15b0f192d5df))
- **rindex:** opt-in `search()`-diff attach probe ([`deecf3e`](https://github.com/jolars/arity/commit/deecf3e74496dea03788bb904cf88e7e00862791))
- **rindex:** capture attach sets at harvest ([`4c6e7d8`](https://github.com/jolars/arity/commit/4c6e7d89ee9362930e027a1f8fe033dcf70b2238))
- **lint:** gate undefined-symbol on harvested attach sets ([`ed92f87`](https://github.com/jolars/arity/commit/ed92f8769a3f435394a0215ef88be32d899a2d1d))
- **rindex:** resolve members from harvested attach sets ([`492cfd0`](https://github.com/jolars/arity/commit/492cfd05db1798d13758735e7e68d902f0f04e04))
- **rindex:** add `attaches` to the index schema ([`731c4db`](https://github.com/jolars/arity/commit/731c4db8fcf62770b5cf28435f89c0a1871ac141))
- **formatter:** re-export `rowan` for embedders ([`81a8d02`](https://github.com/jolars/arity/commit/81a8d028ef7522dd3c7cc1ccc710b584bd9f3bb7))
- **formatter:** options-taking `format_with_options` entry ([`76ab583`](https://github.com/jolars/arity/commit/76ab583c1f07efb504995a8e2578f9791513c9ea))
- **formatter:** add serde and schema features ([`341e173`](https://github.com/jolars/arity/commit/341e173a76dbef8d5aa998b716d8f2262b4ed603))
- **parser:** caller-set roxygen markdown default ([`6367b0b`](https://github.com/jolars/arity/commit/6367b0bc291504fe6073edba31da486ea95a0c47)), closes [#94](https://github.com/jolars/arity/issues/94)

### Bug Fixes
- **lsp:** expand meta-package members in `packages_to_build` ([`a5b7466`](https://github.com/jolars/arity/commit/a5b7466d015dee11d6830b7f87369e26db5896f7))
- **linter:** simulate R argument matching for model-frame calls ([`7eb78e0`](https://github.com/jolars/arity/commit/7eb78e096d9c53d187666e410c4a3a2f93f2a563))

### Dependencies
- updated crates/arity-formatter to v0.2.0
- updated crates/arity-parser to v0.2.0

## [crates/arity-formatter: 0.2.0](https://github.com/jolars/arity/compare/arity-formatter-v0.1.0...arity-formatter-v0.2.0) (2026-08-06)

### Features
- **formatter:** re-export `rowan` for embedders ([`81a8d02`](https://github.com/jolars/arity/commit/81a8d028ef7522dd3c7cc1ccc710b584bd9f3bb7))
- **format:** honor package roxygen markdown default ([`5606f61`](https://github.com/jolars/arity/commit/5606f61ec5326469643902c7ae793050d8d4442a))
- **formatter:** options-taking `format_with_options` entry ([`76ab583`](https://github.com/jolars/arity/commit/76ab583c1f07efb504995a8e2578f9791513c9ea))
- **formatter:** add serde and schema features ([`341e173`](https://github.com/jolars/arity/commit/341e173a76dbef8d5aa998b716d8f2262b4ed603))

### Dependencies
- updated crates/arity-parser to v0.2.0

## [crates/arity-parser: 0.2.0](https://github.com/jolars/arity/compare/arity-parser-v0.1.0...arity-parser-v0.2.0) (2026-08-06)

### Features
- **parser:** caller-set roxygen markdown default ([`6367b0b`](https://github.com/jolars/arity/commit/6367b0bc291504fe6073edba31da486ea95a0c47)), closes [#94](https://github.com/jolars/arity/issues/94)

## [editors/code: 0.16.0](https://github.com/jolars/arity/compare/arity-code-v0.15.0...arity-code-v0.16.0) (2026-08-06)

### Dependencies
- updated arity to v0.16.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).