### PR TITLE
chore(release): v0.17.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5e53edaa2fe020b15e016626f2ae732751739aa4",
+  "baseline-sha": "c9a88c46558d137f839f7923bffa6b2d0ecbef22",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.2.0",
-      "tag": "arity-formatter-v0.2.0"
+      "version": "0.3.0",
+      "tag": "arity-formatter-v0.3.0"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.2.0",
-      "tag": "arity-parser-v0.2.0"
+      "version": "0.3.0",
+      "tag": "arity-parser-v0.3.0"
     },
     {
       "path": "editors/code",
-      "version": "0.16.0",
-      "tag": "arity-code-v0.16.0"
+      "version": "0.17.0",
+      "tag": "arity-code-v0.17.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.16.0",
-      "tag": "v0.16.0"
+      "version": "0.17.0",
+      "tag": "v0.17.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.2.0",
-      "tag": "arity-formatter-v0.2.0"
+      "version": "0.3.0",
+      "tag": "arity-formatter-v0.3.0"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.2.0",
-      "tag": "arity-parser-v0.2.0"
+      "version": "0.3.0",
+      "tag": "arity-parser-v0.3.0"
     },
     {
       "path": "editors/code",
-      "version": "0.16.0",
-      "tag": "arity-code-v0.16.0"
+      "version": "0.17.0",
+      "tag": "arity-code-v0.17.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/arity/compare/v0.16.0...v0.17.0) (2026-08-07)
+
+### Features
+- **parser:** let Rd macros win over literal backticks ([`c9a88c4`](https://github.com/jolars/arity/commit/c9a88c46558d137f839f7923bffa6b2d0ecbef22))
+- **parser:** model zero-arity Rd user macros ([`884448e`](https://github.com/jolars/arity/commit/884448eadf47998aeb1e28644f10b90aaf1e982b))
+- **parser:** model per-macro Rd argument arity ([`b0b3f34`](https://github.com/jolars/arity/commit/b0b3f345d31a01f190e2264197c5235e91da41d6))
+- **roxygen:** expand R system Rd user macros ([`4867f69`](https://github.com/jolars/arity/commit/4867f694a6d68d8c97f82c310b917ed2fb4d6c97))
+- **parser:** model md blocks in block-macro bodies ([`26aaa75`](https://github.com/jolars/arity/commit/26aaa75ad0e4a8ed998388ed0b01840736cf77e6))
+- **parser:** model multi-line Rd macro arguments ([`b3b88e4`](https://github.com/jolars/arity/commit/b3b88e400f75b31ee7bfd8fd91415e6454399045))
+- **roxygen:** collapse within-block same-head sections ([`104da98`](https://github.com/jolars/arity/commit/104da989ff98f525a753578573d5438764de3261))
+- **roxygen:** project block-form verbatim macro bodies per-line ([`c5e5f8b`](https://github.com/jolars/arity/commit/c5e5f8b7b580efecdaad0e56a574f801a450c8ad))
+- **parser:** model `\eqn` and `\deqn` optional second argument ([`3051dd4`](https://github.com/jolars/arity/commit/3051dd4013f591292118eb61a9d8f0693aed2afc))
+- **roxygen:** model demoted md code spans via fragile gating ([`30f0127`](https://github.com/jolars/arity/commit/30f0127031e9b4f4fc477f1f021a2cea945304bc))
+- **roxygen:** model parse_Rd brace recovery for kept md sections ([`6121854`](https://github.com/jolars/arity/commit/612185494977522608b474656ea74cfdb15bc520))
+- **lint:** add `r-compat` and `roxygen2-compat` rules ([`9098185`](https://github.com/jolars/arity/commit/90981859908f88a520914e219f8a91c902ab9ab6))
+- **config:** add `[compat]` minimum-version floors ([`4152c80`](https://github.com/jolars/arity/commit/4152c80a9c4093832464c8265a0ab93e5743c48e))
+- **roxygen:** model roxygen2 8.0.0 grammar additions ([`501180c`](https://github.com/jolars/arity/commit/501180ce824f95c0187beb05d0a8a8ff4b61ac1b))
+- **roxygen:** track roxygen2 8.0.0 as the parity oracle ([`925411f`](https://github.com/jolars/arity/commit/925411f02952ed145bca189a5ae00b1135cbceaa))
+- **linter:** add `outdated-suppression` ([`e017cbf`](https://github.com/jolars/arity/commit/e017cbf0b67d3d2ceb4dae78396976fdc3e08033))
+- **linter:** add `unexplained-suppression` ([`b84eea9`](https://github.com/jolars/arity/commit/b84eea93fe7de6153bfd74fb0750c5006d6e9f56))
+- **linter:** add `blanket-suppression` ([`cba661e`](https://github.com/jolars/arity/commit/cba661ebc6d1545bb906f20f7784925c89628699))
+- **linter:** add `misnamed-suppression` ([`404baa7`](https://github.com/jolars/arity/commit/404baa70f84f332fa0ad7645cf1d205abfe7cc58))
+- **linter:** add `duplicated-function-definition` ([`f3ec2fc`](https://github.com/jolars/arity/commit/f3ec2fc7a08f7199838a0cd8b8534a898e21a348))
+- **linter:** add `unused-function` ([`740bf81`](https://github.com/jolars/arity/commit/740bf810ea8a19fe98630b477e3f43234cfcf84b))
+- **linter:** add `internal-function` ([`6632b06`](https://github.com/jolars/arity/commit/6632b061aec49f72b303ca5dd35b611309d9c666))
+- **cli:** suppress `format --check` diff under `--quiet` ([`3865fb0`](https://github.com/jolars/arity/commit/3865fb0c07b7db4de41f2a9f94155af4fb111af0))
+- **linter:** add `for-loop-index`/`for-loop-dup-index` ([`e75efad`](https://github.com/jolars/arity/commit/e75efadbdbc08c005d4a956d1307f44e20c07435))
+- **linter:** add `download-file` ([`bea9893`](https://github.com/jolars/arity/commit/bea98930dfe9d45c2f370a8408ae6d1ab2da18bd))
+- **linter:** add per-rule config and `undesirable-function` ([`4f7a112`](https://github.com/jolars/arity/commit/4f7a112069b284fb034029e8d52c0bcbf8183df8))
+- **formatter:** classify `@prop` and `@R6method` tags ([`a0e81d0`](https://github.com/jolars/arity/commit/a0e81d09890d0935c36d219c640e6cab679f411e))
+- **parser:** model block-macro tails and adjacent second arg groups ([`f7413a7`](https://github.com/jolars/arity/commit/f7413a7537cd6be7f9946881325157afbf20da12))
+- **parser:** model parse_Rd verbatim args and Rd fragment reparse ([`903f500`](https://github.com/jolars/arity/commit/903f5006f932293b4b3f89f9651d146f20879343))
+- **parser:** roxygen2 8.0.0 tag grammar ([`f6d3647`](https://github.com/jolars/arity/commit/f6d3647be8cd0d64cec61105856800d58d197b91))
+- **vscode:** add per-feature enable toggles ([`e8370b0`](https://github.com/jolars/arity/commit/e8370b096f2b5883c94271af399ab5f44b028136))
+
+### Bug Fixes
+- **roxygen:** treat a wide tag separator as prose ([`d9f6a1b`](https://github.com/jolars/arity/commit/d9f6a1be7125da36513b8463bb322e27ae5563c3)), closes [#96](https://github.com/jolars/arity/issues/96)
+- **formatter:** keep marker-less remainder after a block macro ([`40a89cb`](https://github.com/jolars/arity/commit/40a89cb78a342281ecce8e674302788ab4be7c4f))
+- **parser:** fold deep-indented block starts into an open paragraph ([`72ef2f1`](https://github.com/jolars/arity/commit/72ef2f1568dc6231f0f7337a783a6f33a8063be9))
+
+### Dependencies
+- updated crates/arity-formatter to v0.3.0
+- updated crates/arity-parser to v0.3.0
+
 ## [0.16.0](https://github.com/jolars/arity/compare/v0.15.0...v0.16.0) (2026-08-06)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arity-parser",
  "insta",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -394,9 +394,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -492,9 +492,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f383fe92a826d3b1a3c18e0cb791bef22948931b4909f6781adea466ede5e8"
+checksum = "c630ddc90572b3d9abd3f887f0007b4e048faf5c5a59ae607f8ac1c5e3790873"
 dependencies = [
  "clap",
  "roff",
@@ -778,9 +778,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -2269,18 +2269,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.2.0" }
-arity-parser = { path = "crates/arity-parser", version = "0.2.0" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.3.0" }
+arity-parser = { path = "crates/arity-parser", version = "0.3.0" }
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.5"
 crossbeam-channel = "0.5"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/arity/compare/arity-formatter-v0.2.0...arity-formatter-v0.3.0) (2026-08-07)
+
+### Features
+- **formatter:** classify `@prop` and `@R6method` tags ([`a0e81d0`](https://github.com/jolars/arity/commit/a0e81d09890d0935c36d219c640e6cab679f411e))
+
+### Bug Fixes
+- **formatter:** keep marker-less remainder after a block macro ([`40a89cb`](https://github.com/jolars/arity/commit/40a89cb78a342281ecce8e674302788ab4be7c4f))
+- **roxygen:** treat a wide tag separator as prose ([`d9f6a1b`](https://github.com/jolars/arity/commit/d9f6a1be7125da36513b8463bb322e27ae5563c3)), closes [#96](https://github.com/jolars/arity/issues/96)
+
+### Dependencies
+- updated crates/arity-parser to v0.3.0
+
 ## [0.2.0](https://github.com/jolars/arity/compare/arity-formatter-v0.1.0...arity-formatter-v0.2.0) (2026-08-06)
 
 ### Features

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.2.0" }
+arity-parser = { path = "../arity-parser", version = "0.3.0" }
 rowan = "0.16.1"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/arity/compare/arity-parser-v0.2.0...arity-parser-v0.3.0) (2026-08-07)
+
+### Features
+- **parser:** let Rd macros win over literal backticks ([`c9a88c4`](https://github.com/jolars/arity/commit/c9a88c46558d137f839f7923bffa6b2d0ecbef22))
+- **parser:** model zero-arity Rd user macros ([`884448e`](https://github.com/jolars/arity/commit/884448eadf47998aeb1e28644f10b90aaf1e982b))
+- **parser:** model per-macro Rd argument arity ([`b0b3f34`](https://github.com/jolars/arity/commit/b0b3f345d31a01f190e2264197c5235e91da41d6))
+- **parser:** model md blocks in block-macro bodies ([`26aaa75`](https://github.com/jolars/arity/commit/26aaa75ad0e4a8ed998388ed0b01840736cf77e6))
+- **parser:** model multi-line Rd macro arguments ([`b3b88e4`](https://github.com/jolars/arity/commit/b3b88e400f75b31ee7bfd8fd91415e6454399045))
+- **parser:** model block-macro tails and adjacent second arg groups ([`f7413a7`](https://github.com/jolars/arity/commit/f7413a7537cd6be7f9946881325157afbf20da12))
+- **parser:** model `\eqn` and `\deqn` optional second argument ([`3051dd4`](https://github.com/jolars/arity/commit/3051dd4013f591292118eb61a9d8f0693aed2afc))
+- **parser:** model parse_Rd verbatim args and Rd fragment reparse ([`903f500`](https://github.com/jolars/arity/commit/903f5006f932293b4b3f89f9651d146f20879343))
+- **parser:** roxygen2 8.0.0 tag grammar ([`f6d3647`](https://github.com/jolars/arity/commit/f6d3647be8cd0d64cec61105856800d58d197b91))
+
+### Bug Fixes
+- **parser:** fold deep-indented block starts into an open paragraph ([`72ef2f1`](https://github.com/jolars/arity/commit/72ef2f1568dc6231f0f7337a783a6f33a8063be9))
+- **roxygen:** treat a wide tag separator as prose ([`d9f6a1b`](https://github.com/jolars/arity/commit/d9f6a1be7125da36513b8463bb322e27ae5563c3)), closes [#96](https://github.com/jolars/arity/issues/96)
+
 ## [0.2.0](https://github.com/jolars/arity/compare/arity-parser-v0.1.0...arity-parser-v0.2.0) (2026-08-06)
 
 ### Features

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.17.0](https://github.com/jolars/arity/compare/arity-code-v0.16.0...arity-code-v0.17.0) (2026-08-07)
+
+### Features
+- **vscode:** add per-feature enable toggles ([`e8370b0`](https://github.com/jolars/arity/commit/e8370b096f2b5883c94271af399ab5f44b028136))
+
+### Dependencies
+- updated arity to v0.17.0
+
 ## [0.16.0](https://github.com/jolars/arity/compare/arity-code-v0.15.0...arity-code-v0.16.0) (2026-08-06)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.16.0",
-    "@arity-cli/linux-arm64-gnu": "0.16.0",
-    "@arity-cli/linux-x64-musl": "0.16.0",
-    "@arity-cli/linux-arm64-musl": "0.16.0",
-    "@arity-cli/darwin-x64": "0.16.0",
-    "@arity-cli/darwin-arm64": "0.16.0",
-    "@arity-cli/win32-x64": "0.16.0",
-    "@arity-cli/win32-arm64": "0.16.0"
+    "@arity-cli/linux-x64-gnu": "0.17.0",
+    "@arity-cli/linux-arm64-gnu": "0.17.0",
+    "@arity-cli/linux-x64-musl": "0.17.0",
+    "@arity-cli/linux-arm64-musl": "0.17.0",
+    "@arity-cli/darwin-x64": "0.17.0",
+    "@arity-cli/darwin-arm64": "0.17.0",
+    "@arity-cli/win32-x64": "0.17.0",
+    "@arity-cli/win32-arm64": "0.17.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.17.0](https://github.com/jolars/arity/compare/v0.16.0...v0.17.0) (2026-08-07)

### Features
- **parser:** let Rd macros win over literal backticks ([`c9a88c4`](https://github.com/jolars/arity/commit/c9a88c46558d137f839f7923bffa6b2d0ecbef22))
- **parser:** model zero-arity Rd user macros ([`884448e`](https://github.com/jolars/arity/commit/884448eadf47998aeb1e28644f10b90aaf1e982b))
- **parser:** model per-macro Rd argument arity ([`b0b3f34`](https://github.com/jolars/arity/commit/b0b3f345d31a01f190e2264197c5235e91da41d6))
- **roxygen:** expand R system Rd user macros ([`4867f69`](https://github.com/jolars/arity/commit/4867f694a6d68d8c97f82c310b917ed2fb4d6c97))
- **parser:** model md blocks in block-macro bodies ([`26aaa75`](https://github.com/jolars/arity/commit/26aaa75ad0e4a8ed998388ed0b01840736cf77e6))
- **parser:** model multi-line Rd macro arguments ([`b3b88e4`](https://github.com/jolars/arity/commit/b3b88e400f75b31ee7bfd8fd91415e6454399045))
- **roxygen:** collapse within-block same-head sections ([`104da98`](https://github.com/jolars/arity/commit/104da989ff98f525a753578573d5438764de3261))
- **roxygen:** project block-form verbatim macro bodies per-line ([`c5e5f8b`](https://github.com/jolars/arity/commit/c5e5f8b7b580efecdaad0e56a574f801a450c8ad))
- **parser:** model `\eqn` and `\deqn` optional second argument ([`3051dd4`](https://github.com/jolars/arity/commit/3051dd4013f591292118eb61a9d8f0693aed2afc))
- **roxygen:** model demoted md code spans via fragile gating ([`30f0127`](https://github.com/jolars/arity/commit/30f0127031e9b4f4fc477f1f021a2cea945304bc))
- **roxygen:** model parse_Rd brace recovery for kept md sections ([`6121854`](https://github.com/jolars/arity/commit/612185494977522608b474656ea74cfdb15bc520))
- **lint:** add `r-compat` and `roxygen2-compat` rules ([`9098185`](https://github.com/jolars/arity/commit/90981859908f88a520914e219f8a91c902ab9ab6))
- **config:** add `[compat]` minimum-version floors ([`4152c80`](https://github.com/jolars/arity/commit/4152c80a9c4093832464c8265a0ab93e5743c48e))
- **roxygen:** model roxygen2 8.0.0 grammar additions ([`501180c`](https://github.com/jolars/arity/commit/501180ce824f95c0187beb05d0a8a8ff4b61ac1b))
- **roxygen:** track roxygen2 8.0.0 as the parity oracle ([`925411f`](https://github.com/jolars/arity/commit/925411f02952ed145bca189a5ae00b1135cbceaa))
- **linter:** add `outdated-suppression` ([`e017cbf`](https://github.com/jolars/arity/commit/e017cbf0b67d3d2ceb4dae78396976fdc3e08033))
- **linter:** add `unexplained-suppression` ([`b84eea9`](https://github.com/jolars/arity/commit/b84eea93fe7de6153bfd74fb0750c5006d6e9f56))
- **linter:** add `blanket-suppression` ([`cba661e`](https://github.com/jolars/arity/commit/cba661ebc6d1545bb906f20f7784925c89628699))
- **linter:** add `misnamed-suppression` ([`404baa7`](https://github.com/jolars/arity/commit/404baa70f84f332fa0ad7645cf1d205abfe7cc58))
- **linter:** add `duplicated-function-definition` ([`f3ec2fc`](https://github.com/jolars/arity/commit/f3ec2fc7a08f7199838a0cd8b8534a898e21a348))
- **linter:** add `unused-function` ([`740bf81`](https://github.com/jolars/arity/commit/740bf810ea8a19fe98630b477e3f43234cfcf84b))
- **linter:** add `internal-function` ([`6632b06`](https://github.com/jolars/arity/commit/6632b061aec49f72b303ca5dd35b611309d9c666))
- **cli:** suppress `format --check` diff under `--quiet` ([`3865fb0`](https://github.com/jolars/arity/commit/3865fb0c07b7db4de41f2a9f94155af4fb111af0))
- **linter:** add `for-loop-index`/`for-loop-dup-index` ([`e75efad`](https://github.com/jolars/arity/commit/e75efadbdbc08c005d4a956d1307f44e20c07435))
- **linter:** add `download-file` ([`bea9893`](https://github.com/jolars/arity/commit/bea98930dfe9d45c2f370a8408ae6d1ab2da18bd))
- **linter:** add per-rule config and `undesirable-function` ([`4f7a112`](https://github.com/jolars/arity/commit/4f7a112069b284fb034029e8d52c0bcbf8183df8))
- **formatter:** classify `@prop` and `@R6method` tags ([`a0e81d0`](https://github.com/jolars/arity/commit/a0e81d09890d0935c36d219c640e6cab679f411e))
- **parser:** model block-macro tails and adjacent second arg groups ([`f7413a7`](https://github.com/jolars/arity/commit/f7413a7537cd6be7f9946881325157afbf20da12))
- **parser:** model parse_Rd verbatim args and Rd fragment reparse ([`903f500`](https://github.com/jolars/arity/commit/903f5006f932293b4b3f89f9651d146f20879343))
- **parser:** roxygen2 8.0.0 tag grammar ([`f6d3647`](https://github.com/jolars/arity/commit/f6d3647be8cd0d64cec61105856800d58d197b91))
- **vscode:** add per-feature enable toggles ([`e8370b0`](https://github.com/jolars/arity/commit/e8370b096f2b5883c94271af399ab5f44b028136))

### Bug Fixes
- **roxygen:** treat a wide tag separator as prose ([`d9f6a1b`](https://github.com/jolars/arity/commit/d9f6a1be7125da36513b8463bb322e27ae5563c3)), closes [#96](https://github.com/jolars/arity/issues/96)
- **formatter:** keep marker-less remainder after a block macro ([`40a89cb`](https://github.com/jolars/arity/commit/40a89cb78a342281ecce8e674302788ab4be7c4f))
- **parser:** fold deep-indented block starts into an open paragraph ([`72ef2f1`](https://github.com/jolars/arity/commit/72ef2f1568dc6231f0f7337a783a6f33a8063be9))

### Dependencies
- updated crates/arity-formatter to v0.3.0
- updated crates/arity-parser to v0.3.0

## [crates/arity-formatter: 0.3.0](https://github.com/jolars/arity/compare/arity-formatter-v0.2.0...arity-formatter-v0.3.0) (2026-08-07)

### Features
- **formatter:** classify `@prop` and `@R6method` tags ([`a0e81d0`](https://github.com/jolars/arity/commit/a0e81d09890d0935c36d219c640e6cab679f411e))

### Bug Fixes
- **formatter:** keep marker-less remainder after a block macro ([`40a89cb`](https://github.com/jolars/arity/commit/40a89cb78a342281ecce8e674302788ab4be7c4f))
- **roxygen:** treat a wide tag separator as prose ([`d9f6a1b`](https://github.com/jolars/arity/commit/d9f6a1be7125da36513b8463bb322e27ae5563c3)), closes [#96](https://github.com/jolars/arity/issues/96)

### Dependencies
- updated crates/arity-parser to v0.3.0

## [crates/arity-parser: 0.3.0](https://github.com/jolars/arity/compare/arity-parser-v0.2.0...arity-parser-v0.3.0) (2026-08-07)

### Features
- **parser:** let Rd macros win over literal backticks ([`c9a88c4`](https://github.com/jolars/arity/commit/c9a88c46558d137f839f7923bffa6b2d0ecbef22))
- **parser:** model zero-arity Rd user macros ([`884448e`](https://github.com/jolars/arity/commit/884448eadf47998aeb1e28644f10b90aaf1e982b))
- **parser:** model per-macro Rd argument arity ([`b0b3f34`](https://github.com/jolars/arity/commit/b0b3f345d31a01f190e2264197c5235e91da41d6))
- **parser:** model md blocks in block-macro bodies ([`26aaa75`](https://github.com/jolars/arity/commit/26aaa75ad0e4a8ed998388ed0b01840736cf77e6))
- **parser:** model multi-line Rd macro arguments ([`b3b88e4`](https://github.com/jolars/arity/commit/b3b88e400f75b31ee7bfd8fd91415e6454399045))
- **parser:** model block-macro tails and adjacent second arg groups ([`f7413a7`](https://github.com/jolars/arity/commit/f7413a7537cd6be7f9946881325157afbf20da12))
- **parser:** model `\eqn` and `\deqn` optional second argument ([`3051dd4`](https://github.com/jolars/arity/commit/3051dd4013f591292118eb61a9d8f0693aed2afc))
- **parser:** model parse_Rd verbatim args and Rd fragment reparse ([`903f500`](https://github.com/jolars/arity/commit/903f5006f932293b4b3f89f9651d146f20879343))
- **parser:** roxygen2 8.0.0 tag grammar ([`f6d3647`](https://github.com/jolars/arity/commit/f6d3647be8cd0d64cec61105856800d58d197b91))

### Bug Fixes
- **parser:** fold deep-indented block starts into an open paragraph ([`72ef2f1`](https://github.com/jolars/arity/commit/72ef2f1568dc6231f0f7337a783a6f33a8063be9))
- **roxygen:** treat a wide tag separator as prose ([`d9f6a1b`](https://github.com/jolars/arity/commit/d9f6a1be7125da36513b8463bb322e27ae5563c3)), closes [#96](https://github.com/jolars/arity/issues/96)

## [editors/code: 0.17.0](https://github.com/jolars/arity/compare/arity-code-v0.16.0...arity-code-v0.17.0) (2026-08-07)

### Features
- **vscode:** add per-feature enable toggles ([`e8370b0`](https://github.com/jolars/arity/commit/e8370b096f2b5883c94271af399ab5f44b028136))

### Dependencies
- updated arity to v0.17.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).