### PR TITLE
chore(release): v0.19.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ae70cbb3c86455fcf368c73503c774fe65ceff39",
+  "baseline-sha": "5e1e2157e685ed9661e7bfca2981eca64831563d",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "0.19.0",
+      "tag": "v0.19.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.3.1",
-      "tag": "arity-formatter-v0.3.1"
+      "version": "0.4.0",
+      "tag": "arity-formatter-v0.4.0"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.4.0",
-      "tag": "arity-parser-v0.4.0"
+      "version": "0.5.0",
+      "tag": "arity-parser-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.18.0",
-      "tag": "arity-code-v0.18.0"
+      "version": "0.19.0",
+      "tag": "arity-code-v0.19.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.18.0",
-      "tag": "v0.18.0"
+      "version": "0.19.0",
+      "tag": "v0.19.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.3.1",
-      "tag": "arity-formatter-v0.3.1"
+      "version": "0.4.0",
+      "tag": "arity-formatter-v0.4.0"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.4.0",
-      "tag": "arity-parser-v0.4.0"
+      "version": "0.5.0",
+      "tag": "arity-parser-v0.5.0"
     },
     {
       "path": "editors/code",
-      "version": "0.18.0",
-      "tag": "arity-code-v0.18.0"
+      "version": "0.19.0",
+      "tag": "arity-code-v0.19.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,83 @@
 # Changelog
 
-## Unreleased
+## [0.19.0](https://github.com/jolars/arity/compare/v0.18.0...v0.19.0) (2026-08-14)
 
 The most prominent feature of this release is that Arity now handles the `DESCRIPTION`
 file in R projects: it lints it, formats it, and provides language-server features like
 inlay hints for loaded versions.
+
+### Breaking changes
+- **deps:** bump `rowan` to 0.17 ([`64ad43b`](https://github.com/jolars/arity/commit/64ad43be2125e8713e0656307d094a8e0a0601a4))
+
+### Features
+- **lint:** add deprecated-suppression ([`41c37c0`](https://github.com/jolars/arity/commit/41c37c062d812c7326cfa6866a04a6604084f8cb))
+- **lint:** add region directives and lint the new forms ([`fdd1e5e`](https://github.com/jolars/arity/commit/fdd1e5e89cb7461e22a478bb2a47ad43742bba41))
+- **lsp:** send line-scoped formatting edits ([`406b5ab`](https://github.com/jolars/arity/commit/406b5abc7a34c7dbacb4e87ddfbb0fe84f1084fd))
+- **lsp:** add inlay hints for DESCRIPTION deps ([`7aa282a`](https://github.com/jolars/arity/commit/7aa282a008861c40806b126de4898013153b6e6e))
+- **lint:** add `description-empty-person` ([`41c7786`](https://github.com/jolars/arity/commit/41c77868b6f7a9dd8849f4dd91bb42439b3c3c13))
+- **lint:** add `description-authors-at-r` ([`21c4597`](https://github.com/jolars/arity/commit/21c4597dbddb9893391c76ce6cc3cdf07de7a3de))
+- **lint:** add `description-malformed-maintainer` ([`f813cb5`](https://github.com/jolars/arity/commit/f813cb538927e66faf9f1d7dc4b1dacefd655808))
+- **lint:** add `description-malformed-version` ([`31fcb76`](https://github.com/jolars/arity/commit/31fcb765d659c8f00d615f34abccb96aa6a3aa96))
+- **lint:** add `description-malformed-name` ([`3347825`](https://github.com/jolars/arity/commit/3347825cca35ddecc36ad951f2425bd3dcd7d106))
+- **lint:** add `description-package-in-multiple-fields` ([`41cd5af`](https://github.com/jolars/arity/commit/41cd5af4f8c792116eded921bd5c7f4dc4cf00f7))
+- format package DESCRIPTION files (#104) ([`40583bf`](https://github.com/jolars/arity/commit/40583bf0caf22499453080456dfac9e12e8c239d))
+- **lsp:** hover a DESCRIPTION dependency ([`5655f64`](https://github.com/jolars/arity/commit/5655f647824827b0f1b75ee2afe9b06400943d26))
+- **lsp:** complete package names in DESCRIPTION dependency fields ([`76f339f`](https://github.com/jolars/arity/commit/76f339f69174642cef22c0d795f4187ebf537247))
+- **lsp:** make an open DESCRIPTION authoritative in salsa ([`2537f39`](https://github.com/jolars/arity/commit/2537f398558c17a2e99f3423291a37fc397860c7))
+- **lsp:** publish DESCRIPTION diagnostics ([`9b433a5`](https://github.com/jolars/arity/commit/9b433a52c0d34411ade474027831737b8de573f9))
+- **lsp:** route DESCRIPTION documents away from the R pipeline ([`23a61fc`](https://github.com/jolars/arity/commit/23a61fc327464e8b885d13f0ed8d4cf02b616686))
+- **linter:** add unused-dependency ([`b6d73cf`](https://github.com/jolars/arity/commit/b6d73cf7f7a6701791dc5f1584a88ad5b89cce05))
+- **linter:** add undeclared-dependency ([`d35c7fc`](https://github.com/jolars/arity/commit/d35c7fc13efdffe407b534a0d0be3ea970e46e21))
+- **linter:** add three DESCRIPTION rules ([`7ac50e4`](https://github.com/jolars/arity/commit/7ac50e4024343398c3f1d41da462029eccbd6592))
+- **linter:** discover and lint DESCRIPTION files ([`18c9366`](https://github.com/jolars/arity/commit/18c9366cc7bb413bcd3fcc88c5d8c2065cbb74ce))
+- **linter:** add a rule trait for the DCF grammar ([`f3779d5`](https://github.com/jolars/arity/commit/f3779d50de5052a0985bb9bd0e7dac8adbeb6565))
+- **rindex:** treat declared dependencies as referenced ([`256d4c8`](https://github.com/jolars/arity/commit/256d4c8b7f2a831dd4ab958823b5fb75b301482a))
+- **project:** defer the import(pkg) verdict to the library index ([`6f580bf`](https://github.com/jolars/arity/commit/6f580bf27e75c5314b8a250ab99618c3f95a189e))
+- **project:** resolve against declared Depends ([`d999290`](https://github.com/jolars/arity/commit/d9992901c758845e83dd53671c3c36bdc40edf2e))
+- **incremental:** make DESCRIPTION a salsa input ([`3340923`](https://github.com/jolars/arity/commit/33409232acd5d931f123efdf870564ad9c069bc1))
+- **parser:** add a lossless DCF CST parser ([`42ca268`](https://github.com/jolars/arity/commit/42ca26849d41bff20c8e4189c2a73b9ad9a166a1))
+- **lsp:** widen call hierarchy edge attribution ([`00a798d`](https://github.com/jolars/arity/commit/00a798dd4d7dcb62e1c3d67bb35cd8defab4501a))
+- **formatter:** honor skip-file in a DESCRIPTION ([`f737e8b`](https://github.com/jolars/arity/commit/f737e8b03aec62b72e3a15f59f843ab38d42e07d))
+- **formatter:** honor arity-format directives ([`922813c`](https://github.com/jolars/arity/commit/922813c86fccb2b1204c62b3c1b52ba6f786c268))
+- **parser:** record a directive's prefix range ([`72d8536`](https://github.com/jolars/arity/commit/72d853656683116b4f5716c67dfc805ec76ebe3e))
+- **parser:** add the shared arity directive grammar ([`39651b0`](https://github.com/jolars/arity/commit/39651b0789e6bd6de24fcc741d24077cb79e3902))
+- **ast:** add `RoxygenTag::value_text` ([`5b35b6d`](https://github.com/jolars/arity/commit/5b35b6dd190c9a41cd4f0cd2dbbe2b28fe7ceb09))
+- **parser:** re-export the dependency-field helpers from dcf ([`fbb8183`](https://github.com/jolars/arity/commit/fbb8183efa0bfd4140b3b82ad40049514d86b6dc))
+- **dcf:** parse structured dependency entries ([`e5ee844`](https://github.com/jolars/arity/commit/e5ee8448186e949c14fd8839816846b2be9b935d))
+- **vscode:** gate inlay hints on the feature toggle ([`dd6fde8`](https://github.com/jolars/arity/commit/dd6fde821a63fa24a48517cf95472f035264e520))
+- **code:** claim DESCRIPTION for the language server ([`0fe3077`](https://github.com/jolars/arity/commit/0fe30773c0c30d8f16f61f333c0fca6b47acef8b))
+
+### Bug Fixes
+- **linter:** skip `coalesce` in the `%||%` definition ([`2114c88`](https://github.com/jolars/arity/commit/2114c88ede126119788f924aebd26f4632eca0c2))
+- **semantic:** mark every def a closure read reaches ([`32e98e2`](https://github.com/jolars/arity/commit/32e98e2f1f3930105c470033e14310ce5f7ea65e))
+- **semantic:** resolve names bound by `useDynLib` ([`c72462a`](https://github.com/jolars/arity/commit/c72462a6d28d3aa5f826c69e5d817e3ba3640e70))
+- **semantic:** make defusing operators unquote-aware ([`dd2ce0a`](https://github.com/jolars/arity/commit/dd2ce0a96fad2aa3297b6aeeab2a171d2a16d564))
+- **roxygen:** read projector topic names whole ([`f7b6d3e`](https://github.com/jolars/arity/commit/f7b6d3e4688ed706f4df0f2ac098150e42540cec))
+- **lint:** resolve roxygen topics across the package ([`7e6e7ce`](https://github.com/jolars/arity/commit/7e6e7ce82071926a53ed6f4add86e28b6cdf582a))
+- **lint:** exempt S3 methods from `unused-binding` ([`a107859`](https://github.com/jolars/arity/commit/a1078598efa1cd279bd31490d2c358ff757f3c40))
+- **lint:** judge roxygen topics, not single blocks ([`3357e83`](https://github.com/jolars/arity/commit/3357e83a9da4b8baf4f3b92f8fb864f3ba88c36c))
+- **cli:** give `lint --fix` the project scope ([`85d6d1e`](https://github.com/jolars/arity/commit/85d6d1e22abb00ace742ee538c2aabecc31f310e))
+- **lint:** skip `roxygen-param` on `@noRd` blocks ([`0b842d9`](https://github.com/jolars/arity/commit/0b842d9d24df2ec6c5e1b40693261dfa20b57ecf))
+- **semantic:** mask the `.External2` routine name ([`c090566`](https://github.com/jolars/arity/commit/c090566e9e114a5e324e5a3d458c67895a91007a))
+- **semantic:** never bind the walrus operator ([`d1251b9`](https://github.com/jolars/arity/commit/d1251b9d440e792b325e5c43559de1297938ddd9))
+- **semantic:** match backticked names to NAMESPACE ([`078d0e0`](https://github.com/jolars/arity/commit/078d0e040e67096303b1f4f4fd451730e1fe6985))
+- **lint:** name the actual range in `seq` messages ([`5d4cbab`](https://github.com/jolars/arity/commit/5d4cbab256b1ac3e359e31bc8e1c551c189f891c))
+- **lint:** skip roxygen topic rules on S3 methods ([`029af86`](https://github.com/jolars/arity/commit/029af86114891fa2b3f55fc8a41ba7c2e50bae38))
+- **lsp:** refresh the graph when a DESCRIPTION disappears ([`f987130`](https://github.com/jolars/arity/commit/f98713095c2980c23c2ee8b56123d8671ab3343a))
+- **linter:** skip a fixture package's DESCRIPTION when walking ([`0d70adb`](https://github.com/jolars/arity/commit/0d70adb29157f91b0a879f1b6bfa8580f9ef531a))
+- **semantic:** resolve backtick-quoted names ([`cc3d1db`](https://github.com/jolars/arity/commit/cc3d1dbfa7a0bbf9d10bd4c61a476e2d48f57358))
+- **rindex:** keep only the packages import() names ([`205957c`](https://github.com/jolars/arity/commit/205957ca2fd6ebfdf042007e6238748d6621bac9))
+- **formatter:** give an Rd `\item` its own line ([`481b9ac`](https://github.com/jolars/arity/commit/481b9ac1ccfa72f2db0496b475bf94012d1fa465))
+- **formatter:** flush a block Rd macro's opener line ([`bd27d5c`](https://github.com/jolars/arity/commit/bd27d5c35f327475facea9b8128e0a3ce418b23d))
+
+### Performance Improvements
+- **linter:** keep the standalone attach set lazy ([`a238d64`](https://github.com/jolars/arity/commit/a238d648de42c02357b51e3b42e06a06c9c0dec3))
+- **lsp:** invalidate package metadata by path ([`629ac9c`](https://github.com/jolars/arity/commit/629ac9cd01dc3487a875dc25100bf24b7d433472))
+- **formatter:** answer both prepasses in one green-tree walk ([`6f8a444`](https://github.com/jolars/arity/commit/6f8a4440d3efb68e65058044d5581de051412de6))
+
+### Dependencies
+- updated crates/arity-formatter to v0.4.0
+- updated crates/arity-parser to v0.5.0
 
 ## [0.18.0](https://github.com/jolars/arity/compare/v0.17.0...v0.18.0) (2026-08-11)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arity-parser",
  "insta",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -396,9 +396,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -494,9 +494,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c630ddc90572b3d9abd3f887f0007b4e048faf5c5a59ae607f8ac1c5e3790873"
+checksum = "211d617eaa4b735c96c9e0228fcbdb5120ef623f2b8cb67ffb84c3e02dbc28a4"
 dependencies = [
  "clap",
  "roff",
@@ -769,9 +769,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.3.1" }
-arity-parser = { path = "crates/arity-parser", version = "0.4.0" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.4.0" }
+arity-parser = { path = "crates/arity-parser", version = "0.5.0" }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"
 crossbeam-channel = "0.5.16"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/arity/compare/arity-formatter-v0.3.1...arity-formatter-v0.4.0) (2026-08-14)
+
+### Breaking changes
+- **deps:** bump `rowan` to 0.17 ([`64ad43b`](https://github.com/jolars/arity/commit/64ad43be2125e8713e0656307d094a8e0a0601a4))
+
+### Features
+- **formatter:** honor skip-file in a DESCRIPTION ([`f737e8b`](https://github.com/jolars/arity/commit/f737e8b03aec62b72e3a15f59f843ab38d42e07d))
+- **formatter:** honor arity-format directives ([`922813c`](https://github.com/jolars/arity/commit/922813c86fccb2b1204c62b3c1b52ba6f786c268))
+- format package DESCRIPTION files (#104) ([`40583bf`](https://github.com/jolars/arity/commit/40583bf0caf22499453080456dfac9e12e8c239d))
+
+### Bug Fixes
+- **formatter:** give an Rd `\item` its own line ([`481b9ac`](https://github.com/jolars/arity/commit/481b9ac1ccfa72f2db0496b475bf94012d1fa465))
+- **formatter:** flush a block Rd macro's opener line ([`bd27d5c`](https://github.com/jolars/arity/commit/bd27d5c35f327475facea9b8128e0a3ce418b23d))
+
+### Performance Improvements
+- **formatter:** answer both prepasses in one green-tree walk ([`6f8a444`](https://github.com/jolars/arity/commit/6f8a4440d3efb68e65058044d5581de051412de6))
+
+### Dependencies
+- updated crates/arity-parser to v0.5.0
+
 ## [0.3.1](https://github.com/jolars/arity/compare/arity-formatter-v0.3.0...arity-formatter-v0.3.1) (2026-08-11)
 
 ### Bug Fixes

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.4.0" }
+arity-parser = { path = "../arity-parser", version = "0.5.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.2", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/arity/compare/arity-parser-v0.4.0...arity-parser-v0.5.0) (2026-08-14)
+
+### Breaking changes
+- **deps:** bump `rowan` to 0.17 ([`64ad43b`](https://github.com/jolars/arity/commit/64ad43be2125e8713e0656307d094a8e0a0601a4))
+
+### Features
+- **parser:** record a directive's prefix range ([`72d8536`](https://github.com/jolars/arity/commit/72d853656683116b4f5716c67dfc805ec76ebe3e))
+- **parser:** add the shared arity directive grammar ([`39651b0`](https://github.com/jolars/arity/commit/39651b0789e6bd6de24fcc741d24077cb79e3902))
+- **ast:** add `RoxygenTag::value_text` ([`5b35b6d`](https://github.com/jolars/arity/commit/5b35b6dd190c9a41cd4f0cd2dbbe2b28fe7ceb09))
+- **parser:** re-export the dependency-field helpers from dcf ([`fbb8183`](https://github.com/jolars/arity/commit/fbb8183efa0bfd4140b3b82ad40049514d86b6dc))
+- **linter:** add a rule trait for the DCF grammar ([`f3779d5`](https://github.com/jolars/arity/commit/f3779d50de5052a0985bb9bd0e7dac8adbeb6565))
+- **dcf:** parse structured dependency entries ([`e5ee844`](https://github.com/jolars/arity/commit/e5ee8448186e949c14fd8839816846b2be9b935d))
+- **parser:** add a lossless DCF CST parser ([`42ca268`](https://github.com/jolars/arity/commit/42ca26849d41bff20c8e4189c2a73b9ad9a166a1))
+
 ## [0.4.0](https://github.com/jolars/arity/compare/arity-parser-v0.3.0...arity-parser-v0.4.0) (2026-08-11)
 
 ### Features

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.19.0](https://github.com/jolars/arity/compare/arity-code-v0.18.0...arity-code-v0.19.0) (2026-08-14)
+
+### Features
+- **vscode:** gate inlay hints on the feature toggle ([`dd6fde8`](https://github.com/jolars/arity/commit/dd6fde821a63fa24a48517cf95472f035264e520))
+- format package DESCRIPTION files (#104) ([`40583bf`](https://github.com/jolars/arity/commit/40583bf0caf22499453080456dfac9e12e8c239d))
+- **code:** claim DESCRIPTION for the language server ([`0fe3077`](https://github.com/jolars/arity/commit/0fe30773c0c30d8f16f61f333c0fca6b47acef8b))
+
+### Dependencies
+- updated arity to v0.19.0
+
 ## [0.18.0](https://github.com/jolars/arity/compare/arity-code-v0.17.0...arity-code-v0.18.0) (2026-08-11)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.18.0",
-    "@arity-cli/linux-arm64-gnu": "0.18.0",
-    "@arity-cli/linux-x64-musl": "0.18.0",
-    "@arity-cli/linux-arm64-musl": "0.18.0",
-    "@arity-cli/darwin-x64": "0.18.0",
-    "@arity-cli/darwin-arm64": "0.18.0",
-    "@arity-cli/win32-x64": "0.18.0",
-    "@arity-cli/win32-arm64": "0.18.0"
+    "@arity-cli/linux-x64-gnu": "0.19.0",
+    "@arity-cli/linux-arm64-gnu": "0.19.0",
+    "@arity-cli/linux-x64-musl": "0.19.0",
+    "@arity-cli/linux-arm64-musl": "0.19.0",
+    "@arity-cli/darwin-x64": "0.19.0",
+    "@arity-cli/darwin-arm64": "0.19.0",
+    "@arity-cli/win32-x64": "0.19.0",
+    "@arity-cli/win32-arm64": "0.19.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.19.0](https://github.com/jolars/arity/compare/v0.18.0...v0.19.0) (2026-08-14)

The most prominent feature of this release is that Arity now handles the `DESCRIPTION`
file in R projects: it lints it, formats it, and provides language-server features like
inlay hints for loaded versions.

### Breaking changes
- **deps:** bump `rowan` to 0.17 ([`64ad43b`](https://github.com/jolars/arity/commit/64ad43be2125e8713e0656307d094a8e0a0601a4))

### Features
- **lint:** add deprecated-suppression ([`41c37c0`](https://github.com/jolars/arity/commit/41c37c062d812c7326cfa6866a04a6604084f8cb))
- **lint:** add region directives and lint the new forms ([`fdd1e5e`](https://github.com/jolars/arity/commit/fdd1e5e89cb7461e22a478bb2a47ad43742bba41))
- **lsp:** send line-scoped formatting edits ([`406b5ab`](https://github.com/jolars/arity/commit/406b5abc7a34c7dbacb4e87ddfbb0fe84f1084fd))
- **lsp:** add inlay hints for DESCRIPTION deps ([`7aa282a`](https://github.com/jolars/arity/commit/7aa282a008861c40806b126de4898013153b6e6e))
- **lint:** add `description-empty-person` ([`41c7786`](https://github.com/jolars/arity/commit/41c77868b6f7a9dd8849f4dd91bb42439b3c3c13))
- **lint:** add `description-authors-at-r` ([`21c4597`](https://github.com/jolars/arity/commit/21c4597dbddb9893391c76ce6cc3cdf07de7a3de))
- **lint:** add `description-malformed-maintainer` ([`f813cb5`](https://github.com/jolars/arity/commit/f813cb538927e66faf9f1d7dc4b1dacefd655808))
- **lint:** add `description-malformed-version` ([`31fcb76`](https://github.com/jolars/arity/commit/31fcb765d659c8f00d615f34abccb96aa6a3aa96))
- **lint:** add `description-malformed-name` ([`3347825`](https://github.com/jolars/arity/commit/3347825cca35ddecc36ad951f2425bd3dcd7d106))
- **lint:** add `description-package-in-multiple-fields` ([`41cd5af`](https://github.com/jolars/arity/commit/41cd5af4f8c792116eded921bd5c7f4dc4cf00f7))
- format package DESCRIPTION files (#104) ([`40583bf`](https://github.com/jolars/arity/commit/40583bf0caf22499453080456dfac9e12e8c239d))
- **lsp:** hover a DESCRIPTION dependency ([`5655f64`](https://github.com/jolars/arity/commit/5655f647824827b0f1b75ee2afe9b06400943d26))
- **lsp:** complete package names in DESCRIPTION dependency fields ([`76f339f`](https://github.com/jolars/arity/commit/76f339f69174642cef22c0d795f4187ebf537247))
- **lsp:** make an open DESCRIPTION authoritative in salsa ([`2537f39`](https://github.com/jolars/arity/commit/2537f398558c17a2e99f3423291a37fc397860c7))
- **lsp:** publish DESCRIPTION diagnostics ([`9b433a5`](https://github.com/jolars/arity/commit/9b433a52c0d34411ade474027831737b8de573f9))
- **lsp:** route DESCRIPTION documents away from the R pipeline ([`23a61fc`](https://github.com/jolars/arity/commit/23a61fc327464e8b885d13f0ed8d4cf02b616686))
- **linter:** add unused-dependency ([`b6d73cf`](https://github.com/jolars/arity/commit/b6d73cf7f7a6701791dc5f1584a88ad5b89cce05))
- **linter:** add undeclared-dependency ([`d35c7fc`](https://github.com/jolars/arity/commit/d35c7fc13efdffe407b534a0d0be3ea970e46e21))
- **linter:** add three DESCRIPTION rules ([`7ac50e4`](https://github.com/jolars/arity/commit/7ac50e4024343398c3f1d41da462029eccbd6592))
- **linter:** discover and lint DESCRIPTION files ([`18c9366`](https://github.com/jolars/arity/commit/18c9366cc7bb413bcd3fcc88c5d8c2065cbb74ce))
- **linter:** add a rule trait for the DCF grammar ([`f3779d5`](https://github.com/jolars/arity/commit/f3779d50de5052a0985bb9bd0e7dac8adbeb6565))
- **rindex:** treat declared dependencies as referenced ([`256d4c8`](https://github.com/jolars/arity/commit/256d4c8b7f2a831dd4ab958823b5fb75b301482a))
- **project:** defer the import(pkg) verdict to the library index ([`6f580bf`](https://github.com/jolars/arity/commit/6f580bf27e75c5314b8a250ab99618c3f95a189e))
- **project:** resolve against declared Depends ([`d999290`](https://github.com/jolars/arity/commit/d9992901c758845e83dd53671c3c36bdc40edf2e))
- **incremental:** make DESCRIPTION a salsa input ([`3340923`](https://github.com/jolars/arity/commit/33409232acd5d931f123efdf870564ad9c069bc1))
- **parser:** add a lossless DCF CST parser ([`42ca268`](https://github.com/jolars/arity/commit/42ca26849d41bff20c8e4189c2a73b9ad9a166a1))
- **lsp:** widen call hierarchy edge attribution ([`00a798d`](https://github.com/jolars/arity/commit/00a798dd4d7dcb62e1c3d67bb35cd8defab4501a))
- **formatter:** honor skip-file in a DESCRIPTION ([`f737e8b`](https://github.com/jolars/arity/commit/f737e8b03aec62b72e3a15f59f843ab38d42e07d))
- **formatter:** honor arity-format directives ([`922813c`](https://github.com/jolars/arity/commit/922813c86fccb2b1204c62b3c1b52ba6f786c268))
- **parser:** record a directive's prefix range ([`72d8536`](https://github.com/jolars/arity/commit/72d853656683116b4f5716c67dfc805ec76ebe3e))
- **parser:** add the shared arity directive grammar ([`39651b0`](https://github.com/jolars/arity/commit/39651b0789e6bd6de24fcc741d24077cb79e3902))
- **ast:** add `RoxygenTag::value_text` ([`5b35b6d`](https://github.com/jolars/arity/commit/5b35b6dd190c9a41cd4f0cd2dbbe2b28fe7ceb09))
- **parser:** re-export the dependency-field helpers from dcf ([`fbb8183`](https://github.com/jolars/arity/commit/fbb8183efa0bfd4140b3b82ad40049514d86b6dc))
- **dcf:** parse structured dependency entries ([`e5ee844`](https://github.com/jolars/arity/commit/e5ee8448186e949c14fd8839816846b2be9b935d))
- **vscode:** gate inlay hints on the feature toggle ([`dd6fde8`](https://github.com/jolars/arity/commit/dd6fde821a63fa24a48517cf95472f035264e520))
- **code:** claim DESCRIPTION for the language server ([`0fe3077`](https://github.com/jolars/arity/commit/0fe30773c0c30d8f16f61f333c0fca6b47acef8b))

### Bug Fixes
- **linter:** skip `coalesce` in the `%||%` definition ([`2114c88`](https://github.com/jolars/arity/commit/2114c88ede126119788f924aebd26f4632eca0c2))
- **semantic:** mark every def a closure read reaches ([`32e98e2`](https://github.com/jolars/arity/commit/32e98e2f1f3930105c470033e14310ce5f7ea65e))
- **semantic:** resolve names bound by `useDynLib` ([`c72462a`](https://github.com/jolars/arity/commit/c72462a6d28d3aa5f826c69e5d817e3ba3640e70))
- **semantic:** make defusing operators unquote-aware ([`dd2ce0a`](https://github.com/jolars/arity/commit/dd2ce0a96fad2aa3297b6aeeab2a171d2a16d564))
- **roxygen:** read projector topic names whole ([`f7b6d3e`](https://github.com/jolars/arity/commit/f7b6d3e4688ed706f4df0f2ac098150e42540cec))
- **lint:** resolve roxygen topics across the package ([`7e6e7ce`](https://github.com/jolars/arity/commit/7e6e7ce82071926a53ed6f4add86e28b6cdf582a))
- **lint:** exempt S3 methods from `unused-binding` ([`a107859`](https://github.com/jolars/arity/commit/a1078598efa1cd279bd31490d2c358ff757f3c40))
- **lint:** judge roxygen topics, not single blocks ([`3357e83`](https://github.com/jolars/arity/commit/3357e83a9da4b8baf4f3b92f8fb864f3ba88c36c))
- **cli:** give `lint --fix` the project scope ([`85d6d1e`](https://github.com/jolars/arity/commit/85d6d1e22abb00ace742ee538c2aabecc31f310e))
- **lint:** skip `roxygen-param` on `@noRd` blocks ([`0b842d9`](https://github.com/jolars/arity/commit/0b842d9d24df2ec6c5e1b40693261dfa20b57ecf))
- **semantic:** mask the `.External2` routine name ([`c090566`](https://github.com/jolars/arity/commit/c090566e9e114a5e324e5a3d458c67895a91007a))
- **semantic:** never bind the walrus operator ([`d1251b9`](https://github.com/jolars/arity/commit/d1251b9d440e792b325e5c43559de1297938ddd9))
- **semantic:** match backticked names to NAMESPACE ([`078d0e0`](https://github.com/jolars/arity/commit/078d0e040e67096303b1f4f4fd451730e1fe6985))
- **lint:** name the actual range in `seq` messages ([`5d4cbab`](https://github.com/jolars/arity/commit/5d4cbab256b1ac3e359e31bc8e1c551c189f891c))
- **lint:** skip roxygen topic rules on S3 methods ([`029af86`](https://github.com/jolars/arity/commit/029af86114891fa2b3f55fc8a41ba7c2e50bae38))
- **lsp:** refresh the graph when a DESCRIPTION disappears ([`f987130`](https://github.com/jolars/arity/commit/f98713095c2980c23c2ee8b56123d8671ab3343a))
- **linter:** skip a fixture package's DESCRIPTION when walking ([`0d70adb`](https://github.com/jolars/arity/commit/0d70adb29157f91b0a879f1b6bfa8580f9ef531a))
- **semantic:** resolve backtick-quoted names ([`cc3d1db`](https://github.com/jolars/arity/commit/cc3d1dbfa7a0bbf9d10bd4c61a476e2d48f57358))
- **rindex:** keep only the packages import() names ([`205957c`](https://github.com/jolars/arity/commit/205957ca2fd6ebfdf042007e6238748d6621bac9))
- **formatter:** give an Rd `\item` its own line ([`481b9ac`](https://github.com/jolars/arity/commit/481b9ac1ccfa72f2db0496b475bf94012d1fa465))
- **formatter:** flush a block Rd macro's opener line ([`bd27d5c`](https://github.com/jolars/arity/commit/bd27d5c35f327475facea9b8128e0a3ce418b23d))

### Performance Improvements
- **linter:** keep the standalone attach set lazy ([`a238d64`](https://github.com/jolars/arity/commit/a238d648de42c02357b51e3b42e06a06c9c0dec3))
- **lsp:** invalidate package metadata by path ([`629ac9c`](https://github.com/jolars/arity/commit/629ac9cd01dc3487a875dc25100bf24b7d433472))
- **formatter:** answer both prepasses in one green-tree walk ([`6f8a444`](https://github.com/jolars/arity/commit/6f8a4440d3efb68e65058044d5581de051412de6))

### Dependencies
- updated crates/arity-formatter to v0.4.0
- updated crates/arity-parser to v0.5.0

## [crates/arity-formatter: 0.4.0](https://github.com/jolars/arity/compare/arity-formatter-v0.3.1...arity-formatter-v0.4.0) (2026-08-14)

### Breaking changes
- **deps:** bump `rowan` to 0.17 ([`64ad43b`](https://github.com/jolars/arity/commit/64ad43be2125e8713e0656307d094a8e0a0601a4))

### Features
- **formatter:** honor skip-file in a DESCRIPTION ([`f737e8b`](https://github.com/jolars/arity/commit/f737e8b03aec62b72e3a15f59f843ab38d42e07d))
- **formatter:** honor arity-format directives ([`922813c`](https://github.com/jolars/arity/commit/922813c86fccb2b1204c62b3c1b52ba6f786c268))
- format package DESCRIPTION files (#104) ([`40583bf`](https://github.com/jolars/arity/commit/40583bf0caf22499453080456dfac9e12e8c239d))

### Bug Fixes
- **formatter:** give an Rd `\item` its own line ([`481b9ac`](https://github.com/jolars/arity/commit/481b9ac1ccfa72f2db0496b475bf94012d1fa465))
- **formatter:** flush a block Rd macro's opener line ([`bd27d5c`](https://github.com/jolars/arity/commit/bd27d5c35f327475facea9b8128e0a3ce418b23d))

### Performance Improvements
- **formatter:** answer both prepasses in one green-tree walk ([`6f8a444`](https://github.com/jolars/arity/commit/6f8a4440d3efb68e65058044d5581de051412de6))

### Dependencies
- updated crates/arity-parser to v0.5.0

## [crates/arity-parser: 0.5.0](https://github.com/jolars/arity/compare/arity-parser-v0.4.0...arity-parser-v0.5.0) (2026-08-14)

### Breaking changes
- **deps:** bump `rowan` to 0.17 ([`64ad43b`](https://github.com/jolars/arity/commit/64ad43be2125e8713e0656307d094a8e0a0601a4))

### Features
- **parser:** record a directive's prefix range ([`72d8536`](https://github.com/jolars/arity/commit/72d853656683116b4f5716c67dfc805ec76ebe3e))
- **parser:** add the shared arity directive grammar ([`39651b0`](https://github.com/jolars/arity/commit/39651b0789e6bd6de24fcc741d24077cb79e3902))
- **ast:** add `RoxygenTag::value_text` ([`5b35b6d`](https://github.com/jolars/arity/commit/5b35b6dd190c9a41cd4f0cd2dbbe2b28fe7ceb09))
- **parser:** re-export the dependency-field helpers from dcf ([`fbb8183`](https://github.com/jolars/arity/commit/fbb8183efa0bfd4140b3b82ad40049514d86b6dc))
- **linter:** add a rule trait for the DCF grammar ([`f3779d5`](https://github.com/jolars/arity/commit/f3779d50de5052a0985bb9bd0e7dac8adbeb6565))
- **dcf:** parse structured dependency entries ([`e5ee844`](https://github.com/jolars/arity/commit/e5ee8448186e949c14fd8839816846b2be9b935d))
- **parser:** add a lossless DCF CST parser ([`42ca268`](https://github.com/jolars/arity/commit/42ca26849d41bff20c8e4189c2a73b9ad9a166a1))

## [editors/code: 0.19.0](https://github.com/jolars/arity/compare/arity-code-v0.18.0...arity-code-v0.19.0) (2026-08-14)

### Features
- **vscode:** gate inlay hints on the feature toggle ([`dd6fde8`](https://github.com/jolars/arity/commit/dd6fde821a63fa24a48517cf95472f035264e520))
- format package DESCRIPTION files (#104) ([`40583bf`](https://github.com/jolars/arity/commit/40583bf0caf22499453080456dfac9e12e8c239d))
- **code:** claim DESCRIPTION for the language server ([`0fe3077`](https://github.com/jolars/arity/commit/0fe30773c0c30d8f16f61f333c0fca6b47acef8b))

### Dependencies
- updated arity to v0.19.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).