### PR TITLE
chore(release): v0.18.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "c9a88c46558d137f839f7923bffa6b2d0ecbef22",
+  "baseline-sha": "ae70cbb3c86455fcf368c73503c774fe65ceff39",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.3.0",
-      "tag": "arity-formatter-v0.3.0"
+      "version": "0.3.1",
+      "tag": "arity-formatter-v0.3.1"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.3.0",
-      "tag": "arity-parser-v0.3.0"
+      "version": "0.4.0",
+      "tag": "arity-parser-v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.17.0",
-      "tag": "arity-code-v0.17.0"
+      "version": "0.18.0",
+      "tag": "arity-code-v0.18.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.17.0",
-      "tag": "v0.17.0"
+      "version": "0.18.0",
+      "tag": "v0.18.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.3.0",
-      "tag": "arity-formatter-v0.3.0"
+      "version": "0.3.1",
+      "tag": "arity-formatter-v0.3.1"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.3.0",
-      "tag": "arity-parser-v0.3.0"
+      "version": "0.4.0",
+      "tag": "arity-parser-v0.4.0"
     },
     {
       "path": "editors/code",
-      "version": "0.17.0",
-      "tag": "arity-code-v0.17.0"
+      "version": "0.18.0",
+      "tag": "arity-code-v0.18.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/arity/compare/v0.17.0...v0.18.0) (2026-08-11)
+
+### Features
+- **cli:** read stdin from `-`, not a bare terminal ([`ae70cbb`](https://github.com/jolars/arity/commit/ae70cbb3c86455fcf368c73503c774fe65ceff39))
+- **text:** add TextBuffer pairing text with its line index ([`bff3617`](https://github.com/jolars/arity/commit/bff3617575cb920d0f520c5a39fb5235b14c5b1e))
+- **text:** patch the line index across an edit ([`06c10c5`](https://github.com/jolars/arity/commit/06c10c598103ebb49faeade850bcdb0d73872eea))
+- **semantic:** mask data.table subsets, gate masking verbs ([`aa7a8aa`](https://github.com/jolars/arity/commit/aa7a8aa7b56f51d620d3ec66a4de0780652c7b2f))
+- **lsp:** support folder renames ([`00151ee`](https://github.com/jolars/arity/commit/00151ee19e749c31482d1de4112318a8d540b151))
+- **parser:** make brace-less system Rd macros sticky ([`aed2df0`](https://github.com/jolars/arity/commit/aed2df0dcccd8633eac694e0b1ce0d6e86a1f61a))
+- **parser:** stop unknown Rd macros consuming a group ([`374879e`](https://github.com/jolars/arity/commit/374879e0002373f955554ed651f98725a63268e9))
+- **parser:** expose an `is_single_expression` predicate ([`93cae60`](https://github.com/jolars/arity/commit/93cae60d35c342b62a82df4737971fe8e6b1722d))
+
+### Bug Fixes
+- **lsp:** drop file renames that leave the workspace scope ([`237daea`](https://github.com/jolars/arity/commit/237daea34f724f94661bd37260848cfddf64e25b))
+- **lsp:** follow a renamed workspace root through a rename ([`1de3fb2`](https://github.com/jolars/arity/commit/1de3fb2efd4994646a55e85dde5aaab1f54ed6d9))
+- **roxygen:** keep a trailing `;` in a code span as `\code` ([`a1fcff9`](https://github.com/jolars/arity/commit/a1fcff97d632179cd03b3b9e909ad4e909de3521)), closes [#99](https://github.com/jolars/arity/issues/99)
+- **formatter:** keep blank line after a comment ([`e50f7fe`](https://github.com/jolars/arity/commit/e50f7fef855b33152f9f0f948f9efe14072185ae))
+
+### Performance Improvements
+- **lsp:** answer position reads off the shared index ([`e53de52`](https://github.com/jolars/arity/commit/e53de527dea8df5b1459f215a052e57757226b01))
+- **lsp:** answer whole-document reads off the shared index ([`a354814`](https://github.com/jolars/arity/commit/a3548145f5c4ac3eb5308c51cda0d68d41a0021e))
+- **lsp:** thread the shared buffer into the lint request ([`9b610a0`](https://github.com/jolars/arity/commit/9b610a090a372091fd905a43f3a969077790cd6c))
+- **text:** scan for line starts with memchr ([`6aa8b3b`](https://github.com/jolars/arity/commit/6aa8b3bed8ae6c4d1f67762f9a8dd422a8cfbbb5))
+
+### Dependencies
+- updated crates/arity-formatter to v0.3.1
+- updated crates/arity-parser to v0.4.0
+
 ## [0.17.0](https://github.com/jolars/arity/compare/v0.16.0...v0.17.0) (2026-08-07)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arity-parser",
  "insta",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -373,9 +373,9 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -396,9 +396,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1297,9 +1297,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1876,18 +1876,18 @@ checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.3.0" }
-arity-parser = { path = "crates/arity-parser", version = "0.3.0" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.3.1" }
+arity-parser = { path = "crates/arity-parser", version = "0.4.0" }
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.5"
 crossbeam-channel = "0.5"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1](https://github.com/jolars/arity/compare/arity-formatter-v0.3.0...arity-formatter-v0.3.1) (2026-08-11)
+
+### Bug Fixes
+- **formatter:** keep blank line after a comment ([`e50f7fe`](https://github.com/jolars/arity/commit/e50f7fef855b33152f9f0f948f9efe14072185ae))
+
+### Dependencies
+- updated crates/arity-parser to v0.4.0
+
 ## [0.3.0](https://github.com/jolars/arity/compare/arity-formatter-v0.2.0...arity-formatter-v0.3.0) (2026-08-07)
 
 ### Features

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.3.0" }
+arity-parser = { path = "../arity-parser", version = "0.4.0" }
 rowan = "0.16.1"
 schemars = { version = "1.2.1", optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/arity/compare/arity-parser-v0.3.0...arity-parser-v0.4.0) (2026-08-11)
+
+### Features
+- **parser:** expose an `is_single_expression` predicate ([`93cae60`](https://github.com/jolars/arity/commit/93cae60d35c342b62a82df4737971fe8e6b1722d))
+- **parser:** make brace-less system Rd macros sticky ([`aed2df0`](https://github.com/jolars/arity/commit/aed2df0dcccd8633eac694e0b1ce0d6e86a1f61a))
+- **parser:** stop unknown Rd macros consuming a group ([`374879e`](https://github.com/jolars/arity/commit/374879e0002373f955554ed651f98725a63268e9))
+
 ## [0.3.0](https://github.com/jolars/arity/compare/arity-parser-v0.2.0...arity-parser-v0.3.0) (2026-08-07)
 
 ### Features

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.18.0](https://github.com/jolars/arity/compare/arity-code-v0.17.0...arity-code-v0.18.0) (2026-08-11)
+
+### Dependencies
+- updated arity to v0.18.0
+
 ## [0.17.0](https://github.com/jolars/arity/compare/arity-code-v0.16.0...arity-code-v0.17.0) (2026-08-07)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.17.0",
-    "@arity-cli/linux-arm64-gnu": "0.17.0",
-    "@arity-cli/linux-x64-musl": "0.17.0",
-    "@arity-cli/linux-arm64-musl": "0.17.0",
-    "@arity-cli/darwin-x64": "0.17.0",
-    "@arity-cli/darwin-arm64": "0.17.0",
-    "@arity-cli/win32-x64": "0.17.0",
-    "@arity-cli/win32-arm64": "0.17.0"
+    "@arity-cli/linux-x64-gnu": "0.18.0",
+    "@arity-cli/linux-arm64-gnu": "0.18.0",
+    "@arity-cli/linux-x64-musl": "0.18.0",
+    "@arity-cli/linux-arm64-musl": "0.18.0",
+    "@arity-cli/darwin-x64": "0.18.0",
+    "@arity-cli/darwin-arm64": "0.18.0",
+    "@arity-cli/win32-x64": "0.18.0",
+    "@arity-cli/win32-arm64": "0.18.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.18.0](https://github.com/jolars/arity/compare/v0.17.0...v0.18.0) (2026-08-11)

### Features
- **cli:** read stdin from `-`, not a bare terminal ([`ae70cbb`](https://github.com/jolars/arity/commit/ae70cbb3c86455fcf368c73503c774fe65ceff39))
- **text:** add TextBuffer pairing text with its line index ([`bff3617`](https://github.com/jolars/arity/commit/bff3617575cb920d0f520c5a39fb5235b14c5b1e))
- **text:** patch the line index across an edit ([`06c10c5`](https://github.com/jolars/arity/commit/06c10c598103ebb49faeade850bcdb0d73872eea))
- **semantic:** mask data.table subsets, gate masking verbs ([`aa7a8aa`](https://github.com/jolars/arity/commit/aa7a8aa7b56f51d620d3ec66a4de0780652c7b2f))
- **lsp:** support folder renames ([`00151ee`](https://github.com/jolars/arity/commit/00151ee19e749c31482d1de4112318a8d540b151))
- **parser:** make brace-less system Rd macros sticky ([`aed2df0`](https://github.com/jolars/arity/commit/aed2df0dcccd8633eac694e0b1ce0d6e86a1f61a))
- **parser:** stop unknown Rd macros consuming a group ([`374879e`](https://github.com/jolars/arity/commit/374879e0002373f955554ed651f98725a63268e9))
- **parser:** expose an `is_single_expression` predicate ([`93cae60`](https://github.com/jolars/arity/commit/93cae60d35c342b62a82df4737971fe8e6b1722d))

### Bug Fixes
- **lsp:** drop file renames that leave the workspace scope ([`237daea`](https://github.com/jolars/arity/commit/237daea34f724f94661bd37260848cfddf64e25b))
- **lsp:** follow a renamed workspace root through a rename ([`1de3fb2`](https://github.com/jolars/arity/commit/1de3fb2efd4994646a55e85dde5aaab1f54ed6d9))
- **roxygen:** keep a trailing `;` in a code span as `\code` ([`a1fcff9`](https://github.com/jolars/arity/commit/a1fcff97d632179cd03b3b9e909ad4e909de3521)), closes [#99](https://github.com/jolars/arity/issues/99)
- **formatter:** keep blank line after a comment ([`e50f7fe`](https://github.com/jolars/arity/commit/e50f7fef855b33152f9f0f948f9efe14072185ae))

### Performance Improvements
- **lsp:** answer position reads off the shared index ([`e53de52`](https://github.com/jolars/arity/commit/e53de527dea8df5b1459f215a052e57757226b01))
- **lsp:** answer whole-document reads off the shared index ([`a354814`](https://github.com/jolars/arity/commit/a3548145f5c4ac3eb5308c51cda0d68d41a0021e))
- **lsp:** thread the shared buffer into the lint request ([`9b610a0`](https://github.com/jolars/arity/commit/9b610a090a372091fd905a43f3a969077790cd6c))
- **text:** scan for line starts with memchr ([`6aa8b3b`](https://github.com/jolars/arity/commit/6aa8b3bed8ae6c4d1f67762f9a8dd422a8cfbbb5))

### Dependencies
- updated crates/arity-formatter to v0.3.1
- updated crates/arity-parser to v0.4.0

## [crates/arity-formatter: 0.3.1](https://github.com/jolars/arity/compare/arity-formatter-v0.3.0...arity-formatter-v0.3.1) (2026-08-11)

### Bug Fixes
- **formatter:** keep blank line after a comment ([`e50f7fe`](https://github.com/jolars/arity/commit/e50f7fef855b33152f9f0f948f9efe14072185ae))

### Dependencies
- updated crates/arity-parser to v0.4.0

## [crates/arity-parser: 0.4.0](https://github.com/jolars/arity/compare/arity-parser-v0.3.0...arity-parser-v0.4.0) (2026-08-11)

### Features
- **parser:** expose an `is_single_expression` predicate ([`93cae60`](https://github.com/jolars/arity/commit/93cae60d35c342b62a82df4737971fe8e6b1722d))
- **parser:** make brace-less system Rd macros sticky ([`aed2df0`](https://github.com/jolars/arity/commit/aed2df0dcccd8633eac694e0b1ce0d6e86a1f61a))
- **parser:** stop unknown Rd macros consuming a group ([`374879e`](https://github.com/jolars/arity/commit/374879e0002373f955554ed651f98725a63268e9))

## [editors/code: 0.18.0](https://github.com/jolars/arity/compare/arity-code-v0.17.0...arity-code-v0.18.0) (2026-08-11)

### Dependencies
- updated arity to v0.18.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).