### PR TITLE
feat: read, analyze, and lint DESCRIPTION

### DIFF
--- a/.claude/rules/linter.md
+++ b/.claude/rules/linter.md
@@ -14,7 +14,14 @@ linter against a real R codebase: the `linter-investigation` skill.
 - **The linter is purely semantic.** Anything the formatter's `--check` mode can
   catch belongs to the formatter, not here.
 - Parse diagnostics **block** linting a file: `check_paths` reports
-  `LintStatus::{Clean, Findings, ParseDiagnostics}`.
+  `LintStatus::{Clean, Findings, ParseDiagnostics}`. That holds for
+  `DESCRIPTION` too; the whole policy is `lint_description_source`.
+- Lint inputs are `.R` files **and** a package's `DESCRIPTION`
+  (`collect_lint_files`). A walked `DESCRIPTION` must sit at a package root that
+  is not itself inside another package — the fake packages under a project's
+  `tests/` are fixture data, not its metadata. An explicitly named one is always
+  linted, and reading is never gated on the rule set (`syntax-error` is not a
+  rule).
 
 ## Dispatch
 
@@ -47,6 +54,9 @@ linter against a real R codebase: the `linter-investigation` skill.
   `[lint.rules.<id>]` key. Renaming one is a breaking change.
 - Every rule needs a description and `examples()`. The examples are run through
   the **real linter** to render the docs page, so they are behavior, not prose.
+  A rule whose subject is a *package-level* fact is silent on the single-file
+  path, so it declares the synthetic package its examples live in via
+  `doc_package` — otherwise the example renders with no finding.
 
 ## Autofix correctness
 
@@ -79,8 +89,11 @@ A fix is a **textual edit**, so the bar is **correctness, not formatting**.
 
 ## Testing and docs
 
-- Lint has no fixture directory: add a `#[test]` in `tests/lint.rs`, plus the
-  rule's own `examples()`. Write the failing test first.
+- Lint has no fixture directory: add a `#[test]` in `tests/lint.rs` — or in
+  `tests/lint_description.rs` for anything about `DESCRIPTION` — plus the rule's
+  own `examples()`. Write the failing test first.
+- A package fixture's `DESCRIPTION` should be *complete* (`TEST_DESCRIPTION` in
+  `tests/lint.rs`), so a test only ever reports what it is about.
 - `tests/lint.rs` checks that fixed output parses, and stays format-clean on the
   curated width-safe cases.
 - The rule reference (`docs/src/reference/rules.md`) is **generated** by

--- a/.claude/rules/linter.md
+++ b/.claude/rules/linter.md
@@ -25,6 +25,13 @@ linter against a real R codebase: the `linter-investigation` skill.
 - `src/linter/rules.rs` is the **single source of truth**: `rules_by_category`
   is what `all_rules`, `all_rule_ids`, and the reference page's category
   sections are all derived from. Register there, once.
+- **Two grammars, one catalogue.** A `DESCRIPTION` rule implements `DcfRule`
+  and is registered as `AnyRule::Dcf` in that same list, so rule IDs are one
+  namespace and everything derived from the registry sees both. `run_dcf_rules`
+  mirrors `run_rules`; `ResolvedRules` splits the two dispatch tables exactly
+  once, in `with_config`, leaving the R hot path untouched. Never add a second
+  registry — merging two per-category lists back together to render one section
+  *is* a second source of truth for catalogue order.
 - `run_rules` owns **suppression filtering** — it is the only place holding both
   the directive map and the findings — plus the post-suppression pass.
 - `Rule::check_suppressions` is the post-pass for facts that only exist after

--- a/.claude/rules/semantic.md
+++ b/.claude/rules/semantic.md
@@ -43,14 +43,29 @@ Two layers, deliberately separate: `src/semantic/` is **strictly single-file**,
   `exported_by_namespace` (public API), `is_s3_method` (reached by dispatch).
   `used_elsewhere` is the union of the first two, which is what
   `unused-binding` asks; `unused-function` asks for each separately.
-- `description.rs` derives the `[compat]` floors per file from the enclosing
-  `DESCRIPTION` (`Depends: R (>= …)`; `Config/roxygen2/version`, then
-  `RoxygenNote`) when config sets none.
+- `description.rs` derives **all** DESCRIPTION facts in one parse
+  (`DescriptionFacts`): package name, declared dependencies, the `[compat]`
+  floors, the `Roxygen` field, `Collate`. **`R` is never a dependency** — it
+  names the language, and an attach set containing it makes `package_indexed`
+  fail and silences every diagnostic in the package.
+- **Only `Depends` attaches.** `Imports` is reachable solely through `pkg::` or
+  a NAMESPACE `importFrom`/`import`; resolving its exports as bare names would
+  accept code that fails under `R CMD check`.
+- `ProjectScope::build` is **pure** and must stay so. It *records* a wholesale
+  `import(pkg)` rather than deciding it: "can we enumerate pkg's exports" needs
+  the `LibraryIndex`, so `external_resolution` decides. An index lookup put back
+  inside `build` would look like a simplification and would break the
+  project-graph memo. `FileScope::resolution_incomplete` now means only "a
+  dynamic or unanalyzed `source()`".
 
 ## Incrementality
 
 - `src/incremental.rs` models file text → CST → semantic model as salsa queries.
   The parser crate itself stays salsa-free; salsa lives only above it.
 - **Store green nodes in salsa, never red** (`SyntaxNode` is not `Send`/`Eq`).
+- `DESCRIPTION` is a tracked input holding **text** (`DescriptionFile`), with
+  `description_facts` the `Eq` projection over it. That is what makes a prose
+  edit backdate instead of rebuilding the project graph, so **the facts must
+  stay range-free**, exactly as for the per-file projections.
 - Salsa is **strictly single-writer**. Anything that writes must respect the
   LSP's lint-thread ownership (`.claude/rules/lsp.md`).

--- a/.claude/skills/add-lint-rule/SKILL.md
+++ b/.claude/skills/add-lint-rule/SKILL.md
@@ -49,11 +49,16 @@ the rule's correctness actually requires.
   **`rules_by_category()`, the single source of truth**. `all_rules()` flattens
   it, `all_rule_ids()` derives from that, and the generated rule reference takes
   its category sections from the same grouping—so there is no second list to
-  sync. Every new rule is added here exactly once.
+  sync. Every new rule is added here exactly once, wrapped in `AnyRule::R`.
+- **A `DESCRIPTION` rule** implements `DcfRule` instead (`interests`/`check`
+  over `dcf::SyntaxKind`, or `check_file`; `DcfRuleContext` carries the parsed
+  `Document`, the `DescriptionFacts` folded from it, and the enclosing package's
+  `PackageUsage`), registers as `AnyRule::Dcf` in that **same** list, and is
+  tested in `tests/lint_description.rs`. `run_dcf_rules` is the driver twin.
+  Never add a second registry.
 - `src/linter/rules/<category>.rs`—the category module
-  (`correctness`/`suspicious`/`readability`; add `performance`/`meta`/`pkg/...`
-  per the roadmap when first needed). Holds `mod <id>;` +
-  `pub use <id>::<Name>;`.
+  (`correctness`/`suspicious`/`readability`/`performance`/`documentation`/
+  `packaging`/`meta`). Holds `mod <id>;` + `pub use <id>::<Name>;`.
 - `src/linter/rules/<category>/<id>.rs`—one file per rule: a unit
   `pub struct` implementing `Rule`. (File name may differ from the rule id when
   the id is a Rust keyword, e.g. `repeat` lives in `suspicious/repeat_loop.rs`.)
@@ -85,7 +90,9 @@ the rule's correctness actually requires.
   in registry order, and asserts every rule has a non-empty
   `description()` + at least one `examples()` entry, **and that each example
   actually triggers its own rule**. Accept new snapshots with
-  `cargo insta   accept`.
+  `cargo insta   accept`. A rule whose subject is a package-level fact is silent
+  on the single-file path the renderer uses, so it declares the synthetic
+  package its examples live in via `doc_package`.
 - `docs/src/reference/rules.md`—**generated**; never hand-edit it, and never
   add a `SUMMARY.md` entry for a rule (the reference is one page).
 - `TODO.md`—the live roadmap. Check off the rule's item (with a one-line

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,10 @@ matching `.claude/rules/` file.
   `source()` graph, a package's implicit shared namespace, per-file export
   projection, the S4/R6/reference-class index, wired into salsa by `graph.rs`.
 - **Linter** (`src/linter/`) — **purely semantic**; anything `format --check`
-  catches belongs to the formatter. 48 rules across six categories, with
-  autofixes, `# arity-ignore` suppression, and a generated rule reference.
+  catches belongs to the formatter. 55 rules across seven categories, with
+  autofixes, `# arity-ignore` suppression, and a generated rule reference. Runs
+  over **two grammars**: `Rule` for `.R`, `DcfRule` for `DESCRIPTION`, one
+  registry and one namespace of rule IDs.
 - **Language server** (`src/lsp.rs` + `src/lsp/`) — stdio JSON-RPC on
   `lsp-server`, with a dedicated lint thread owning the salsa database and
   purpose-built read and index task pools.
@@ -146,7 +148,8 @@ matching `.claude/rules/` file.
 - **File discovery** (`src/file_discovery.rs`) — walks for `.R` files honoring
   the config's `ExcludeFilter`; a non-`.R` explicit path is rejected unless
   force-excluded, so a runner like pre-commit staging one is skipped, not an
-  error.
+  error. `collect_lint_files` adds the lint driver's second input, a package's
+  `DESCRIPTION`; `collect_r_files` stays the R-only view its other callers need.
 
 ## Invariants and conventions
 
@@ -190,7 +193,8 @@ fixture case or snapshot) before touching the fix. **Run
   `cargo insta review`. **Never accept a snapshot you have not read.**
 - Which suite to reach for: formatter bug → a formatter fixture; parser bug → a
   parser fixture + `cargo insta review`; lint rule → a `#[test]` in
-  `tests/lint.rs` (no fixture dir) plus the rule's own `examples()`;
+  `tests/lint.rs` (no fixture dir), or `tests/lint_description.rs` for a
+  `DESCRIPTION` rule, plus the rule's own `examples()`;
   cross-file/LSP work → `tests/lsp.rs`, `tests/lsp_protocol.rs`, and
   `tests/salsa_incremental.rs`, which guards that a body edit does *not*
   invalidate the project graph.

--- a/TODO.md
+++ b/TODO.md
@@ -454,20 +454,26 @@ completion and hover, and it formats. Staged so each step is useful alone.
       lifting the `import(pkg)` poison exposes findings in every package using
       it—which is how the item below was found.
 
-- [ ] **A backticked name never resolves against a package export list.**
-      `` e$a <- `:` `` and ``map_lgl(imp, `%in%`, x = topic)`` are flagged
+- [x] **A backticked name never resolves against a package export list.** Fixed.
+      `` e$a <- `:` `` and ``map_lgl(imp, `%in%`, x = topic)`` were flagged
       `undefined-symbol`. The backticks are part of the `IDENT` token, which is
       *correct* and load-bearing for user operators (`src/semantic/builder.rs`
       records a `` `%+%` `` binding backtick-quoted so references match), but
       the base and CRAN export lists store `:` and `%in%` unquoted, so the
-      lookup misses. The fix belongs in the provider lookup
-      (`origin`/`is_base`/`resolve_origin`, `src/semantic/symbols.rs` +
-      `src/rindex/provider.rs`), which should also try the backtick-stripped
-      name—**not** in the builder, which must keep quoting bindings.
+      lookup missed.
 
-      Predates stage 2 (reproduces on `2c5168c`); it was invisible in packages
+      `semantic::symbols::unbacktick` strips a *matched* backtick pair, and
+      every leaf provider lookup now applies it: `StaticBaseR`'s
+      `origin`/`is_base`/`package_of`, `BundledPackages::exports`,
+      `RemoteExports::exports`, and `IndexedProvider`'s `exports`/`lookup`. Put
+      at the leaves rather than in `resolve_origin` so all four resolution
+      tiers, `StaticBaseR` used as a bare provider, and hover's rich `lookup`
+      are covered by one rule. Nothing changed in the builder, which must keep
+      quoting bindings.
+
+      Predated stage 2 (reproduced on `2c5168c`); it was invisible in packages
       using `import(pkg)` only because the wholesale-import poison suppressed
-      the whole file. Repro: `f <- function() { e <- new.env(); e$a <- `:`; e }`.
+      the whole file.
 
 - [ ] **3. DESCRIPTION lint rules.** `undeclared-dependency` (`pkg::x` or
       `library(pkg)` in `R/` with `pkg` absent from `Depends`/`Imports`) and

--- a/TODO.md
+++ b/TODO.md
@@ -475,16 +475,72 @@ completion and hover, and it formats. Staged so each step is useful alone.
       using `import(pkg)` only because the wholesale-import poison suppressed
       the whole file.
 
-- [ ] **3. DESCRIPTION lint rules.** `undeclared-dependency` (`pkg::x` or
-      `library(pkg)` in `R/` with `pkg` absent from `Depends`/`Imports`) and
-      `unused-dependency` (an `Imports` entry no `::` or `importFrom()`
-      reaches—cross-file, so it needs the project layer and NAMESPACE, both of
-      which exist). Plus file-local rules: `duplicate-field` (also the place to
-      fix the first-vs-last divergence below, visibly), missing required fields,
-      unparseable version constraints. Needs a non-`.R` path through
-      `file_discovery.rs` (the extension filter is hard-coded `"r"`) and the
-      lint driver; `linter::render` and `to_lsp_diagnostic` are already
-      file-type-agnostic and need no change.
+- [x] **3. DESCRIPTION lint rules.** Done. Five rules in a new `Packaging`
+      category, the one category spanning both grammars:
+      `undeclared-dependency` (R-side, default on), `unused-dependency`
+      (DESCRIPTION-side, **default off**), `description-missing-field`,
+      `description-duplicate-field`, `description-version-constraint`. None
+      ships an autofix; each repair needs a value or a decision only the author
+      has, and for `unused-dependency` a fix would also mean editing a
+      comma-separated list, which is stage 5's job.
+
+      A `DcfRule` runs over a parsed `DESCRIPTION` the way `Rule` runs over R,
+      and both register in the **same** `rules_by_category` via `AnyRule`, so
+      rule IDs stay one namespace and `all_rule_ids`, `select`/`ignore`, and the
+      reference page are still derived from one list. A second registry was
+      rejected: merging two per-category lists back together to render one
+      section *is* a second source of truth for catalogue order. `ResolvedRules`
+      splits the two dispatch tables once, in `with_config`, so a run over R
+      files never pays for the DCF table. `linter::render` and
+      `to_lsp_diagnostic` needed no change, as predicted.
+
+      `# arity-ignore` works in `DESCRIPTION`. A comment line is a child of the
+      field it follows—a `FIELD` stays open across its continuation lines—so a
+      directive attaches to its enclosing field only when a value line still
+      follows it, and otherwise points at the next field, which is what its
+      author meant.
+
+      `collect_lint_files` splits discovery by grammar. A walk takes a
+      `DESCRIPTION` only at a package root that is not itself inside another
+      package: the first half skips `inst/extdata` fixtures, the second skips
+      the complete fake packages roxygen2 and devtools keep under `tests/`,
+      which a corpus sweep found immediately. An explicitly named one is always
+      linted. Reading is *not* gated on the rule set: `syntax-error` is not a
+      rule, so a `DESCRIPTION` `read.dcf` would reject surfaces under `--select`
+      exactly as a broken `.R` file does.
+
+      The exempt set for `undeclared-dependency` is R's own, read off
+      `tools:::.check_packages_used` and pinned against R by
+      `tests/deps_oracle.rs` (`task deps-oracle`): the base-priority packages
+      minus `methods` and `stats4`. That is deliberately **not**
+      `default_packages()`, which answers what a session *attaches* and differs
+      in both directions—`parallel` and `tools` ship unattached, `methods` is
+      attached and still has to be declared.
+
+      `unused-dependency` reports on *absence*, so it is the one rule here that
+      could talk a maintainer into deleting a dependency their package needs.
+      Hence default-off, `PackageUsage::complete` (the whole `R/` set analyzed,
+      a NAMESPACE read, at least one source), and exemptions for a `LinkingTo`
+      co-declaration, `methods` under S4, and any package named as a plain
+      string. `PackageReferences` records load calls at **any depth**—
+      `requireNamespace()` in a function body is the conditional-dependency
+      idiom, and `SemanticModel::loaded_packages` is top-level-only because it
+      models attachment, a narrower fact. Both it and the `package_usage` fold
+      are range-free `Eq` firewalls, guarded with negative controls in
+      `tests/salsa_incremental.rs`.
+
+      A sweep over 15 real packages (tidyverse, r-lib, data.table, Rcpp) found
+      zero findings; injecting an unused `Imports` entry and deleting a used one
+      proved both dependency rules fire. That sweep is the gate for ever
+      flipping `unused-dependency` on, and it is not enough on its own—the
+      `linter-investigation` skill is.
+
+      Two rules deliberately **not** written here. `library-in-package`:
+      `library(dplyr)` in `R/` is wrong even when `dplyr` *is* in `Imports`, and
+      reporting that under an ID meaning "not declared" would read as a false
+      positive. `unconditional-suggest`: flagging unguarded use of a `Suggests`
+      package is a control-flow question over `ctx.cfg`, not a name-set one, and
+      R exempts `Suggests` for exactly that reason.
 
 - [ ] **4. DESCRIPTION in the LSP.** `didOpen` for DESCRIPTION (today it is only
       a watched file, never a document), a `documentSelector` entry in
@@ -520,6 +576,8 @@ completion and hover, and it formats. Staged so each step is useful alone.
   - A field whose own line is empty folds with a leading `\n`
     (`Collate:\n a.R\n b.R` -> `"\na.R\nb.R"`); R drops the empty segment.
   - A duplicate field resolves to the **first** occurrence; R takes the last.
+    `description-duplicate-field` now makes this visible at the duplicate
+    instead of leaving it silent, which is the prerequisite for the flip.
   - A field name is trimmed. R does *not*: `Package : p` declares a field
     literally named `"Package "`, so R sees no `Package` at all. arity is
     deliberately lenient here (it reads the obvious intent of a typo'd header),

--- a/TODO.md
+++ b/TODO.md
@@ -237,9 +237,10 @@ ships—the existing low-priority note under "Navigation" stands, unelevated.)
   - [ ] Pin-aware versions: resolve the project's actual version from
         renv.lock/DESCRIPTION (needs CRAN Archive coverage); the URL/disk schema
         is already version-keyed for this.
-  - [ ] Feed DESCRIPTION `Imports`/`Depends` and `import(pkg)` into the referenced
+  - [x] Feed DESCRIPTION `Imports`/`Depends` and `import(pkg)` into the referenced
         and resolved sets so the `resolution_incomplete` poison
         (`src/project/scope.rs`) clears once the sidecar can enumerate exports.
+        Landed with DESCRIPTION stage 2 below, as one change.
 
 - [x] Data-masking/tidy-eval suppression (landed). A bare name in a
   data-masking verb's arguments (`mutate(b = a + 1)`) resolves to a data-frame
@@ -416,19 +417,57 @@ completion and hover, and it formats. Staged so each step is useful alone.
       `parse_dcf` and all five of its consumers with no behavior change. Lives
       in the published parser crate so a dprint plugin can reach it at stage 5.
 
-- [ ] **2. DESCRIPTION as an analysis input.** Parse structured dependency
-      entries (`Depends`, `Imports`, `Suggests`, `LinkingTo`, `Enhances`—name
-      plus optional version constraint, generalizing `r_depends_floor`) and make
-      DESCRIPTION a salsa input rather than an ad-hoc `read_to_string` at query
-      time. Five readers still re-read and re-parse the same file per package
-      (`harvest`, `package_name`, `description_compat`,
-      `roxygen_markdown_default`, `expected_r_sources`), memoized only in
-      `MarkdownDefaultResolver`; invalidation is the blunt
-      `package_meta_changed -> refresh the whole graph`
-      (`src/lsp/lint_thread.rs`). Then feed the declared packages into the
-      referenced and resolved sets—this **is** the Cross-cutting-prerequisite
-      item "Feed DESCRIPTION `Imports`/`Depends` and `import(pkg)` into the
-      referenced and resolved sets" above; do them as one change.
+- [x] **2. DESCRIPTION as an analysis input.** Done. `dcf::deps` parses
+      dependency entries (name plus version constraints, spanned), and
+      `DescriptionFacts` (`src/project/description.rs`) derives every fact in
+      one parse: `package_name`, `description_compat`, the `Roxygen` field, and
+      `expected_r_sources`'s `Collate` half are all projections of it, and
+      `r_depends_floor` became a lookup over the entries rather than a bespoke
+      string splitter. `harvest` is deliberately untouched—it reads *installed*
+      packages in a library directory, a different problem with no database and
+      no watcher.
+
+      DESCRIPTION is a salsa input holding **text** (`DescriptionFile`), with
+      `description_facts` the `Eq` projection over it. That split is the whole
+      point: a `Description:` prose edit re-derives the facts, they compare
+      equal, and salsa backdates—so `workspace_project` is never re-executed.
+      `discover_packages` no longer reads DESCRIPTION at all
+      (`PackageInfo.expected_sources` became `dir_sources`).
+
+      Declared packages feed both sets. `Depends` joins the resolved set via
+      `attached_names`; `Imports` deliberately does **not** (R does not attach
+      it). All five fields join the referenced set, so `arity index` and the
+      sidecar fetch cover a dependency no `.R` file mentions. `import(pkg)` no
+      longer poisons: `ProjectScope::build` stays pure and records the packages,
+      and `external_resolution`—which holds the library index—runs them through
+      the existing enumerability gate, so the suppression lifts by itself once
+      the package can be enumerated. `resolution_incomplete` now means only "a
+      dynamic or unanalyzed `source()`".
+
+      Invalidation is no longer blunt: `WatchedFilesBatch` carries each changed
+      path with its kind, the refreshers report whether they actually wrote, and
+      a save that changed nothing no longer relints.
+
+      Two consequences worth knowing, both the conservative-correct direction
+      and both pinned by tests: a `Depends` we cannot enumerate now suppresses
+      the whole file (exactly as an unindexed `library()` already did), and
+      lifting the `import(pkg)` poison exposes findings in every package using
+      it—which is how the item below was found.
+
+- [ ] **A backticked name never resolves against a package export list.**
+      `` e$a <- `:` `` and ``map_lgl(imp, `%in%`, x = topic)`` are flagged
+      `undefined-symbol`. The backticks are part of the `IDENT` token, which is
+      *correct* and load-bearing for user operators (`src/semantic/builder.rs`
+      records a `` `%+%` `` binding backtick-quoted so references match), but
+      the base and CRAN export lists store `:` and `%in%` unquoted, so the
+      lookup misses. The fix belongs in the provider lookup
+      (`origin`/`is_base`/`resolve_origin`, `src/semantic/symbols.rs` +
+      `src/rindex/provider.rs`), which should also try the backtick-stripped
+      name—**not** in the builder, which must keep quoting bindings.
+
+      Predates stage 2 (reproduces on `2c5168c`); it was invisible in packages
+      using `import(pkg)` only because the wholesale-import poison suppressed
+      the whole file. Repro: `f <- function() { e <- new.env(); e$a <- `:`; e }`.
 
 - [ ] **3. DESCRIPTION lint rules.** `undeclared-dependency` (`pkg::x` or
       `library(pkg)` in `R/` with `pkg` absent from `Depends`/`Imports`) and

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -98,6 +98,11 @@ tasks:
     cmds:
       - cargo test --test dcf_oracle -- --ignored --nocapture
 
+  deps-oracle:
+    desc: Check the dependency-exemption sets against `R CMD check`'s own (needs R)
+    cmds:
+      - cargo test --test deps_oracle -- --ignored --nocapture
+
   roxygen-oracle:
     desc: Measure roxygen2 Rd-preservation fixed point on the curated corpus (writes ROXYGEN_ORACLE.md; needs R + roxygen2)
     cmds:

--- a/crates/arity-parser/src/dcf.rs
+++ b/crates/arity-parser/src/dcf.rs
@@ -27,10 +27,12 @@
 //! sharing a name, disambiguated by module path — never glob-import both.
 
 pub mod ast;
+pub mod deps;
 pub mod parser;
 pub mod syntax;
 
 pub use ast::{CommentLine, Document, Field, MalformedLine, Record, ValueLine};
+pub use deps::{DependencyEntry, VersionConstraint, VersionOp, dependency_entries};
 pub use parser::{ParseOutput, parse, reconstruct};
 pub use syntax::{DcfLanguage, SyntaxKind, SyntaxNode, SyntaxToken};
 

--- a/crates/arity-parser/src/dcf.rs
+++ b/crates/arity-parser/src/dcf.rs
@@ -34,6 +34,6 @@ pub mod syntax;
 pub use ast::{CommentLine, Document, Field, MalformedLine, Record, ValueLine};
 pub use deps::{DependencyEntry, VersionConstraint, VersionOp, dependency_entries};
 pub use parser::{ParseOutput, parse, reconstruct};
-pub use syntax::{DcfLanguage, SyntaxKind, SyntaxNode, SyntaxToken};
+pub use syntax::{DcfLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
 
 pub use crate::parser::ParseDiagnostic;

--- a/crates/arity-parser/src/dcf/deps.rs
+++ b/crates/arity-parser/src/dcf/deps.rs
@@ -1,0 +1,495 @@
+//! The dependency-field grammar: `name (>= version), name, ...`.
+//!
+//! `Depends`, `Imports`, `Suggests`, `LinkingTo`, and `Enhances` all carry a
+//! comma-separated list of package names, each optionally followed by a
+//! parenthesized version constraint. That shape is *grammar*, so it lives here
+//! next to the DCF parser rather than in a consumer.
+//!
+//! What is deliberately **not** here is R semantics: that `R` names the
+//! language and not a package, that `Depends` attaches to the search path while
+//! `Imports` does not, and how two version strings order. Those are the
+//! consumer's, and the version is handed back as text for exactly that reason.
+//!
+//! Every range is a **source** range, into the same buffer the field was parsed
+//! from — so a diagnostic or a hover can point at one entry without a second
+//! mapping layer. Entries are reported across continuation lines: the field's
+//! logical value is what R splits, and a list wrapped one-per-line is the
+//! canonical style.
+//!
+//! Parsing never fails. An entry whose parenthesized part does not yield a
+//! constraint keeps its name and reports [`DependencyEntry::malformed_constraint`],
+//! because a broken constraint must never hide a package name from resolution.
+
+use rowan::{TextRange, TextSize};
+use smol_str::SmolStr;
+
+use crate::dcf::ast::Field;
+
+/// The DCF fields that carry a dependency list, in R's canonical order.
+pub const DEPENDENCY_FIELDS: [&str; 5] =
+    ["Depends", "Imports", "Suggests", "LinkingTo", "Enhances"];
+
+/// Whether `name` is one of [`DEPENDENCY_FIELDS`].
+pub fn is_dependency_field(name: &str) -> bool {
+    DEPENDENCY_FIELDS.contains(&name)
+}
+
+/// The comparison operator of a version constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VersionOp {
+    /// `>=`
+    Ge,
+    /// `>`
+    Gt,
+    /// `<=`
+    Le,
+    /// `<`
+    Lt,
+    /// `==`
+    Eq,
+    /// `!=`
+    Ne,
+}
+
+impl VersionOp {
+    /// The operator this text starts with, and its length in bytes. Two-byte
+    /// operators are tried first, so `>=` never lexes as `>` followed by `=`.
+    fn lex(text: &str) -> Option<(VersionOp, usize)> {
+        const TWO: [(&str, VersionOp); 4] = [
+            (">=", VersionOp::Ge),
+            ("<=", VersionOp::Le),
+            ("==", VersionOp::Eq),
+            ("!=", VersionOp::Ne),
+        ];
+        const ONE: [(&str, VersionOp); 2] = [(">", VersionOp::Gt), ("<", VersionOp::Lt)];
+        TWO.iter()
+            .find(|(s, _)| text.starts_with(s))
+            .map(|(s, op)| (*op, s.len()))
+            .or_else(|| {
+                ONE.iter()
+                    .find(|(s, _)| text.starts_with(s))
+                    .map(|(s, op)| (*op, s.len()))
+            })
+    }
+
+    /// Whether this operator states a *lower* bound — the only kind a version
+    /// floor can be read from.
+    pub fn is_lower_bound(self) -> bool {
+        matches!(self, VersionOp::Ge | VersionOp::Gt)
+    }
+}
+
+/// One version constraint: an operator and the version it compares against.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VersionConstraint {
+    pub op: VersionOp,
+    /// The version exactly as written, trimmed (`4.1.0`, `1.2-3`). Text, not a
+    /// parsed version: how two versions order is the consumer's policy.
+    pub version: SmolStr,
+    /// The whole constraint's source range, operator included.
+    pub range: TextRange,
+}
+
+/// One entry of a dependency field.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DependencyEntry {
+    /// The entry's name as written: a package name, or the literal `R`.
+    pub name: SmolStr,
+    pub name_range: TextRange,
+    /// The text between the parentheses, verbatim, and its range — `None` when
+    /// the entry carries no parenthesized part at all.
+    pub constraint_text: Option<(SmolStr, TextRange)>,
+    /// The constraints parsed out of `constraint_text`, in source order. R
+    /// writes one, but a comma-separated pair (`(>= 1.0, < 2.0)`) is the reason
+    /// entry splitting has to be paren-aware, so both are supported.
+    pub constraints: Vec<VersionConstraint>,
+    /// The whole entry's source range.
+    pub range: TextRange,
+}
+
+impl DependencyEntry {
+    /// The entry declares a parenthesized part that yielded no constraint —
+    /// exactly the "unparseable version constraint" case, kept as a fact here
+    /// and reported as a diagnostic by the consumer.
+    pub fn malformed_constraint(&self) -> bool {
+        self.constraint_text.is_some() && self.constraints.is_empty()
+    }
+
+    /// The first constraint stating a lower bound, which is what a version
+    /// floor asks for.
+    pub fn lower_bound(&self) -> Option<&VersionConstraint> {
+        self.constraints.iter().find(|c| c.op.is_lower_bound())
+    }
+}
+
+/// Split a dependency field into its entries, in source order.
+///
+/// Empty entries (a trailing or doubled comma) are dropped — R tolerates them
+/// and they name no package.
+pub fn dependency_entries(field: &Field) -> Vec<DependencyEntry> {
+    let folded = Folded::new(field);
+    split_top_level(&folded.text, 0)
+        .into_iter()
+        .filter_map(|span| entry(&folded, span))
+        .collect()
+}
+
+/// One entry from its span in the folded text.
+fn entry(folded: &Folded, span: Span) -> Option<DependencyEntry> {
+    let text = &folded.text[span.start..span.end];
+    // The parenthesized part starts at the first `(`; everything before it is
+    // the name. An unclosed `(` still yields a name, which is the point.
+    let (name_span, paren) = match text.find('(') {
+        Some(open) => {
+            let close = text.rfind(')').filter(|c| *c > open).unwrap_or(text.len());
+            (
+                Span::new(span.start, span.start + open),
+                Some(Span::new(span.start + open + 1, span.start + close)),
+            )
+        }
+        None => (span, None),
+    };
+
+    let name_span = trim(&folded.text, name_span);
+    if name_span.is_empty() {
+        return None;
+    }
+
+    let constraint_text = paren.map(|p| {
+        let inner = trim(&folded.text, p);
+        (
+            SmolStr::new(&folded.text[inner.start..inner.end]),
+            folded.source_range(inner),
+        )
+    });
+    let constraints = paren.map(|p| constraints_in(folded, p)).unwrap_or_default();
+
+    Some(DependencyEntry {
+        name: SmolStr::new(&folded.text[name_span.start..name_span.end]),
+        name_range: folded.source_range(name_span),
+        constraint_text,
+        constraints,
+        range: folded.source_range(trim(&folded.text, span)),
+    })
+}
+
+/// The constraints inside a parenthesized span.
+fn constraints_in(folded: &Folded, paren: Span) -> Vec<VersionConstraint> {
+    split_top_level(&folded.text[paren.start..paren.end], paren.start)
+        .into_iter()
+        .filter_map(|span| constraint(folded, span))
+        .collect()
+}
+
+/// One `op version` constraint from its span in the folded text.
+fn constraint(folded: &Folded, span: Span) -> Option<VersionConstraint> {
+    let span = trim(&folded.text, span);
+    let (op, len) = VersionOp::lex(&folded.text[span.start..span.end])?;
+    let version = trim(&folded.text, Span::new(span.start + len, span.end));
+    if version.is_empty() {
+        return None;
+    }
+    Some(VersionConstraint {
+        op,
+        version: SmolStr::new(&folded.text[version.start..version.end]),
+        range: folded.source_range(span),
+    })
+}
+
+/// A half-open byte span of the folded text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Span {
+    start: usize,
+    end: usize,
+}
+
+impl Span {
+    fn new(start: usize, end: usize) -> Self {
+        Span { start, end }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.start >= self.end
+    }
+}
+
+/// `span` with leading and trailing ASCII whitespace removed.
+fn trim(text: &str, span: Span) -> Span {
+    let slice = &text[span.start..span.end];
+    let lead = slice.len() - slice.trim_start().len();
+    let trail = slice.len() - slice.trim_end().len();
+    if lead + trail >= slice.len() {
+        return Span::new(span.start, span.start);
+    }
+    Span::new(span.start + lead, span.end - trail)
+}
+
+/// Split `text` on commas that are not inside parentheses, returning spans
+/// offset by `base`. Paren-awareness is not optional: `pkg (>= 1.0, < 2.0)` is
+/// one entry, and splitting it naively would invent a package named `< 2.0`.
+fn split_top_level(text: &str, base: usize) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (i, ch) in text.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                spans.push(Span::new(base + start, base + i));
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    spans.push(Span::new(base + start, base + text.len()));
+    spans
+}
+
+/// A field's folded value next to a map from folded offsets back to source
+/// offsets.
+///
+/// The fold is exactly [`Field::folded_value`]'s — each value line's content
+/// run, joined by `\n` — which is what makes the map trivial: a `VALUE_TEXT`
+/// token is already the trimmed run, so each segment is a verbatim slice of the
+/// source and offsets inside it shift by a constant.
+struct Folded {
+    text: String,
+    /// `(folded start, source start, byte length)` per contributing line.
+    segments: Vec<(usize, TextSize, usize)>,
+}
+
+impl Folded {
+    fn new(field: &Field) -> Self {
+        let mut text = String::new();
+        let mut segments = Vec::new();
+        let mut first = true;
+        for line in field.value_lines() {
+            if !first {
+                text.push('\n');
+            }
+            first = false;
+            if let Some(tok) = line.content() {
+                let content = tok.text();
+                segments.push((text.len(), tok.text_range().start(), content.len()));
+                text.push_str(content);
+            }
+        }
+        Folded { text, segments }
+    }
+
+    /// The source range of a folded span. A span crossing a fold join covers
+    /// the newline and indent in the source too, which is what a reader of the
+    /// diagnostic expects to see underlined.
+    fn source_range(&self, span: Span) -> TextRange {
+        let start = self.source_offset(span.start, false);
+        let end = self.source_offset(span.end, true);
+        TextRange::new(start, end.max(start))
+    }
+
+    /// The source offset of a folded offset. `at_end` breaks the tie when the
+    /// offset sits exactly on a segment boundary: a span's end belongs to the
+    /// segment it closes, its start to the segment it opens.
+    fn source_offset(&self, folded: usize, at_end: bool) -> TextSize {
+        let mut last = TextSize::from(0);
+        for &(fstart, sstart, len) in &self.segments {
+            if folded < fstart {
+                // Between two segments (inside the join) — clamp to whichever
+                // side the caller is anchored on.
+                return if at_end { last } else { sstart };
+            }
+            if folded < fstart + len || (folded == fstart + len && (at_end || len == 0)) {
+                return sstart + TextSize::from((folded - fstart) as u32);
+            }
+            last = sstart + TextSize::from(len as u32);
+        }
+        last
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dcf;
+
+    /// The single field of a one-field document.
+    fn field(text: &str) -> (String, dcf::Field) {
+        let output = dcf::parse(text);
+        let field = output
+            .document()
+            .fields()
+            .next()
+            .expect("the fixture declares one field");
+        (text.to_string(), field)
+    }
+
+    fn entries(text: &str) -> Vec<DependencyEntry> {
+        let (_, f) = field(text);
+        dependency_entries(&f)
+    }
+
+    fn names(text: &str) -> Vec<String> {
+        entries(text).iter().map(|e| e.name.to_string()).collect()
+    }
+
+    /// Every entry's name and whole-entry text, sliced out of the *source* by
+    /// the reported ranges. This is what proves the spans, not the values.
+    fn sliced(text: &str) -> Vec<(String, String)> {
+        entries(text)
+            .iter()
+            .map(|e| (text[e.name_range].to_string(), text[e.range].to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn bare_names_split_on_commas() {
+        assert_eq!(
+            names("Imports: dplyr, rlang, vctrs\n"),
+            ["dplyr", "rlang", "vctrs"]
+        );
+    }
+
+    #[test]
+    fn empty_entries_are_dropped() {
+        // A trailing comma and a doubled comma name no package.
+        assert_eq!(names("Imports: dplyr, , rlang,\n"), ["dplyr", "rlang"]);
+        assert!(names("Imports:\n").is_empty());
+        assert!(names("Imports:   \n").is_empty());
+    }
+
+    #[test]
+    fn r_entry_carries_its_floor() {
+        let entries = entries("Depends: R (>= 4.1.0)\n");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "R");
+        let bound = entries[0].lower_bound().expect("a lower bound");
+        assert_eq!(bound.op, VersionOp::Ge);
+        assert_eq!(bound.version, "4.1.0");
+    }
+
+    #[test]
+    fn every_operator_lexes() {
+        let cases = [
+            (">= 1", VersionOp::Ge),
+            ("> 1", VersionOp::Gt),
+            ("<= 1", VersionOp::Le),
+            ("< 1", VersionOp::Lt),
+            ("== 1", VersionOp::Eq),
+            ("!= 1", VersionOp::Ne),
+        ];
+        for (constraint, op) in cases {
+            let text = format!("Imports: pkg ({constraint})\n");
+            let entries = entries(&text);
+            assert_eq!(entries[0].constraints.len(), 1, "{constraint}");
+            assert_eq!(entries[0].constraints[0].op, op, "{constraint}");
+            assert_eq!(entries[0].constraints[0].version, "1", "{constraint}");
+        }
+    }
+
+    #[test]
+    fn whitespace_around_the_operator_is_optional() {
+        let entries = entries("Depends: R(>=3.5.0)\n");
+        assert_eq!(entries[0].name, "R");
+        assert_eq!(entries[0].lower_bound().expect("a bound").version, "3.5.0");
+    }
+
+    #[test]
+    fn a_comma_inside_parentheses_does_not_split_the_entry() {
+        // The reason splitting is paren-aware: naive splitting would invent a
+        // package named `< 2.0`.
+        let entries = entries("Imports: pkg (>= 1.0, < 2.0), other\n");
+        assert_eq!(
+            entries.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            ["pkg", "other"]
+        );
+        assert_eq!(entries[0].constraints.len(), 2);
+        assert_eq!(entries[0].constraints[1].op, VersionOp::Lt);
+        assert_eq!(entries[0].constraints[1].version, "2.0");
+    }
+
+    #[test]
+    fn an_unparseable_constraint_keeps_the_name() {
+        for text in [
+            "Imports: pkg (garbage)\n",
+            "Imports: pkg (>=)\n",
+            "Imports: pkg ()\n",
+        ] {
+            let entries = entries(text);
+            assert_eq!(entries.len(), 1, "{text}");
+            assert_eq!(entries[0].name, "pkg", "{text}");
+            assert!(entries[0].constraints.is_empty(), "{text}");
+            assert!(entries[0].malformed_constraint(), "{text}");
+        }
+        // No parenthesized part at all is not malformed — it is the common case.
+        assert!(!entries("Imports: pkg\n")[0].malformed_constraint());
+    }
+
+    #[test]
+    fn entries_span_continuation_lines() {
+        // The canonical one-per-line style, and an entry split across the fold.
+        let text = "Imports:\n    dplyr (>= 1.0.0),\n    rlang,\n    vctrs\n";
+        assert_eq!(names(text), ["dplyr", "rlang", "vctrs"]);
+
+        let text = "Depends:\n    R (>=\n    4.1.0)\n";
+        let entries = entries(text);
+        assert_eq!(entries[0].name, "R");
+        assert_eq!(entries[0].lower_bound().expect("a bound").version, "4.1.0");
+    }
+
+    #[test]
+    fn ranges_point_at_the_source_bytes() {
+        assert_eq!(
+            sliced("Imports: dplyr (>= 1.0), rlang\n"),
+            [
+                ("dplyr".to_string(), "dplyr (>= 1.0)".to_string()),
+                ("rlang".to_string(), "rlang".to_string()),
+            ]
+        );
+        // Across a continuation line the whole-entry range covers the newline
+        // and indent, and the name range stays tight.
+        assert_eq!(
+            sliced("Imports:\n    dplyr,\n    rlang\n"),
+            [
+                ("dplyr".to_string(), "dplyr".to_string()),
+                ("rlang".to_string(), "rlang".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn constraint_ranges_point_at_the_source_bytes() {
+        let text = "Depends: R (>= 4.1.0), stats\n";
+        let entries = entries(text);
+        let (raw, range) = entries[0]
+            .constraint_text
+            .clone()
+            .expect("a parenthesized part");
+        assert_eq!(raw, ">= 4.1.0");
+        assert_eq!(&text[range], ">= 4.1.0");
+        assert_eq!(&text[entries[0].constraints[0].range], ">= 4.1.0");
+        // The second entry has none.
+        assert!(entries[1].constraint_text.is_none());
+    }
+
+    #[test]
+    fn the_fold_matches_the_ast_wrapper() {
+        // `Folded` must reproduce `Field::folded_value` byte for byte, or every
+        // range it hands out is off. Includes the leading-`\n` divergence case.
+        for text in [
+            "Imports: a, b\n",
+            "Imports:\n    a,\n    b\n",
+            "Imports: a\n    b\n",
+            "Imports:\n",
+        ] {
+            let (_, f) = field(text);
+            assert_eq!(Folded::new(&f).text, f.folded_value(), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn dependency_fields_are_recognized_by_name() {
+        assert!(DEPENDENCY_FIELDS.iter().all(|f| is_dependency_field(f)));
+        assert!(!is_dependency_field("Collate"));
+        assert!(!is_dependency_field("depends"));
+    }
+}

--- a/docs/src/reference/rules.md
+++ b/docs/src/reference/rules.md
@@ -1554,7 +1554,9 @@ An `Imports` entry promises that installing this package installs that one, so a
 
 A package counts as reached by `pkg::`, `pkg:::`, a `library`, `require`, `requireNamespace`, or `loadNamespace` call at any depth, a NAMESPACE `import()`/`importFrom()`/`importClassesFrom()`/`importMethodsFrom()`, or a roxygen `@import`/`@importFrom` tag. Exempt on top of that: anything also in `LinkingTo` (the Rcpp skeleton), `methods` when the package defines an S4 or reference class, and any package whose name appears as a plain string (a dynamic `do.call("::", …)` or `system.file(package = …)`).
 
-Only `Imports` is checked. `Depends` is an API decision the package's own code may never name; `Suggests` is for tests, vignettes, and examples, which this analysis does not cover; `LinkingTo` and `Enhances` are invisible to R-source analysis. A package used *only* from `tests/` or a vignette **is** flagged—it belongs in `Suggests`.
+Only `Imports` is checked. `Depends` is an API decision the package's own code may never name; `Suggests` is for tests, vignettes, and examples, reached from outside the package's own code; `LinkingTo` and `Enhances` are invisible to R-source analysis.
+
+Usage is folded over every R file the run analyzed under the package root, so a package reached only from `tests/`, `inst/`, or `data-raw/` counts as used when those files are in the run (`arity lint .`) and is reported when they are not (`arity lint R/`). A vignette's R code is never analyzed either way, so a dependency used only there is reported—it belongs in `Suggests`.
 
 It reports on *absence*, and a wrong finding would have a maintainer delete a dependency their package needs, so it stays silent unless the run analyzed the package's whole `R/` source set and read its NAMESPACE—which is also why it is off by default.
 

--- a/docs/src/reference/rules.md
+++ b/docs/src/reference/rules.md
@@ -85,6 +85,7 @@ so this page never drifts from the rules' actual behavior.
 - [`description-missing-field`](#description-missing-field)
 - [`description-duplicate-field`](#description-duplicate-field)
 - [`description-version-constraint`](#description-version-constraint)
+- [`unused-dependency`](#unused-dependency)
 
 **Meta**
 
@@ -1543,6 +1544,39 @@ warning: description-version-constraint
 3 | Imports: dplyr (1.0.0)
   |          ^^^^^^^^^^^^^ the version constraint on `dplyr` states no bound, so R enforces nothing here
   = help: Write a comparison operator and a version, as in `(>= 1.0.0)`.
+```
+
+### `unused-dependency`
+
+Flag an `Imports:` entry that nothing in the package reaches.
+
+An `Imports` entry promises that installing this package installs that one, so an entry no code reaches costs every user a download, a build, and a constraint to satisfy for nothing. `R CMD check` reports it too.
+
+A package counts as reached by `pkg::`, `pkg:::`, a `library`, `require`, `requireNamespace`, or `loadNamespace` call at any depth, a NAMESPACE `import()`/`importFrom()`/`importClassesFrom()`/`importMethodsFrom()`, or a roxygen `@import`/`@importFrom` tag. Exempt on top of that: anything also in `LinkingTo` (the Rcpp skeleton), `methods` when the package defines an S4 or reference class, and any package whose name appears as a plain string (a dynamic `do.call("::", …)` or `system.file(package = …)`).
+
+Only `Imports` is checked. `Depends` is an API decision the package's own code may never name; `Suggests` is for tests, vignettes, and examples, which this analysis does not cover; `LinkingTo` and `Enhances` are invisible to R-source analysis. A package used *only* from `tests/` or a vignette **is** flagged—it belongs in `Suggests`.
+
+It reports on *absence*, and a wrong finding would have a maintainer delete a dependency their package needs, so it stays silent unless the run analyzed the package's whole `R/` source set and read its NAMESPACE—which is also why it is off by default.
+
+There is no autofix: removing an entry from a comma-separated list is not a local edit, and this is not a claim a tool should act on destructively.
+
+This rule is **disabled by default**; enable it with `select`.
+
+In a package whose only R source is `f <- function() rlang::abort("no")`:
+
+```text
+Package: mypkg
+Version: 0.1.0
+Imports: rlang, tibble
+```
+
+```text
+warning: unused-dependency
+ --> DESCRIPTION:3:17
+  |
+3 | Imports: rlang, tibble
+  |                 ^^^^^^ `tibble` is declared in `Imports:` but nothing in the package uses it
+  = help: Remove `tibble` from `Imports:`, or move it to `Suggests:` if only tests, vignettes, or examples need it.
 ```
 
 ## Meta

--- a/docs/src/reference/rules.md
+++ b/docs/src/reference/rules.md
@@ -81,6 +81,7 @@ so this page never drifts from the rules' actual behavior.
 
 **Packaging**
 
+- [`undeclared-dependency`](#undeclared-dependency)
 - [`description-missing-field`](#description-missing-field)
 - [`description-duplicate-field`](#description-duplicate-field)
 - [`description-version-constraint`](#description-version-constraint)
@@ -1417,6 +1418,37 @@ warning: roxygen2-compat
 ```
 
 ## Packaging
+
+### `undeclared-dependency`
+
+Flag package code that reaches a package its `DESCRIPTION` never declares.
+
+`dplyr::filter()` in `R/` works on the author's machine because `dplyr` happens to be installed there; on a clean machine it is a load-time error, and `R CMD check` reports it. Declaring the dependency is what causes it to be installed, so leaving it out is a bug that only ever surfaces somewhere else.
+
+The rule matches `pkg::name`, `pkg:::name`, and the package argument of `library`, `require`, `requireNamespace`, and `loadNamespace`—at any depth, since the conditional-dependency idiom lives inside a function body.
+
+The exempt set is R's own: everything declared in any of `Depends`, `Imports`, `Suggests`, `LinkingTo`, or `Enhances`, the package's own name, and the packages R ships at base priority—except `methods` and `stats4`, which `R CMD check` still expects a package to declare. Only files directly in `R/` are checked: a test's or a vignette's dependencies belong in `Suggests`, and R does not scan those directories for this check either.
+
+There is no autofix. A fix is an edit to the file the finding is in, and the repair here is a line in `DESCRIPTION`.
+
+This rule is **enabled by default**.
+
+In `R/` of a package whose `DESCRIPTION` declares only `Imports: rlang`:
+
+```r
+summarize <- function(data) {
+  dplyr::group_by(data, id)
+}
+```
+
+```text
+warning: undeclared-dependency
+ --> example.R:2:3
+  |
+2 |   dplyr::group_by(data, id)
+  |   ^^^^^ package `dplyr` is used here but is not declared in DESCRIPTION
+  = help: Add `dplyr` to `Imports:` in DESCRIPTION.
+```
 
 ### `description-missing-field`
 

--- a/docs/src/reference/rules.md
+++ b/docs/src/reference/rules.md
@@ -79,6 +79,12 @@ so this page never drifts from the rules' actual behavior.
 - [`roxygen-examples`](#roxygen-examples)
 - [`roxygen2-compat`](#roxygen2-compat)
 
+**Packaging**
+
+- [`description-missing-field`](#description-missing-field)
+- [`description-duplicate-field`](#description-duplicate-field)
+- [`description-version-constraint`](#description-version-constraint)
+
 **Meta**
 
 - [`misnamed-suppression`](#misnamed-suppression)
@@ -1408,6 +1414,103 @@ warning: roxygen2-compat
 2 | #' @inheritParams other -verbose
   |                         ^^^^^^^^ `@inheritParams` argument filters require roxygen2 >= 8.0.0; older versions silently misread them as argument names (this project targets 7.3.2)
   = help: Drop the filters or raise `[compat] roxygen2`.
+```
+
+## Packaging
+
+### `description-missing-field`
+
+Flag a `DESCRIPTION` missing a field R requires.
+
+`R CMD build` refuses a package whose `DESCRIPTION` omits `Package`, `Version`, `Title`, `Description`, `Author`, `Maintainer`, or `License`. `Authors@R` satisfies `Author` and `Maintainer`, since `R CMD build` derives both from it. A field that is present but empty declares nothing and counts as missing.
+
+Every missing field is reported as one finding rather than one each: the defect is that the file is incomplete, and it takes one decision—and one suppression—to settle.
+
+A file with no fields at all is left alone; that is not an incomplete package description.
+
+There is no autofix: each of these fields needs a value only the author has.
+
+This rule is **enabled by default**.
+
+A `DESCRIPTION` that `R CMD build` would reject:
+
+```text
+Package: mypkg
+Version: 0.1.0
+```
+
+```text
+warning: description-missing-field
+ --> DESCRIPTION:1:1
+  |
+1 | Package: mypkg
+  | ^^^^^^^ DESCRIPTION is missing the required fields `Title`, `Description`, `Author`, `Maintainer`, `License`
+  = help: Add the fields `Title`, `Description`, `Author`, `Maintainer`, `License`, or declare `Authors@R` in place of `Author` and `Maintainer`.
+```
+
+### `description-duplicate-field`
+
+Flag a `DESCRIPTION` field declared more than once.
+
+A repeated field is a silent mistake: nothing errors, and the file keeps whichever value the reader picks—except the readers disagree. R's `read.dcf` takes the **last** occurrence; arity takes the **first**. A duplicated `Version` therefore means R and arity are describing two different packages, and every tool downstream of either inherits the split.
+
+The finding is reported on the *later* occurrence, since the earlier one is what arity already read. Duplicates are detected across DCF records, so a stray blank line does not hide one.
+
+There is no autofix: removing a duplicate means choosing a value, and this rule exists precisely because it is not settled which value is already in effect.
+
+This rule is **enabled by default**.
+
+A field declared twice, which arity and `read.dcf` read differently:
+
+```text
+Package: mypkg
+Version: 0.1.0
+License: MIT + file LICENSE
+Version: 0.2.0
+```
+
+```text
+warning: description-duplicate-field
+ --> DESCRIPTION:4:1
+  |
+4 | Version: 0.2.0
+  | ^^^^^^^ `Version` is already declared on line 2; arity reads the first occurrence and R's `read.dcf` reads the last, so the two disagree about this file
+  = help: Keep one `Version` field and delete the other.
+```
+
+### `description-version-constraint`
+
+Flag a dependency entry whose parenthesized part is not a version constraint.
+
+R reads `pkg (>= 1.0.0)`: an operator and a version. Anything else—`dplyr (1.0.0)`, `dplyr (>=)`, `dplyr (latest)`—states no bound at all, and R's dependency check enforces nothing. The line reads as a requirement and behaves as none, so the package installs against exactly the versions its author meant to exclude.
+
+Checked in all five dependency fields, `R` included: `Depends: R (>= 4.1)` is the most common constraint in any `DESCRIPTION`.
+
+There is no autofix. `dplyr (1.0.0)` most likely means `>=`, but it could mean `==` or `>`, and guessing would invent a requirement the author never wrote.
+
+This rule is **enabled by default**.
+
+A version requirement R will not enforce:
+
+```text
+Package: mypkg
+Depends: R (4.1)
+Imports: dplyr (1.0.0)
+```
+
+```text
+warning: description-version-constraint
+ --> DESCRIPTION:2:10
+  |
+2 | Depends: R (4.1)
+  |          ^^^^^^^ the version constraint on `R` states no bound, so R enforces nothing here
+  = help: Write a comparison operator and a version, as in `(>= 1.0.0)`.
+warning: description-version-constraint
+ --> DESCRIPTION:3:10
+  |
+3 | Imports: dplyr (1.0.0)
+  |          ^^^^^^^^^^^^^ the version constraint on `dplyr` states no bound, so R enforces nothing here
+  = help: Write a comparison operator and a version, as in `(>= 1.0.0)`.
 ```
 
 ## Meta

--- a/docs/src/reference/suppression.md
+++ b/docs/src/reference/suppression.md
@@ -39,6 +39,25 @@ Suppresses **every** rule in the file, including every rule arity ships in the
 future. It is rarely what you want; prefer the rule-scoped form above. The
 [`blanket-suppression`](rules.md#blanket-suppression) rule flags it.
 
+## In `DESCRIPTION`
+
+The same three forms work in a `DESCRIPTION`, on a line of their own:
+
+```text
+Package: mypkg
+# arity-ignore unused-dependency: loaded reflectively by the plugin registry
+Imports: somepkg
+```
+
+DCF has no trailing comments --- a `#` in the middle of a value is part of that
+value --- so a directive must start at column zero, and one written after a
+field applies to the field that *follows* it. A `#` line between the
+continuation lines of a single field is the exception: R's `read.dcf` skips it
+and resumes the value, so a directive there covers the whole field it
+interrupts.
+
+The `meta` rules below lint directives in `.R` files only.
+
 ## Reasons
 
 The text after the `:` is free-form and arity never interprets it --- but a

--- a/docs/src/version.md
+++ b/docs/src/version.md
@@ -1,1 +1,1 @@
-arity v0.16.0
+arity v0.18.0

--- a/src/file_discovery.rs
+++ b/src/file_discovery.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use ignore::WalkBuilder;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
+use crate::project::is_package_root;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileDiscoveryError {
     NonRFilePath { path: PathBuf },
@@ -128,11 +130,48 @@ impl ExcludeFilter {
     }
 }
 
+/// The files one lint run will process, split by grammar.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiscoveredFiles {
+    pub r: Vec<PathBuf>,
+    /// Package `DESCRIPTION`s — see [`collect_lint_files`] for which ones a walk
+    /// picks up.
+    pub description: Vec<PathBuf>,
+}
+
+/// Discover the `.R` files under `paths`. The R-only view, for the callers that
+/// want exactly that: the formatter, `arity index`, and the lint driver's
+/// project-scope seeding.
 pub fn collect_r_files(
     paths: &[PathBuf],
     exclude: &ExcludeFilter,
 ) -> Result<Vec<PathBuf>, FileDiscoveryError> {
+    collect(paths, exclude, false).map(|files| files.r)
+}
+
+/// Discover both grammars' lint inputs under `paths` — the lint driver's entry
+/// point.
+///
+/// A **walk** picks up a `DESCRIPTION` only when its directory is a package root
+/// ([`is_package_root`]), so an `inst/extdata/DESCRIPTION` fixture, a vendored
+/// copy, or a test corpus's scraped metadata is skipped rather than linted as if
+/// it described the project. An **explicitly named** `DESCRIPTION` is always
+/// accepted, matching how an explicitly named excluded `.R` file is still
+/// processed.
+pub fn collect_lint_files(
+    paths: &[PathBuf],
+    exclude: &ExcludeFilter,
+) -> Result<DiscoveredFiles, FileDiscoveryError> {
+    collect(paths, exclude, true)
+}
+
+fn collect(
+    paths: &[PathBuf],
+    exclude: &ExcludeFilter,
+    descriptions: bool,
+) -> Result<DiscoveredFiles, FileDiscoveryError> {
     let mut files = Vec::new();
+    let mut found_descriptions = Vec::new();
 
     for path in paths {
         if path.is_file() {
@@ -142,11 +181,15 @@ pub fn collect_r_files(
             if exclude.force_excludes(path) {
                 continue;
             }
-            if !is_r_file(path) {
-                return Err(FileDiscoveryError::NonRFilePath { path: path.clone() });
+            if is_r_file(path) {
+                files.push(path.clone());
+                continue;
             }
-            files.push(path.clone());
-            continue;
+            if descriptions && is_description_file(path) {
+                found_descriptions.push(path.clone());
+                continue;
+            }
+            return Err(FileDiscoveryError::NonRFilePath { path: path.clone() });
         }
 
         if path.is_dir() {
@@ -165,9 +208,16 @@ pub fn collect_r_files(
                 match entry {
                     Ok(entry) => {
                         let entry_path = entry.path();
-                        if entry.file_type().is_some_and(|ft| ft.is_file()) && is_r_file(entry_path)
-                        {
+                        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                            continue;
+                        }
+                        if is_r_file(entry_path) {
                             files.push(entry_path.to_path_buf());
+                        } else if descriptions
+                            && is_description_file(entry_path)
+                            && entry_path.parent().is_some_and(is_package_root)
+                        {
+                            found_descriptions.push(entry_path.to_path_buf());
                         }
                     }
                     Err(err) => {
@@ -189,13 +239,24 @@ pub fn collect_r_files(
 
     files.sort();
     files.dedup();
-    Ok(files)
+    found_descriptions.sort();
+    found_descriptions.dedup();
+    Ok(DiscoveredFiles {
+        r: files,
+        description: found_descriptions,
+    })
 }
 
 fn is_r_file(path: &Path) -> bool {
     path.extension()
         .and_then(|ext| ext.to_str())
         .is_some_and(|ext| ext.eq_ignore_ascii_case("r"))
+}
+
+/// Whether `path` is named `DESCRIPTION`. Case-sensitive: R reads that exact
+/// name, so `description` is an unrelated file.
+fn is_description_file(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == "DESCRIPTION")
 }
 
 #[cfg(test)]

--- a/src/file_discovery.rs
+++ b/src/file_discovery.rs
@@ -153,11 +153,14 @@ pub fn collect_r_files(
 /// point.
 ///
 /// A **walk** picks up a `DESCRIPTION` only when its directory is a package root
-/// ([`is_package_root`]), so an `inst/extdata/DESCRIPTION` fixture, a vendored
-/// copy, or a test corpus's scraped metadata is skipped rather than linted as if
-/// it described the project. An **explicitly named** `DESCRIPTION` is always
-/// accepted, matching how an explicitly named excluded `.R` file is still
-/// processed.
+/// ([`is_package_root`]) that is not itself inside another package. The first
+/// half skips an `inst/extdata/DESCRIPTION` fixture, a vendored copy, or a test
+/// corpus's scraped metadata; the second skips a *complete* fake package under
+/// `tests/`, which is fixture data for a test rather than anybody's package
+/// metadata — the same reason `undeclared-dependency` looks only at `R/`.
+///
+/// An **explicitly named** `DESCRIPTION` is always accepted, matching how an
+/// explicitly named excluded `.R` file is still processed.
 pub fn collect_lint_files(
     paths: &[PathBuf],
     exclude: &ExcludeFilter,
@@ -215,7 +218,7 @@ fn collect(
                             files.push(entry_path.to_path_buf());
                         } else if descriptions
                             && is_description_file(entry_path)
-                            && entry_path.parent().is_some_and(is_package_root)
+                            && entry_path.parent().is_some_and(is_own_package_root)
                         {
                             found_descriptions.push(entry_path.to_path_buf());
                         }
@@ -257,6 +260,20 @@ fn is_r_file(path: &Path) -> bool {
 /// name, so `description` is an unrelated file.
 fn is_description_file(path: &Path) -> bool {
     path.file_name().is_some_and(|name| name == "DESCRIPTION")
+}
+
+/// Whether `dir` is a package root in its own right, rather than a package
+/// nested inside another one.
+///
+/// A package under a package is a *fixture* — roxygen2, devtools, and pkgbuild
+/// all keep whole miniature packages under `tests/testthat/` — and its
+/// `DESCRIPTION` is data for a test, deliberately minimal, describing nothing
+/// anybody ships. Linting it produces a screenful of findings about files whose
+/// author was never addressing us. Naming one explicitly still lints it.
+fn is_own_package_root(dir: &Path) -> bool {
+    // `package_root` starts one level up, so this asks "is any *ancestor* a
+    // package root", not "is this one".
+    is_package_root(dir) && crate::project::package_root(dir).is_none()
 }
 
 #[cfg(test)]

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -305,6 +305,7 @@ pub enum QueryKind {
     ProjectReads,
     VisibleSymbols,
     LoadedNames,
+    AttachedNames,
     ExternalResolution,
     DescriptionFacts,
 }

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -933,8 +933,10 @@ impl IncrementalDatabase {
     /// every membership change, and a future `didChangeWatchedFiles` watcher calls
     /// it directly to pick up a NAMESPACE/DESCRIPTION/`R/` edit without touching
     /// membership. The write is **skipped when the metadata is unchanged**, since
-    /// a salsa input always bumps its revision on a `set_*`.
-    pub fn refresh_package_graph(&mut self) -> PackageGraph {
+    /// a salsa input always bumps its revision on a `set_*`; the return value
+    /// reports whether anything was actually written, so a caller can skip a
+    /// re-lint that would find nothing new.
+    pub fn refresh_package_graph(&mut self) -> bool {
         let member_paths: Vec<PathBuf> = Workspace::try_get(self)
             .map(|ws| {
                 ws.members(self)
@@ -948,7 +950,7 @@ impl IncrementalDatabase {
         // `PackageInfo`s name roots that `workspace_project` resolves to these
         // handles, so writing it first would open a window where it points at
         // stale bytes.
-        self.refresh_descriptions(packages.iter().map(|p| p.root.clone()));
+        let mut wrote = self.refresh_descriptions(packages.iter().map(|p| p.root.clone()));
         match PackageGraph::try_get(self) {
             Some(graph) => {
                 if graph.packages(self) != &packages {
@@ -956,8 +958,8 @@ impl IncrementalDatabase {
                         .set_packages(self)
                         .with_durability(Durability::MEDIUM)
                         .to(packages);
+                    wrote = true;
                 }
-                graph
             }
             None => {
                 let graph = PackageGraph::new(self, packages.clone());
@@ -967,9 +969,10 @@ impl IncrementalDatabase {
                     .set_packages(self)
                     .with_durability(Durability::MEDIUM)
                     .to(packages);
-                graph
+                wrote = true;
             }
         }
+        wrote
     }
 
     /// Re-read each root's `DESCRIPTION` from disk into its [`DescriptionFile`]
@@ -979,15 +982,15 @@ impl IncrementalDatabase {
     /// Each text write is **skipped when unchanged** — a salsa input always
     /// bumps its revision — so a `didChangeWatchedFiles` event for a
     /// touched-but-unedited `DESCRIPTION` invalidates nothing at all.
-    pub fn refresh_descriptions(
-        &mut self,
-        roots: impl IntoIterator<Item = PathBuf>,
-    ) -> Descriptions {
+    pub fn refresh_descriptions(&mut self, roots: impl IntoIterator<Item = PathBuf>) -> bool {
+        let mut wrote = false;
         let mut files: Vec<DescriptionFile> = roots
             .into_iter()
             .map(|root| {
                 let text = std::fs::read_to_string(root.join("DESCRIPTION")).unwrap_or_default();
-                self.upsert_description(&root, text)
+                let (file, changed) = self.upsert_description(&root, text);
+                wrote |= changed;
+                file
             })
             .collect();
         files.sort_by(|a, b| a.root(self).cmp(b.root(self)));
@@ -999,8 +1002,8 @@ impl IncrementalDatabase {
                     set.set_files(self)
                         .with_durability(Durability::MEDIUM)
                         .to(files);
+                    wrote = true;
                 }
-                set
             }
             None => {
                 let set = Descriptions::new(self, files.clone());
@@ -1009,15 +1012,29 @@ impl IncrementalDatabase {
                 set.set_files(self)
                     .with_durability(Durability::MEDIUM)
                     .to(files);
-                set
+                wrote = true;
             }
         }
+        wrote
+    }
+
+    /// Re-read one root's `DESCRIPTION` from disk. Returns whether the tracked
+    /// text actually changed — the caller's cue to re-lint, so a touched but
+    /// unedited file costs nothing.
+    ///
+    /// Only valid for a root already tracked (see
+    /// [`lookup_description`](Self::lookup_description)); a *new* `DESCRIPTION`
+    /// reshapes package roots and needs the full
+    /// [`refresh_package_graph`](Self::refresh_package_graph).
+    pub fn refresh_description(&mut self, root: &Path) -> bool {
+        let text = std::fs::read_to_string(root.join("DESCRIPTION")).unwrap_or_default();
+        self.upsert_description(root, text).1
     }
 
     /// Insert or update the [`DescriptionFile`] input for `root`, reusing the
     /// existing input so its cached [`description_facts`] survive. Skips the
     /// write when the text is unchanged.
-    pub fn upsert_description(&mut self, root: &Path, text: String) -> DescriptionFile {
+    pub fn upsert_description(&mut self, root: &Path, text: String) -> (DescriptionFile, bool) {
         let existing = self
             .description_map
             .lock()
@@ -1026,12 +1043,13 @@ impl IncrementalDatabase {
             .copied();
         match existing {
             Some(file) => {
-                if file.text(self) != &text {
-                    file.set_text(self)
-                        .with_durability(Durability::MEDIUM)
-                        .to(text);
+                if file.text(self) == &text {
+                    return (file, false);
                 }
-                file
+                file.set_text(self)
+                    .with_durability(Durability::MEDIUM)
+                    .to(text);
+                (file, true)
             }
             None => {
                 let file = DescriptionFile::new(self, root.to_path_buf(), text.clone());
@@ -1044,7 +1062,7 @@ impl IncrementalDatabase {
                     .lock()
                     .expect("description map mutex poisoned")
                     .insert(root.to_path_buf(), file);
-                file
+                (file, true)
             }
         }
     }

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -21,8 +21,8 @@ use crate::parser::{
     map_range_through_edits, parse_with_options, reparse_edits_with_options, reparse_with_options,
 };
 use crate::project::{
-    ClassSystem, DefKind, DescriptionFacts, PackageInfo, ReadBinding, ReadSite, SourceEdgeKey,
-    TopLevelEvent, collect_source_literal_edges, collect_top_level_events,
+    ClassSystem, DefKind, DescriptionFacts, PackageInfo, PackageReferences, ReadBinding, ReadSite,
+    SourceEdgeKey, TopLevelEvent, collect_source_literal_edges, collect_top_level_events,
     collect_top_level_events_spanned, discover_packages, project_classes, project_defs,
     project_graph, project_reads, relative_path, reverse_source_edges, workspace_project,
 };
@@ -308,6 +308,8 @@ pub enum QueryKind {
     AttachedNames,
     ExternalResolution,
     DescriptionFacts,
+    PackageReferences,
+    PackageUsage,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -609,6 +611,22 @@ pub fn loaded_names(db: &dyn IncrementalDb, file: SourceFile) -> BTreeSet<String
         }
     }
     names
+}
+
+/// The packages an R file names ([`crate::project::file_package_references`]).
+///
+/// A backdating firewall like [`loaded_names`], and deliberately *not* that
+/// query: `loaded_names` is top-level-only and models attachment, while this
+/// asks the broader "does this file reach the package at all" — the question
+/// the package-level dependency-usage fold above it is built from. Range-free
+/// and `Eq`, so a body edit leaves it equal and the fold is not re-run.
+#[salsa::tracked(returns(ref))]
+pub fn package_references(db: &dyn IncrementalDb, file: SourceFile) -> PackageReferences {
+    db.record_query(QueryLogEntry {
+        kind: QueryKind::PackageReferences,
+        file: Some(file),
+    });
+    crate::project::file_package_references(&parsed_tree_root(db, file), semantic_model(db, file))
 }
 
 /// The analysis facts a package's `DESCRIPTION` declares.

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -21,10 +21,10 @@ use crate::parser::{
     map_range_through_edits, parse_with_options, reparse_edits_with_options, reparse_with_options,
 };
 use crate::project::{
-    ClassSystem, DefKind, PackageInfo, ReadBinding, ReadSite, SourceEdgeKey, TopLevelEvent,
-    collect_source_literal_edges, collect_top_level_events, collect_top_level_events_spanned,
-    discover_packages, project_classes, project_defs, project_graph, project_reads, relative_path,
-    reverse_source_edges, workspace_project,
+    ClassSystem, DefKind, DescriptionFacts, PackageInfo, ReadBinding, ReadSite, SourceEdgeKey,
+    TopLevelEvent, collect_source_literal_edges, collect_top_level_events,
+    collect_top_level_events_spanned, discover_packages, project_classes, project_defs,
+    project_graph, project_reads, relative_path, reverse_source_edges, workspace_project,
 };
 use crate::rindex::provider::IndexedProvider;
 use crate::rindex::remote::RemoteExports;
@@ -242,6 +242,48 @@ pub struct PackageGraph {
     pub packages: Vec<PackageInfo>,
 }
 
+/// One package root's `DESCRIPTION`, as a tracked input holding the raw text.
+///
+/// Deliberately **not** a [`SourceFile`]: that input carries R-parse state
+/// (`roxygen_markdown`) and every query over it assumes the R grammar. DCF is a
+/// second, independent grammar, and keeping the two input families apart is the
+/// same rule that keeps the two `SyntaxKind` enums apart.
+///
+/// The *text* lives here rather than the derived facts because that is what
+/// buys the backdating: an edit to `Description:` prose bumps this input, and
+/// [`description_facts`] then compares equal and backdates, so
+/// [`workspace_project`](crate::project::workspace_project) is never
+/// re-executed. Storing facts directly in [`PackageGraph`] would instead make
+/// every prose keystroke a project-graph rebuild once stage 4 lands.
+///
+/// A missing or unreadable `DESCRIPTION` is `""` — a salsa input cannot be
+/// un-created, and empty text derives all-default facts, which is exactly what
+/// "no DESCRIPTION" should mean.
+#[salsa::input]
+pub struct DescriptionFile {
+    /// The package root holding this `DESCRIPTION`. Set once, never mutated.
+    #[returns(ref)]
+    pub root: PathBuf,
+    #[returns(ref)]
+    pub text: String,
+}
+
+/// Every tracked `DESCRIPTION`, as a salsa **singleton** input at
+/// `Durability::MEDIUM` — the handle set
+/// [`workspace_project`](crate::project::workspace_project) reads so it can
+/// resolve a package root's facts without touching the filesystem.
+///
+/// Refreshed in lockstep with [`PackageGraph`] by
+/// [`refresh_package_graph`](IncrementalDatabase::refresh_package_graph), which
+/// upserts each root's text *before* writing the graph — so the graph never
+/// points at a handle carrying stale bytes.
+#[salsa::input(singleton)]
+pub struct Descriptions {
+    /// One entry per package root with a tracked `DESCRIPTION`, sorted by root.
+    #[returns(ref)]
+    pub files: Vec<DescriptionFile>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum QueryKind {
     ParsedDocument,
@@ -264,6 +306,7 @@ pub enum QueryKind {
     VisibleSymbols,
     LoadedNames,
     ExternalResolution,
+    DescriptionFacts,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -567,6 +610,26 @@ pub fn loaded_names(db: &dyn IncrementalDb, file: SourceFile) -> BTreeSet<String
     names
 }
 
+/// The analysis facts a package's `DESCRIPTION` declares.
+///
+/// **The backdating firewall for `DESCRIPTION`.** [`DescriptionFile`] holds raw
+/// text, so any edit bumps it; this projection is range-free and `Eq`, so an
+/// edit that changes no fact (prose in `Description:`, a reflowed `Title:`, a
+/// new `Authors@R`) compares equal and backdates — and
+/// [`workspace_project`](crate::project::workspace_project) is not re-executed.
+/// An edit that *does* change a fact propagates, which is the whole point.
+///
+/// Adding a range to [`DescriptionFacts`] would defeat this silently; a
+/// consumer needing spans re-derives them from the CST instead.
+#[salsa::tracked(returns(ref))]
+pub fn description_facts(db: &dyn IncrementalDb, file: DescriptionFile) -> DescriptionFacts {
+    db.record_query(QueryLogEntry {
+        kind: QueryKind::DescriptionFacts,
+        file: None,
+    });
+    DescriptionFacts::from_text(file.text(db))
+}
+
 /// The file's top-level `source()` edges, range-free
 /// ([`crate::project::collect_source_edge_keys`]), as a tracked query. Resolves
 /// relative targets against the file's own directory (`path.parent()`); the
@@ -636,6 +699,11 @@ pub struct IncrementalDatabase {
     /// `DESCRIPTION` events. Outside salsa: a disk-read memo, never a query
     /// output. Shared across clones.
     markdown_resolver: Arc<Mutex<crate::project::description::MarkdownDefaultResolver>>,
+    /// Package root → its [`DescriptionFile`] input, so re-reading the same
+    /// root reuses one input (and its cached facts) instead of minting a
+    /// duplicate. The DCF counterpart of [`source_map`](Self::source_map).
+    /// Shared across clones.
+    description_map: Arc<Mutex<HashMap<PathBuf, DescriptionFile>>>,
 }
 
 impl Default for IncrementalDatabase {
@@ -651,6 +719,7 @@ impl Default for IncrementalDatabase {
             markdown_resolver: Arc::new(Mutex::new(
                 crate::project::description::MarkdownDefaultResolver::new(),
             )),
+            description_map: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -674,6 +743,7 @@ impl Clone for IncrementalDatabase {
             reparse_hits: Arc::clone(&self.reparse_hits),
             precise_reparse_hits: Arc::clone(&self.precise_reparse_hits),
             markdown_resolver: Arc::clone(&self.markdown_resolver),
+            description_map: Arc::clone(&self.description_map),
         }
     }
 }
@@ -873,6 +943,11 @@ impl IncrementalDatabase {
             })
             .unwrap_or_default();
         let packages = discover_packages(&member_paths);
+        // Upsert the DESCRIPTION texts **before** writing the graph: the graph's
+        // `PackageInfo`s name roots that `workspace_project` resolves to these
+        // handles, so writing it first would open a window where it points at
+        // stale bytes.
+        self.refresh_descriptions(packages.iter().map(|p| p.root.clone()));
         match PackageGraph::try_get(self) {
             Some(graph) => {
                 if graph.packages(self) != &packages {
@@ -894,6 +969,93 @@ impl IncrementalDatabase {
                 graph
             }
         }
+    }
+
+    /// Re-read each root's `DESCRIPTION` from disk into its [`DescriptionFile`]
+    /// input, and install the handle set as the [`Descriptions`] singleton at
+    /// `Durability::MEDIUM`.
+    ///
+    /// Each text write is **skipped when unchanged** — a salsa input always
+    /// bumps its revision — so a `didChangeWatchedFiles` event for a
+    /// touched-but-unedited `DESCRIPTION` invalidates nothing at all.
+    pub fn refresh_descriptions(
+        &mut self,
+        roots: impl IntoIterator<Item = PathBuf>,
+    ) -> Descriptions {
+        let mut files: Vec<DescriptionFile> = roots
+            .into_iter()
+            .map(|root| {
+                let text = std::fs::read_to_string(root.join("DESCRIPTION")).unwrap_or_default();
+                self.upsert_description(&root, text)
+            })
+            .collect();
+        files.sort_by(|a, b| a.root(self).cmp(b.root(self)));
+        files.dedup();
+
+        match Descriptions::try_get(self) {
+            Some(set) => {
+                if set.files(self) != &files {
+                    set.set_files(self)
+                        .with_durability(Durability::MEDIUM)
+                        .to(files);
+                }
+                set
+            }
+            None => {
+                let set = Descriptions::new(self, files.clone());
+                // Creation lands at default durability; re-set at MEDIUM so the
+                // first edit after seeding also skips revalidating the set.
+                set.set_files(self)
+                    .with_durability(Durability::MEDIUM)
+                    .to(files);
+                set
+            }
+        }
+    }
+
+    /// Insert or update the [`DescriptionFile`] input for `root`, reusing the
+    /// existing input so its cached [`description_facts`] survive. Skips the
+    /// write when the text is unchanged.
+    pub fn upsert_description(&mut self, root: &Path, text: String) -> DescriptionFile {
+        let existing = self
+            .description_map
+            .lock()
+            .expect("description map mutex poisoned")
+            .get(root)
+            .copied();
+        match existing {
+            Some(file) => {
+                if file.text(self) != &text {
+                    file.set_text(self)
+                        .with_durability(Durability::MEDIUM)
+                        .to(text);
+                }
+                file
+            }
+            None => {
+                let file = DescriptionFile::new(self, root.to_path_buf(), text.clone());
+                // Creation lands at default durability; re-set at MEDIUM so an
+                // R-file keystroke (a LOW write) skips revalidating the facts.
+                file.set_text(self)
+                    .with_durability(Durability::MEDIUM)
+                    .to(text);
+                self.description_map
+                    .lock()
+                    .expect("description map mutex poisoned")
+                    .insert(root.to_path_buf(), file);
+                file
+            }
+        }
+    }
+
+    /// The tracked `DESCRIPTION` for `root`, if one has been seeded. Read-only,
+    /// so it is safe on a shared clone.
+    pub fn lookup_description(&self, root: &Path) -> Option<DescriptionFile> {
+        self.description_map
+            .lock()
+            .expect("description map mutex poisoned")
+            .get(root)
+            .copied()
     }
 
     /// The [`Workspace`] singleton, if one has been seeded. Read-only.

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -19,9 +19,9 @@ pub mod suppression;
 
 pub use check::{
     LintError, LintFileReport, LintResult, LintStatus, PreparedProject, SYNTAX_ERROR_RULE,
-    analyze_prepared, check_document, check_document_in_project, check_document_with_provider,
-    check_paths, check_paths_with_config, check_paths_with_index, prepare_document_in_project,
-    seed_workspace_for, syntax_error_diagnostics,
+    analyze_prepared, check_description_document, check_document, check_document_in_project,
+    check_document_with_provider, check_paths, check_paths_with_config, check_paths_with_index,
+    prepare_document_in_project, seed_workspace_for, syntax_error_diagnostics,
 };
 pub use diagnostic::{Applicability, Diagnostic, Fix, Severity, ViolationData};
 pub use fix::{FixOutcome, apply_fixes};

--- a/src/linter/check.rs
+++ b/src/linter/check.rs
@@ -19,8 +19,8 @@ use crate::incremental::{
     source_edges, top_level_events,
 };
 use crate::project::{
-    ExternalResolution, FileScope, PackageCollation, Project, ProjectMember, expected_r_sources,
-    external_resolution, package_root, visible_symbols, workspace_project,
+    ExternalResolution, FileScope, PackageCollation, PackageDeclarations, Project, ProjectMember,
+    expected_r_sources, external_resolution, package_root, visible_symbols, workspace_project,
 };
 use crate::rindex::provider::IndexedProvider;
 use crate::semantic::SymbolProvider;
@@ -380,9 +380,10 @@ fn intern_project<'db>(
     mut members: Vec<ProjectMember>,
     namespaces: Vec<(PathBuf, String)>,
     collations: Vec<PackageCollation>,
+    declarations: Vec<PackageDeclarations>,
 ) -> Project<'db> {
     members.sort_by(|a, b| a.path.cmp(&b.path));
-    Project::new(db, members, namespaces, collations)
+    Project::new(db, members, namespaces, collations, declarations)
 }
 
 /// Run the resolved rules against a cleanly-parsed file, using the cached parse
@@ -461,6 +462,9 @@ pub struct PreparedProject {
     /// from the interned [`Project`] (disk-derived in [`workspace_project`]) so
     /// the read-phase re-interns it without touching disk.
     collations: Vec<PackageCollation>,
+    /// Per package root, the dependencies its `DESCRIPTION` declares, sorted by
+    /// root. Snapshotted from the interned [`Project`] like `collations`.
+    declarations: Vec<PackageDeclarations>,
 }
 
 /// Write-phase of cross-file linting (needs `&mut db`). Discovers the enclosing
@@ -495,6 +499,7 @@ pub fn prepare_document_in_project(
     let members = project.members(&*db).clone();
     let namespaces = project.namespaces(&*db).clone();
     let collations = project.collations(&*db).clone();
+    let declarations = project.declarations(&*db).clone();
 
     Some(PreparedProject {
         active,
@@ -502,6 +507,7 @@ pub fn prepare_document_in_project(
         members,
         namespaces,
         collations,
+        declarations,
     })
 }
 
@@ -610,6 +616,7 @@ pub fn analyze_prepared(
         prepared.members.clone(),
         prepared.namespaces.clone(),
         prepared.collations.clone(),
+        prepared.declarations.clone(),
     );
     let active_path = analysis
         .file_path(prepared.active)

--- a/src/linter/check.rs
+++ b/src/linter/check.rs
@@ -28,7 +28,7 @@ use crate::rindex::provider::IndexedProvider;
 use crate::semantic::SymbolProvider;
 
 use super::diagnostic::{Diagnostic, Severity, ViolationData};
-use super::rules::{ResolvedRules, default_symbol_provider, run_rules};
+use super::rules::{ResolvedRules, default_symbol_provider, run_dcf_rules, run_rules};
 
 /// Synthetic rule id carried by findings that originate from the parser's error
 /// side channel rather than a lint rule. Shown as the `[code]` in CLI output and
@@ -54,6 +54,21 @@ pub fn syntax_error_diagnostics(diags: &[ParseDiagnosticData], path: &Path) -> V
             fix: None,
         })
         .collect()
+}
+
+/// The DCF parser reports on its own [`ParseDiagnostic`] type (the parser crate
+/// stays salsa-free), structurally identical to the salsa-side one. Converting
+/// here lets `DESCRIPTION` reuse [`syntax_error_diagnostics`] verbatim.
+///
+/// [`ParseDiagnostic`]: crate::parser::ParseDiagnostic
+impl From<&crate::parser::ParseDiagnostic> for ParseDiagnosticData {
+    fn from(value: &crate::parser::ParseDiagnostic) -> Self {
+        Self {
+            message: value.message.clone(),
+            start: value.start,
+            end: value.end,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -684,6 +699,64 @@ pub fn check_document(
     config: &LintConfig,
 ) -> Result<Vec<Diagnostic>, LintError> {
     check_document_with_provider(path, content, config, &default_symbol_provider())
+}
+
+/// Lint one `DESCRIPTION` buffer: parse it as DCF, and either report the
+/// parser's diagnostics or run the configured [`DcfRule`]s over the document.
+///
+/// **Parse diagnostics block the rules**, exactly as they do for R
+/// (`.claude/rules/linter.md`): a `DESCRIPTION` that `read.dcf` would reject is
+/// a fix-this-first state, and `LintStatus` must not mean different things for
+/// different file types. The whole policy lives in this one function, so
+/// reporting-without-blocking would be a one-line change here rather than a
+/// scattered one.
+///
+/// [`DcfRule`]: super::rules::DcfRule
+fn lint_description_source(
+    path: &Path,
+    content: &str,
+    rules: &ResolvedRules,
+) -> (LintStatus, Vec<Diagnostic>) {
+    let parsed = crate::dcf::parse(content);
+    if !parsed.diagnostics.is_empty() {
+        let data: Vec<ParseDiagnosticData> = parsed.diagnostics.iter().map(Into::into).collect();
+        return (
+            LintStatus::ParseDiagnostics { count: data.len() },
+            syntax_error_diagnostics(&data, path),
+        );
+    }
+
+    let document = parsed.document();
+    let facts = DescriptionFacts::from_document(&document);
+    let mut diagnostics = run_dcf_rules(rules, path, &parsed.cst, &document, &facts);
+    for d in &mut diagnostics {
+        d.path = path.to_path_buf();
+    }
+    let status = if diagnostics.is_empty() {
+        LintStatus::Clean
+    } else {
+        LintStatus::Findings {
+            count: diagnostics.len(),
+        }
+    };
+    (status, diagnostics)
+}
+
+/// Lint a single in-memory `DESCRIPTION` by path + text — the DCF twin of
+/// [`check_document`], used by the docs generator and tests.
+///
+/// No database: a document's facts come from the document itself, and no
+/// cross-file question is answerable from one buffer anyway.
+pub fn check_description_document(
+    path: &Path,
+    content: &str,
+    config: &LintConfig,
+) -> Result<Vec<Diagnostic>, LintError> {
+    let (rules, unknown) = ResolvedRules::resolve(config);
+    if let Some(rule) = unknown.into_iter().next() {
+        return Err(LintError::UnknownRule { rule });
+    }
+    Ok(lint_description_source(path, content, &rules).1)
 }
 
 /// Like [`check_document`] but with a caller-supplied symbol provider.

--- a/src/linter/check.rs
+++ b/src/linter/check.rs
@@ -22,9 +22,9 @@ use crate::incremental::{
 };
 use crate::project::description::DescriptionFacts;
 use crate::project::{
-    ExternalResolution, FileScope, PackageCollation, PackageDeclarations, Project, ProjectMember,
-    expected_r_sources, external_resolution, package_facts_for, package_root, visible_symbols,
-    workspace_project,
+    ExternalResolution, FileScope, PackageCollation, PackageDeclarations, PackageUsage, Project,
+    ProjectMember, expected_r_sources, external_resolution, package_facts_for, package_root,
+    package_usage_for, visible_symbols, workspace_project,
 };
 use crate::rindex::provider::IndexedProvider;
 use crate::semantic::SymbolProvider;
@@ -384,8 +384,11 @@ pub fn check_paths_with_index(
     let description_count = description_sources.len();
     let description_reports: Vec<LintFileReport> = description_sources
         .into_par_iter()
-        .map(|(path, content)| {
-            let (status, diagnostics) = lint_description_source(&path, &content, &rules);
+        .map_with(db.clone(), |worker, (path, content)| {
+            let worker = &*worker;
+            let project = workspace_project(worker);
+            let usage = package_usage_for(worker, project, &path);
+            let (status, diagnostics) = lint_description_source(&path, &content, &rules, usage);
             LintFileReport {
                 path,
                 status,
@@ -762,6 +765,7 @@ fn lint_description_source(
     path: &Path,
     content: &str,
     rules: &ResolvedRules,
+    usage: Option<&PackageUsage>,
 ) -> (LintStatus, Vec<Diagnostic>) {
     let parsed = crate::dcf::parse(content);
     if !parsed.diagnostics.is_empty() {
@@ -774,7 +778,7 @@ fn lint_description_source(
 
     let document = parsed.document();
     let facts = DescriptionFacts::from_document(&document);
-    let mut diagnostics = run_dcf_rules(rules, path, &parsed.cst, &document, &facts);
+    let mut diagnostics = run_dcf_rules(rules, path, &parsed.cst, &document, &facts, usage);
     for d in &mut diagnostics {
         d.path = path.to_path_buf();
     }
@@ -802,7 +806,7 @@ pub fn check_description_document(
     if let Some(rule) = unknown.into_iter().next() {
         return Err(LintError::UnknownRule { rule });
     }
-    Ok(lint_description_source(path, content, &rules).1)
+    Ok(lint_description_source(path, content, &rules, None).1)
 }
 
 /// Like [`check_document`] but with a caller-supplied symbol provider.

--- a/src/linter/check.rs
+++ b/src/linter/check.rs
@@ -12,7 +12,9 @@ use rayon::prelude::*;
 use rowan::{TextRange, TextSize};
 
 use crate::config::LintConfig;
-use crate::file_discovery::{ExcludeFilter, FileDiscoveryError, collect_r_files};
+use crate::file_discovery::{
+    ExcludeFilter, FileDiscoveryError, collect_lint_files, collect_r_files,
+};
 use crate::incremental::{
     Analysis, IncrementalDatabase, IncrementalDb, ParseDiagnosticData, SourceFile, control_flow,
     file_exports, file_free_reads, file_qualified_reads, parsed_tree_root, semantic_model,
@@ -115,10 +117,10 @@ impl fmt::Display for LintError {
                     "lint requires at least one input path (file or directory)"
                 )
             }
-            Self::NoRFiles => write!(f, "no .R files found under the provided input paths"),
+            Self::NoRFiles => write!(f, "no lintable files found under the provided input paths"),
             Self::NonRFilePath { path } => write!(
                 f,
-                "input file {} is not an .R file; lint only supports .R files",
+                "input file {} is not lintable; lint supports .R files and DESCRIPTION",
                 path.display()
             ),
             Self::WalkError { path, message } => {
@@ -178,8 +180,14 @@ pub fn check_paths_with_index(
         return Err(LintError::UnknownRule { rule });
     }
 
-    let files = collect_r_files(paths, exclude).map_err(LintError::from)?;
-    if files.is_empty() {
+    let discovered = collect_lint_files(paths, exclude).map_err(LintError::from)?;
+    let files = discovered.r;
+    // Every package `DESCRIPTION` is an input regardless of which rules are
+    // selected: `syntax-error` is not a rule, and a `DESCRIPTION` that
+    // `read.dcf` would reject must surface under `--select` exactly as a broken
+    // `.R` file does.
+    let descriptions = discovered.description;
+    if files.is_empty() && descriptions.is_empty() {
         // Under force-exclude every named file may be excluded; that is an
         // expected clean no-op, not an error.
         if exclude.force() {
@@ -226,6 +234,24 @@ pub fn check_paths_with_index(
         readable.push(path);
     }
     let files = readable;
+
+    // `DESCRIPTION` buffers, under the same skip-or-fail policy. They are held
+    // as text rather than pushed through `upsert_file`: a `SourceFile` carries
+    // R-parse state and every query over one assumes the R grammar, which is
+    // exactly why `DescriptionFile` is a separate input.
+    let mut description_sources: Vec<(PathBuf, String)> = Vec::with_capacity(descriptions.len());
+    for path in descriptions {
+        match fs::read_to_string(&path) {
+            Ok(content) => description_sources.push((path, content)),
+            Err(err) if err.kind() == io::ErrorKind::InvalidData => skipped.push(path),
+            Err(err) => {
+                return Err(LintError::ReadError {
+                    path,
+                    source: err.to_string(),
+                });
+            }
+        }
+    }
 
     // Scope-only members: a package's generated R sources (`cpp11.R`,
     // `RcppExports.R`, `extendr-wrappers.R`, `import-standalone-*.R`) are in the
@@ -309,7 +335,7 @@ pub fn check_paths_with_index(
     // parallel on db clones. `Project<'db>` is lifetime-bound to its handle, so
     // each worker re-derives it from its own clone (a memo hit after the force
     // above). The ordered collect keeps reports in `files` order.
-    let reports: Vec<LintFileReport> = files
+    let mut reports: Vec<LintFileReport> = files
         .into_par_iter()
         .map_with(db.clone(), |worker, path| {
             let worker = &*worker;
@@ -351,6 +377,26 @@ pub fn check_paths_with_index(
         })
         .collect();
 
+    // Pass 3: the `DESCRIPTION`s. Separate from pass 2 because it runs over a
+    // second grammar with no salsa input of its own, and it comes *after*
+    // because the cross-file DESCRIPTION rules read facts the project graph
+    // above derives.
+    let description_count = description_sources.len();
+    let description_reports: Vec<LintFileReport> = description_sources
+        .into_par_iter()
+        .map(|(path, content)| {
+            let (status, diagnostics) = lint_description_source(&path, &content, &rules);
+            LintFileReport {
+                path,
+                status,
+                diagnostics,
+            }
+        })
+        .collect();
+    reports.extend(description_reports);
+    // `collect_lint_files` sorts each list, so this only interleaves the two.
+    reports.sort_by(|a, b| a.path.cmp(&b.path));
+
     let total_findings = reports
         .iter()
         .map(|r| match r.status {
@@ -360,7 +406,7 @@ pub fn check_paths_with_index(
         .sum();
 
     Ok(LintResult {
-        checked_files: tracked.len(),
+        checked_files: tracked.len() + description_count,
         total_findings,
         reports,
         skipped,

--- a/src/linter/check.rs
+++ b/src/linter/check.rs
@@ -18,9 +18,11 @@ use crate::incremental::{
     file_exports, file_free_reads, file_qualified_reads, parsed_tree_root, semantic_model,
     source_edges, top_level_events,
 };
+use crate::project::description::DescriptionFacts;
 use crate::project::{
     ExternalResolution, FileScope, PackageCollation, PackageDeclarations, Project, ProjectMember,
-    expected_r_sources, external_resolution, package_root, visible_symbols, workspace_project,
+    expected_r_sources, external_resolution, package_facts_for, package_root, visible_symbols,
+    workspace_project,
 };
 use crate::rindex::provider::IndexedProvider;
 use crate::semantic::SymbolProvider;
@@ -308,6 +310,7 @@ pub fn check_paths_with_index(
                 let visibility = visible_symbols(worker, project, file);
                 let file_scope = visibility.scope();
                 let resolution = external_resolution(worker, manifest, project, file);
+                let package = package_facts_for(worker, &path);
                 let kept = lint_parsed_file(
                     worker,
                     file,
@@ -316,6 +319,7 @@ pub fn check_paths_with_index(
                     &fallback,
                     Some(&file_scope),
                     Some(resolution),
+                    package,
                 );
                 let status = if kept.is_empty() {
                     LintStatus::Clean
@@ -391,6 +395,7 @@ fn intern_project<'db>(
 /// without diagnostics.
 ///
 /// Suppression filtering happens inside [`run_rules`], not here — see its doc.
+#[allow(clippy::too_many_arguments)]
 fn lint_parsed_file(
     db: &dyn IncrementalDb,
     file: SourceFile,
@@ -399,12 +404,13 @@ fn lint_parsed_file(
     provider: &dyn SymbolProvider,
     project: Option<&FileScope<'_>>,
     resolution: Option<&ExternalResolution>,
+    package: Option<&DescriptionFacts>,
 ) -> Vec<Diagnostic> {
     let root_node = parsed_tree_root(db, file);
     let model = semantic_model(db, file);
     let cfg = control_flow(db, file);
     let mut diagnostics = run_rules(
-        rules, path, &root_node, model, cfg, provider, project, resolution,
+        rules, path, &root_node, model, cfg, provider, project, resolution, package,
     );
     for d in &mut diagnostics {
         d.path = path.to_path_buf();
@@ -432,7 +438,7 @@ pub fn check_tracked_file(
         return Ok(syntax_error_diagnostics(parse_diagnostics, path));
     }
     Ok(lint_parsed_file(
-        db, file, path, &rules, provider, None, None,
+        db, file, path, &rules, provider, None, None, None,
     ))
 }
 
@@ -638,6 +644,7 @@ pub fn analyze_prepared(
         provider,
         Some(&file_scope),
         resolution,
+        package_facts_for(db, &active_path),
     )
 }
 

--- a/src/linter/docs.rs
+++ b/src/linter/docs.rs
@@ -15,11 +15,11 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use crate::config::LintConfig;
-use crate::linter::check::check_document;
-use crate::linter::diagnostic::Fix;
+use crate::linter::check::{check_description_document, check_document};
+use crate::linter::diagnostic::{Diagnostic, Fix};
 use crate::linter::fix::apply_fixes;
 use crate::linter::render::{OutputMode, render_findings};
-use crate::linter::rules::{Rule, rules_by_category};
+use crate::linter::rules::{AnyRule, Example, rules_by_category};
 
 /// Preamble for the generated page: the header comment warning it off
 /// hand-edits, the title, and the prose that frames the catalogue.
@@ -46,17 +46,32 @@ Every example below is linted live to produce its diagnostic and fixed output,
 so this page never drifts from the rules' actual behavior.
 ";
 
-/// The synthetic path used when linting an example snippet. The same value must
-/// key both `check_document` and the `render_findings` source lookup: the
-/// linter rewrites every diagnostic's `path` to the one passed here, and the
-/// pretty renderer silently degrades to a one-liner if the source can't be
-/// found for that exact path.
-fn example_path() -> PathBuf {
-    PathBuf::from("example.R")
+/// The synthetic path an example snippet is linted under — one per grammar, and
+/// the real file name in both cases.
+///
+/// The same value must key both the lint call and the `render_findings` source
+/// lookup: the linter rewrites every diagnostic's `path` to the one passed
+/// here, and the pretty renderer silently degrades to a one-liner if the source
+/// can't be found for that exact path.
+fn example_path(rule: &AnyRule) -> PathBuf {
+    match rule {
+        AnyRule::R(_) => PathBuf::from("example.R"),
+        AnyRule::Dcf(_) => PathBuf::from("DESCRIPTION"),
+    }
+}
+
+/// The fenced-block language an example is rendered under. mdBook ships stock
+/// highlight.js, which has no DCF grammar — and `yaml`, the nearest thing,
+/// would highlight a lie about continuation lines.
+fn example_language(rule: &AnyRule) -> &'static str {
+    match rule {
+        AnyRule::R(_) => "r",
+        AnyRule::Dcf(_) => "text",
+    }
 }
 
 /// The rule set an example snippet is linted under: the rule itself, plus
-/// whatever it declares via [`Rule::doc_select`].
+/// whatever it declares via `doc_select`.
 ///
 /// Restricting `select` keeps an example from tripping an unrelated rule. Some
 /// rules need company all the same — `outdated-suppression` can only tell a
@@ -64,7 +79,7 @@ fn example_path() -> PathBuf {
 ///
 /// Shared with `tests/rule_docs.rs`, so the pinned pages and the "every example
 /// triggers its rule" check agree on what is enabled.
-pub fn example_lint_config(rule: &dyn Rule) -> LintConfig {
+pub fn example_lint_config(rule: &AnyRule) -> LintConfig {
     let mut select = vec![rule.id().to_string()];
     select.extend(rule.doc_select().iter().map(|id| id.to_string()));
     LintConfig {
@@ -72,6 +87,20 @@ pub fn example_lint_config(rule: &dyn Rule) -> LintConfig {
         compat: rule.doc_compat(),
         ..Default::default()
     }
+}
+
+/// Lint one documented example exactly as the reference page does.
+///
+/// Shared with `tests/rule_docs.rs` so the "does this example still trigger?"
+/// check can never drift from what the page actually renders.
+pub fn lint_example(rule: &AnyRule, example: &Example) -> Vec<Diagnostic> {
+    let config = example_lint_config(rule);
+    let path = example_path(rule);
+    match rule {
+        AnyRule::R(_) => check_document(&path, example.source, &config),
+        AnyRule::Dcf(_) => check_description_document(&path, example.source, &config),
+    }
+    .unwrap_or_default()
 }
 
 /// Render the whole rule reference: preamble, a per-category index, and every
@@ -115,7 +144,7 @@ pub fn render_rules_page() -> String {
         let _ = writeln!(out, "## {}", category.title());
         for rule in rules {
             let _ = writeln!(out);
-            let _ = out.write_str(&render_rule_doc(rule.as_ref()));
+            let _ = out.write_str(&render_rule_doc(rule));
         }
     }
 
@@ -124,7 +153,7 @@ pub fn render_rules_page() -> String {
 
 /// Render one rule's section of the reference page — the unit the snapshot test
 /// pins and [`render_rules_page`] assembles.
-pub fn render_rule_doc(rule: &dyn Rule) -> String {
+pub fn render_rule_doc(rule: &AnyRule) -> String {
     let mut out = String::new();
     let id = rule.id();
     let _ = writeln!(out, "### `{id}`");
@@ -143,7 +172,8 @@ pub fn render_rule_doc(rule: &dyn Rule) -> String {
     };
     let _ = writeln!(out, "{status}");
 
-    let config = example_lint_config(rule);
+    let language = example_language(rule);
+    let path = example_path(rule);
 
     for example in rule.examples() {
         let _ = writeln!(out);
@@ -151,13 +181,12 @@ pub fn render_rule_doc(rule: &dyn Rule) -> String {
             let _ = writeln!(out, "{}", example.caption);
             let _ = writeln!(out);
         }
-        fenced(&mut out, "r", example.source);
+        fenced(&mut out, language, example.source);
 
-        let diagnostics =
-            check_document(&example_path(), example.source, &config).unwrap_or_default();
+        let diagnostics = lint_example(rule, example);
         let source = example.source.to_string();
-        let rendered = render_findings(&diagnostics, OutputMode::Pretty, false, &|path| {
-            (path == &example_path()).then(|| source.clone())
+        let rendered = render_findings(&diagnostics, OutputMode::Pretty, false, &|candidate| {
+            (candidate == &path).then(|| source.clone())
         });
         let _ = writeln!(out);
         fenced(&mut out, "text", &rendered);
@@ -168,7 +197,7 @@ pub fn render_rule_doc(rule: &dyn Rule) -> String {
             let _ = writeln!(out);
             let _ = writeln!(out, "After applying the fix:");
             let _ = writeln!(out);
-            fenced(&mut out, "r", &after.output);
+            fenced(&mut out, language, &after.output);
         }
     }
 

--- a/src/linter/docs.rs
+++ b/src/linter/docs.rs
@@ -12,10 +12,10 @@
 //! index to fall out of step with the registry when a rule is added.
 
 use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::LintConfig;
-use crate::linter::check::{check_description_document, check_document};
+use crate::linter::check::{check_description_document, check_document, check_paths_with_config};
 use crate::linter::diagnostic::{Diagnostic, Fix};
 use crate::linter::fix::apply_fixes;
 use crate::linter::render::{OutputMode, render_findings};
@@ -96,11 +96,66 @@ pub fn example_lint_config(rule: &AnyRule) -> LintConfig {
 pub fn lint_example(rule: &AnyRule, example: &Example) -> Vec<Diagnostic> {
     let config = example_lint_config(rule);
     let path = example_path(rule);
+    if !rule.doc_package().is_empty() {
+        return lint_example_in_package(rule, example, &config, &path);
+    }
     match rule {
         AnyRule::R(_) => check_document(&path, example.source, &config),
         AnyRule::Dcf(_) => check_description_document(&path, example.source, &config),
     }
     .unwrap_or_default()
+}
+
+/// Lint an example inside the synthetic package its rule declares — the
+/// `doc_package` path, for rules whose subject is a package-level fact and are
+/// therefore silent on the single-file path.
+///
+/// The example is written where R would keep it (`R/example.R`, or the
+/// `DESCRIPTION` itself), the whole root is linted through the cross-file
+/// driver, and the surviving findings are relabelled with the synthetic path so
+/// the rendered snippet still matches the source the reader is shown.
+fn lint_example_in_package(
+    rule: &AnyRule,
+    example: &Example,
+    config: &LintConfig,
+    path: &Path,
+) -> Vec<Diagnostic> {
+    let Ok(dir) = tempfile::tempdir() else {
+        return Vec::new();
+    };
+    let root = dir.path();
+    let example_at = match rule {
+        AnyRule::R(_) => root.join("R").join("example.R"),
+        AnyRule::Dcf(_) => root.join("DESCRIPTION"),
+    };
+    let files = rule
+        .doc_package()
+        .iter()
+        .map(|(relative, contents)| (root.join(relative), *contents))
+        .chain(std::iter::once((example_at.clone(), example.source)));
+    for (at, contents) in files {
+        if at
+            .parent()
+            .is_some_and(|parent| std::fs::create_dir_all(parent).is_err())
+            || std::fs::write(&at, contents).is_err()
+        {
+            return Vec::new();
+        }
+    }
+
+    let Ok(result) = check_paths_with_config(&[root.to_path_buf()], config) else {
+        return Vec::new();
+    };
+    result
+        .reports
+        .into_iter()
+        .filter(|report| report.path == example_at)
+        .flat_map(|report| report.diagnostics)
+        .map(|mut d| {
+            d.path = path.to_path_buf();
+            d
+        })
+        .collect()
 }
 
 /// Render the whole rule reference: preamble, a per-category index, and every

--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -731,12 +731,6 @@ impl ResolvedRules {
         }
     }
 
-    /// Whether any `DESCRIPTION` rule is in this set. Lets the driver skip DCF
-    /// discovery and its whole pass when none is enabled.
-    pub fn has_dcf_rules(&self) -> bool {
-        !self.dcf_rules.is_empty()
-    }
-
     /// The rule IDs in this set.
     pub fn enabled(&self) -> &EnabledRules {
         &self.enabled
@@ -1072,7 +1066,6 @@ mod tests {
         );
         assert_eq!(resolved.rules.len(), 1);
         assert_eq!(resolved.dcf_rules.len(), 1);
-        assert!(resolved.has_dcf_rules());
         assert_eq!(resolved.by_kind[SyntaxKind::CALL_EXPR as usize], vec![0]);
         assert_eq!(
             resolved.dcf_by_kind[dcf::SyntaxKind::FIELD as usize],

--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -32,7 +32,7 @@ use crate::ast::{BinaryExpr, CallExpr};
 use crate::config::{CompatConfig, CompatVersion, LintConfig, RulesConfig};
 use crate::dcf;
 use crate::project::description::{DescriptionCompat, DescriptionFacts};
-use crate::project::{ExternalResolution, FileScope};
+use crate::project::{ExternalResolution, FileScope, PackageUsage};
 use crate::rindex::provider::CompositeProvider;
 use crate::semantic::{FileControlFlow, PackageOrigin, SemanticModel, SymbolProvider};
 use crate::syntax::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
@@ -200,6 +200,7 @@ fn packaging_rules() -> Vec<AnyRule> {
         AnyRule::Dcf(Box::new(packaging::DescriptionMissingField)),
         AnyRule::Dcf(Box::new(packaging::DescriptionDuplicateField)),
         AnyRule::Dcf(Box::new(packaging::DescriptionVersionConstraint)),
+        AnyRule::Dcf(Box::new(packaging::UnusedDependency)),
     ]
 }
 
@@ -969,6 +970,12 @@ pub struct DcfRuleContext<'a> {
     /// The facts this document declares, folded once per file so several rules
     /// don't refold the same fields. Derived from `document`, never from disk.
     pub facts: &'a DescriptionFacts,
+    /// The enclosing package's R-side dependency usage, when the caller
+    /// computed one — the cross-file driver does. `None` on the single-file
+    /// paths (`check_description_document`, the docs renderer), where a rule
+    /// that needs it must stay silent, exactly as the version-aware rules do
+    /// without a floor.
+    pub usage: Option<&'a PackageUsage>,
     /// Per-rule option tables from `[lint.rules.<id>]`. See [`RuleContext::config`].
     pub config: &'a RulesConfig,
     /// The document's `# arity-ignore` directives, used by [`run_dcf_rules`] to
@@ -992,6 +999,7 @@ pub fn run_dcf_rules(
     root: &dcf::SyntaxNode,
     document: &dcf::Document,
     facts: &DescriptionFacts,
+    usage: Option<&PackageUsage>,
 ) -> Vec<Diagnostic> {
     let suppressions = SuppressionMap::build_dcf(root);
     let ctx = DcfRuleContext {
@@ -999,6 +1007,7 @@ pub fn run_dcf_rules(
         root,
         document,
         facts,
+        usage,
         config: &resolved.rules_config,
         suppressions: &suppressions,
         enabled_rules: &resolved.enabled,
@@ -1112,6 +1121,7 @@ mod tests {
             &parsed.cst,
             &document,
             &facts,
+            None,
         )
     }
 

--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -44,6 +44,7 @@ pub mod correctness;
 pub mod documentation;
 pub mod matchers;
 pub mod meta;
+pub mod packaging;
 pub mod performance;
 pub mod readability;
 pub mod regex;
@@ -64,6 +65,10 @@ pub enum RuleCategory {
     Readability,
     Performance,
     Documentation,
+    /// The package's declared metadata, and whether it matches its code. The
+    /// one category spanning both grammars — an undeclared dependency and an
+    /// unused one are the same defect seen from two sides.
+    Packaging,
     Meta,
 }
 
@@ -76,6 +81,7 @@ impl RuleCategory {
             Self::Readability => "Readability",
             Self::Performance => "Performance",
             Self::Documentation => "Documentation",
+            Self::Packaging => "Packaging",
             Self::Meta => "Meta",
         }
     }
@@ -97,6 +103,7 @@ pub fn rules_by_category() -> Vec<(RuleCategory, Vec<AnyRule>)> {
         (RuleCategory::Readability, r_rules(readability_rules())),
         (RuleCategory::Performance, r_rules(performance_rules())),
         (RuleCategory::Documentation, r_rules(documentation_rules())),
+        (RuleCategory::Packaging, packaging_rules()),
         (RuleCategory::Meta, r_rules(meta_rules())),
     ]
 }
@@ -182,6 +189,16 @@ fn documentation_rules() -> Vec<Box<dyn Rule>> {
         Box::new(documentation::RoxygenParam),
         Box::new(documentation::RoxygenExamples),
         Box::new(documentation::Roxygen2Compat),
+    ]
+}
+
+/// The one category holding rules over both grammars, so it builds its
+/// `AnyRule`s directly rather than going through [`r_rules`].
+fn packaging_rules() -> Vec<AnyRule> {
+    vec![
+        AnyRule::Dcf(Box::new(packaging::DescriptionMissingField)),
+        AnyRule::Dcf(Box::new(packaging::DescriptionDuplicateField)),
+        AnyRule::Dcf(Box::new(packaging::DescriptionVersionConstraint)),
     ]
 }
 

--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -16,6 +16,11 @@
 //!    source of truth. Both the registry ([`all_rules`], and from it the set of
 //!    valid rule IDs, [`all_rule_ids`]) and the generated rule reference are
 //!    derived from it, so there is no second list to keep in sync.
+//!
+//! A rule over `DESCRIPTION` implements [`DcfRule`] instead and is registered as
+//! [`AnyRule::Dcf`] in the *same* catalogue: two grammars, one list of rules,
+//! one namespace of rule IDs. [`run_dcf_rules`] is that grammar's twin of
+//! [`run_rules`], with the same single-shared-walk discipline.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -25,6 +30,7 @@ use rowan::ast::AstNode as _;
 
 use crate::ast::{BinaryExpr, CallExpr};
 use crate::config::{CompatConfig, CompatVersion, LintConfig, RulesConfig};
+use crate::dcf;
 use crate::project::description::{DescriptionCompat, DescriptionFacts};
 use crate::project::{ExternalResolution, FileScope};
 use crate::rindex::provider::CompositeProvider;
@@ -78,19 +84,30 @@ impl RuleCategory {
 /// All rules currently shipped, grouped into the categories the reference page
 /// is organized by — the single source of truth. [`all_rules`] flattens this,
 /// so the registry order and the catalogue order are one list.
-pub fn rules_by_category() -> Vec<(RuleCategory, Vec<Box<dyn Rule>>)> {
+///
+/// Both grammars live in this one list. Merging them here rather than keeping a
+/// second DCF registry is what keeps the catalogue single-sourced: a parallel
+/// registry would have to be merged back per category to render one
+/// `## Correctness` section, and that merge would *be* a second source of truth
+/// for catalogue order.
+pub fn rules_by_category() -> Vec<(RuleCategory, Vec<AnyRule>)> {
     vec![
-        (RuleCategory::Correctness, correctness_rules()),
-        (RuleCategory::Suspicious, suspicious_rules()),
-        (RuleCategory::Readability, readability_rules()),
-        (RuleCategory::Performance, performance_rules()),
-        (RuleCategory::Documentation, documentation_rules()),
-        (RuleCategory::Meta, meta_rules()),
+        (RuleCategory::Correctness, r_rules(correctness_rules())),
+        (RuleCategory::Suspicious, r_rules(suspicious_rules())),
+        (RuleCategory::Readability, r_rules(readability_rules())),
+        (RuleCategory::Performance, r_rules(performance_rules())),
+        (RuleCategory::Documentation, r_rules(documentation_rules())),
+        (RuleCategory::Meta, r_rules(meta_rules())),
     ]
 }
 
+/// Lift a category's R rules into the mixed-grammar catalogue.
+fn r_rules(rules: Vec<Box<dyn Rule>>) -> Vec<AnyRule> {
+    rules.into_iter().map(AnyRule::R).collect()
+}
+
 /// All rules currently shipped, in registry order.
-pub fn all_rules() -> Vec<Box<dyn Rule>> {
+pub fn all_rules() -> Vec<AnyRule> {
     rules_by_category()
         .into_iter()
         .flat_map(|(_, rules)| rules)
@@ -179,6 +196,10 @@ fn meta_rules() -> Vec<Box<dyn Rule>> {
 
 /// Every shipped rule's ID, derived from [`all_rules`] so the two never drift.
 /// Used to validate `LintConfig::select` / `ignore`.
+///
+/// Both grammars' IDs, in one namespace: `select`, `ignore`, `# arity-ignore`,
+/// and `misnamed-suppression` all see one flat set of rule names, and none of
+/// them has to learn which file type a rule fires in.
 pub fn all_rule_ids() -> Vec<&'static str> {
     all_rules().iter().map(|r| r.id()).collect()
 }
@@ -280,6 +301,127 @@ pub trait Rule: Send + Sync {
     /// examples a floor to violate.
     fn doc_compat(&self) -> CompatConfig {
         CompatConfig::default()
+    }
+}
+
+/// A rule over the DCF grammar — `DESCRIPTION`, not R.
+///
+/// Same discipline as [`Rule`], one grammar over: declare the DCF
+/// [`SyntaxKind`](dcf::SyntaxKind)s you care about via [`DcfRule::interests`]
+/// and implement [`DcfRule::check`], or leave `interests` empty and override
+/// [`DcfRule::check_file`]. [`run_dcf_rules`] walks the document once.
+///
+/// The metadata half is spelled out again rather than factored into a supertrait
+/// shared with [`Rule`]: a supertrait would mean splitting every existing `impl
+/// Rule` in two for no behavior change, and [`AnyRule`] already gives the
+/// catalogue one grammar-blind view of it.
+pub trait DcfRule: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+    fn default_enabled(&self) -> bool {
+        true
+    }
+
+    /// See [`Rule::description`].
+    fn description(&self) -> &'static str {
+        ""
+    }
+
+    /// See [`Rule::examples`]. A DCF rule's `source` is `DESCRIPTION` text, and
+    /// the docs renderer lints it under that file name.
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
+
+    /// See [`Rule::doc_select`].
+    fn doc_select(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// The DCF `SyntaxKind`s this rule subscribes to, for [`run_dcf_rules`]'
+    /// shared traversal. The default opts out of node dispatch entirely.
+    fn interests(&self) -> &'static [dcf::SyntaxKind] {
+        &[]
+    }
+
+    /// Per-element callback, invoked for each DCF element (node *or* token)
+    /// whose kind is in [`DcfRule::interests`].
+    fn check(&self, el: &dcf::SyntaxElement, ctx: &DcfRuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        let _ = (el, ctx, sink);
+    }
+
+    /// Whole-document pass, run once after the shared traversal. The natural
+    /// shape for a rule keyed on a *field* rather than on node shape, which is
+    /// most of them.
+    fn check_file(&self, ctx: &DcfRuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        let _ = (ctx, sink);
+    }
+}
+
+/// A registered rule, whichever grammar it runs over.
+///
+/// The catalogue is one list ([`rules_by_category`]), so everything derived from
+/// it — the valid rule IDs, the reference page, `select`/`ignore` resolution —
+/// is written once and sees both grammars. Dispatch is the only place the
+/// distinction matters, and [`ResolvedRules`] splits it exactly once.
+pub enum AnyRule {
+    R(Box<dyn Rule>),
+    Dcf(Box<dyn DcfRule>),
+}
+
+impl AnyRule {
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::R(rule) => rule.id(),
+            Self::Dcf(rule) => rule.id(),
+        }
+    }
+
+    pub fn default_severity(&self) -> Severity {
+        match self {
+            Self::R(rule) => rule.default_severity(),
+            Self::Dcf(rule) => rule.default_severity(),
+        }
+    }
+
+    pub fn default_enabled(&self) -> bool {
+        match self {
+            Self::R(rule) => rule.default_enabled(),
+            Self::Dcf(rule) => rule.default_enabled(),
+        }
+    }
+
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::R(rule) => rule.description(),
+            Self::Dcf(rule) => rule.description(),
+        }
+    }
+
+    pub fn examples(&self) -> &'static [Example] {
+        match self {
+            Self::R(rule) => rule.examples(),
+            Self::Dcf(rule) => rule.examples(),
+        }
+    }
+
+    pub fn doc_select(&self) -> &'static [&'static str] {
+        match self {
+            Self::R(rule) => rule.doc_select(),
+            Self::Dcf(rule) => rule.doc_select(),
+        }
+    }
+
+    /// The `[compat]` floors this rule's examples are linted under. Only the R
+    /// version-aware rules declare any; `DESCRIPTION` *is* the compat source, so
+    /// a DCF rule has nothing to say here.
+    pub fn doc_compat(&self) -> CompatConfig {
+        match self {
+            Self::R(rule) => rule.doc_compat(),
+            Self::Dcf(_) => CompatConfig::default(),
+        }
     }
 }
 
@@ -511,8 +653,16 @@ pub struct ResolvedRules {
     /// Whether any rule subscribed to a node kind at all — lets [`run_rules`]
     /// skip the whole-tree traversal when every rule is `check_file`-only.
     any_node_rules: bool,
-    /// Each rule ID's [`Rule::default_severity`], so the severity-stamping pass
-    /// is an `O(1)` lookup keyed by the finding's rule ID.
+    /// The DESCRIPTION rules in this set, and their own dispatch table over the
+    /// DCF `SyntaxKind`s. A second, independent table rather than a widened
+    /// first one: a run over R files never touches it, so the R hot path below
+    /// keeps the exact indices and types it had before DCF existed.
+    dcf_rules: Vec<Box<dyn DcfRule>>,
+    dcf_by_kind: Vec<Vec<usize>>,
+    dcf_any_node_rules: bool,
+    /// Each rule ID's default severity, so the severity-stamping pass is an
+    /// `O(1)` lookup keyed by the finding's rule ID. Covers **both** grammars —
+    /// stamping is one rule, whatever the file type.
     severities: HashMap<&'static str, Severity>,
     /// The chosen rule IDs, handed to rules via [`RuleContext::enabled_rules`].
     enabled: EnabledRules,
@@ -530,11 +680,25 @@ pub struct ResolvedRules {
 impl ResolvedRules {
     /// Build the derived dispatch state (`by_kind`, `severities`) for a chosen
     /// rule set. The single place that knows how a rule set maps to dispatch.
-    fn with_config(
-        rules: Vec<Box<dyn Rule>>,
-        rules_config: RulesConfig,
-        compat: CompatConfig,
-    ) -> Self {
+    fn with_config(chosen: Vec<AnyRule>, rules_config: RulesConfig, compat: CompatConfig) -> Self {
+        // Severities and the enabled-ID set are built from the *whole* chosen
+        // set, before the grammar split: both are keyed by rule ID, and IDs are
+        // one namespace.
+        let severities = chosen
+            .iter()
+            .map(|r| (r.id(), r.default_severity()))
+            .collect();
+        let enabled = EnabledRules(chosen.iter().map(|r| r.id()).collect());
+
+        let mut rules: Vec<Box<dyn Rule>> = Vec::new();
+        let mut dcf_rules: Vec<Box<dyn DcfRule>> = Vec::new();
+        for rule in chosen {
+            match rule {
+                AnyRule::R(rule) => rules.push(rule),
+                AnyRule::Dcf(rule) => dcf_rules.push(rule),
+            }
+        }
+
         let mut by_kind: Vec<Vec<usize>> = vec![Vec::new(); SyntaxKind::COUNT];
         let mut any_node_rules = false;
         for (i, rule) in rules.iter().enumerate() {
@@ -543,20 +707,34 @@ impl ResolvedRules {
                 any_node_rules = true;
             }
         }
-        let severities = rules
-            .iter()
-            .map(|r| (r.id(), r.default_severity()))
-            .collect();
-        let enabled = EnabledRules(rules.iter().map(|r| r.id()).collect());
+
+        let mut dcf_by_kind: Vec<Vec<usize>> = vec![Vec::new(); dcf::SyntaxKind::COUNT];
+        let mut dcf_any_node_rules = false;
+        for (i, rule) in dcf_rules.iter().enumerate() {
+            for kind in rule.interests() {
+                dcf_by_kind[*kind as usize].push(i);
+                dcf_any_node_rules = true;
+            }
+        }
+
         Self {
             rules,
             by_kind,
             any_node_rules,
+            dcf_rules,
+            dcf_by_kind,
+            dcf_any_node_rules,
             severities,
             enabled,
             rules_config,
             compat,
         }
+    }
+
+    /// Whether any `DESCRIPTION` rule is in this set. Lets the driver skip DCF
+    /// discovery and its whole pass when none is enabled.
+    pub fn has_dcf_rules(&self) -> bool {
+        !self.dcf_rules.is_empty()
     }
 
     /// The rule IDs in this set.
@@ -589,7 +767,7 @@ impl ResolvedRules {
                 unknown.push(id.clone());
             }
         }
-        let mut chosen: Vec<Box<dyn Rule>> = match select {
+        let mut chosen: Vec<AnyRule> = match select {
             Some(picks) => all
                 .into_iter()
                 .filter(|r| picks.iter().any(|p| p == r.id()))
@@ -684,14 +862,23 @@ pub fn run_rules(
         all.append(&mut post);
     }
 
-    // Stamp each finding's severity from its rule's `default_severity()`. Rules
-    // build findings with a placeholder severity (`Default::default()`); the
-    // authoritative value lives on the rule, so overriding `default_severity()`
-    // actually takes effect here (and is the natural seam for a future per-rule
-    // severity config override). Keyed by rule ID against the parallel `rules`
-    // /`severities` vecs — a whole-file pass may interleave findings from
-    // several rules, so post-hoc lookup is simpler than tracking emit order.
-    for d in &mut all {
+    stamp_and_sort(resolved, &mut all);
+    all
+}
+
+/// Stamp each finding's severity from its rule's `default_severity()`, then
+/// apply the stable `(start, end, rule)` ordering.
+///
+/// Rules build findings with a placeholder severity (`Default::default()`); the
+/// authoritative value lives on the rule, so overriding `default_severity()`
+/// actually takes effect here (and is the natural seam for a future per-rule
+/// severity config override). Keyed by rule ID rather than by emit order — a
+/// whole-file pass may interleave findings from several rules.
+///
+/// Shared by both grammars' drivers so the two can never drift on severity or
+/// ordering.
+fn stamp_and_sort(resolved: &ResolvedRules, all: &mut [Diagnostic]) {
+    for d in all.iter_mut() {
         if let Some(&sev) = resolved.severities.get(d.rule) {
             d.severity = sev;
         }
@@ -704,6 +891,77 @@ pub fn run_rules(
             b.rule,
         ))
     });
+}
+
+/// What a [`DcfRule`] gets to see: one parsed `DESCRIPTION`, and the facts
+/// derived from it.
+///
+/// Deliberately narrow. There is no `compat` (this file *is* the compat
+/// source), none of the R-grammar state, and no lazily-resolved disk fallback —
+/// unlike [`RuleContext`], whose `own_package`/`description_compat` exist
+/// precisely because an R file has to go looking for the document a DCF rule is
+/// already holding.
+pub struct DcfRuleContext<'a> {
+    /// The `DESCRIPTION`'s path. Its parent is the package root.
+    pub path: &'a Path,
+    /// The DCF CST root, for a rule that wants raw tokens or ranges.
+    pub root: &'a dcf::SyntaxNode,
+    /// The typed view — how a rule reads fields.
+    pub document: &'a dcf::Document,
+    /// The facts this document declares, folded once per file so several rules
+    /// don't refold the same fields. Derived from `document`, never from disk.
+    pub facts: &'a DescriptionFacts,
+    /// Per-rule option tables from `[lint.rules.<id>]`. See [`RuleContext::config`].
+    pub config: &'a RulesConfig,
+    /// The document's `# arity-ignore` directives, used by [`run_dcf_rules`] to
+    /// drop suppressed findings.
+    pub suppressions: &'a SuppressionMap,
+    /// The rule IDs running in this pass. See [`RuleContext::enabled_rules`].
+    pub enabled_rules: &'a EnabledRules,
+}
+
+/// Run every configured `DESCRIPTION` rule against one parsed document — the
+/// DCF twin of [`run_rules`], and subject to the same contract: one shared
+/// traversal, suppression filtered here rather than by the caller, findings
+/// stamped and stably sorted.
+///
+/// No post-suppression pass: `Rule::check_suppressions` exists for
+/// `outdated-suppression`, which has no DCF counterpart yet. Adding one is a
+/// default method away.
+pub fn run_dcf_rules(
+    resolved: &ResolvedRules,
+    path: &Path,
+    root: &dcf::SyntaxNode,
+    document: &dcf::Document,
+    facts: &DescriptionFacts,
+) -> Vec<Diagnostic> {
+    let suppressions = SuppressionMap::build_dcf(root);
+    let ctx = DcfRuleContext {
+        path,
+        root,
+        document,
+        facts,
+        config: &resolved.rules_config,
+        suppressions: &suppressions,
+        enabled_rules: &resolved.enabled,
+    };
+    let rules = &resolved.dcf_rules;
+    let mut all = Vec::new();
+
+    if resolved.dcf_any_node_rules {
+        for el in root.descendants_with_tokens() {
+            for &i in &resolved.dcf_by_kind[el.kind() as usize] {
+                rules[i].check(&el, &ctx, &mut all);
+            }
+        }
+    }
+
+    for rule in rules {
+        rule.check_file(&ctx, &mut all);
+    }
+
+    suppressions.filter(&mut all);
+    stamp_and_sort(resolved, &mut all);
     all
 }
 
@@ -747,6 +1005,167 @@ mod tests {
         }
     }
 
+    /// The DCF twin of [`FakeError`]: subscribes to every `FIELD` and emits a
+    /// finding with the placeholder severity, so the same stamping and
+    /// suppression contract can be asserted over the second grammar.
+    struct FakeDcfError;
+    impl DcfRule for FakeDcfError {
+        fn id(&self) -> &'static str {
+            "fake-dcf-error"
+        }
+        fn default_severity(&self) -> Severity {
+            Severity::Error
+        }
+        fn interests(&self) -> &'static [dcf::SyntaxKind] {
+            &[dcf::SyntaxKind::FIELD]
+        }
+        fn check(
+            &self,
+            el: &dcf::SyntaxElement,
+            _ctx: &DcfRuleContext<'_>,
+            sink: &mut Vec<Diagnostic>,
+        ) {
+            sink.push(Diagnostic {
+                rule: "fake-dcf-error",
+                severity: Default::default(),
+                path: Default::default(),
+                range: el.text_range(),
+                message: ViolationData::new("fake-dcf-error", "boom"),
+                fix: None,
+            });
+        }
+    }
+
+    fn dcf_resolved() -> ResolvedRules {
+        ResolvedRules::with_config(
+            vec![AnyRule::Dcf(Box::new(FakeDcfError))],
+            RulesConfig::default(),
+            CompatConfig::default(),
+        )
+    }
+
+    fn run_dcf(resolved: &ResolvedRules, text: &str) -> Vec<Diagnostic> {
+        let parsed = crate::dcf::parse(text);
+        let document = parsed.document();
+        let facts = DescriptionFacts::from_document(&document);
+        run_dcf_rules(
+            resolved,
+            Path::new("DESCRIPTION"),
+            &parsed.cst,
+            &document,
+            &facts,
+        )
+    }
+
+    /// The grammar split happens exactly once, in `with_config`: a DCF rule
+    /// lands in the DCF dispatch table and never in the R one, so the R hot
+    /// path cannot pay for it.
+    #[test]
+    fn with_config_files_rules_by_grammar() {
+        let resolved = ResolvedRules::with_config(
+            vec![
+                AnyRule::R(Box::new(FakeError)),
+                AnyRule::Dcf(Box::new(FakeDcfError)),
+            ],
+            RulesConfig::default(),
+            CompatConfig::default(),
+        );
+        assert_eq!(resolved.rules.len(), 1);
+        assert_eq!(resolved.dcf_rules.len(), 1);
+        assert!(resolved.has_dcf_rules());
+        assert_eq!(resolved.by_kind[SyntaxKind::CALL_EXPR as usize], vec![0]);
+        assert_eq!(
+            resolved.dcf_by_kind[dcf::SyntaxKind::FIELD as usize],
+            vec![0]
+        );
+        // One namespace of IDs and one severity map, whatever the grammar.
+        assert!(resolved.enabled().contains("fake-error"));
+        assert!(resolved.enabled().contains("fake-dcf-error"));
+    }
+
+    #[test]
+    fn run_dcf_rules_stamps_default_severity() {
+        let diags = run_dcf(&dcf_resolved(), "Package: p\n");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+    }
+
+    /// A `# arity-ignore` line in a `DESCRIPTION` suppresses the field that
+    /// follows it, the DCF answer to "the next non-trivia sibling".
+    #[test]
+    fn run_dcf_rules_filters_suppressed_findings() {
+        let diags = run_dcf(
+            &dcf_resolved(),
+            "# arity-ignore fake-dcf-error: quiet\nPackage: p\n",
+        );
+        assert!(diags.is_empty(), "expected no findings, got {diags:?}");
+    }
+
+    /// The range of `field` in `text`, for asserting *which* finding survived.
+    fn field_range(text: &str, name: &str) -> rowan::TextRange {
+        crate::dcf::parse(text)
+            .document()
+            .field(name)
+            .unwrap_or_else(|| panic!("a `{name}` field"))
+            .syntax()
+            .text_range()
+    }
+
+    /// The directive reaches only the field it precedes — the next-item scope
+    /// must not silently widen to the whole record.
+    #[test]
+    fn dcf_node_directive_covers_only_the_next_field() {
+        let text = "# arity-ignore fake-dcf-error: quiet\nPackage: p\nVersion: 1.0\n";
+        let diags = run_dcf(&dcf_resolved(), text);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range, field_range(text, "Version"));
+    }
+
+    /// A comment *between* two fields is grammatically a child of the earlier
+    /// one — a `FIELD` stays open across its continuation lines — but it points
+    /// at the field that follows, which is what its author meant.
+    #[test]
+    fn dcf_trailing_directive_covers_the_following_field() {
+        let text = "Package: p\n# arity-ignore fake-dcf-error: quiet\nVersion: 1.0\n";
+        let diags = run_dcf(&dcf_resolved(), text);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].range, field_range(text, "Package"));
+    }
+
+    /// A comment *inside* a field's continuation attaches to that field: R
+    /// skips the line and resumes the value, so there is no "next line" that
+    /// means anything else.
+    #[test]
+    fn dcf_directive_inside_a_field_covers_that_field() {
+        let diags = run_dcf(
+            &dcf_resolved(),
+            "Imports:\n    dplyr,\n# arity-ignore fake-dcf-error: quiet\n    rlang\n",
+        );
+        assert!(diags.is_empty(), "expected no findings, got {diags:?}");
+    }
+
+    #[test]
+    fn dcf_file_directive_covers_the_whole_document() {
+        let diags = run_dcf(
+            &dcf_resolved(),
+            "# arity-ignore-file: quiet\nPackage: p\nVersion: 1.0\n",
+        );
+        assert!(diags.is_empty(), "expected no findings, got {diags:?}");
+    }
+
+    /// A directive with nothing after it is dangling, exactly as in R — it is
+    /// recorded (so the `meta` rules can see it) but suppresses nothing. The
+    /// blank line closes the record, and a comment never opens one, so nothing
+    /// follows this directive even though the file continues.
+    #[test]
+    fn dcf_dangling_directive_suppresses_nothing() {
+        let text = "Package: p\n\n# arity-ignore fake-dcf-error: quiet\n";
+        let map = SuppressionMap::build_dcf(&crate::dcf::parse(text).cst);
+        assert_eq!(map.directives().len(), 1);
+        assert!(map.directives()[0].is_dangling());
+        assert_eq!(run_dcf(&dcf_resolved(), text).len(), 1);
+    }
+
     #[test]
     fn run_rules_stamps_default_severity() {
         let root = crate::parser::parse("f(1)").cst;
@@ -754,7 +1173,7 @@ mod tests {
         let cfg = FileControlFlow::build(&root);
         let symbols = crate::semantic::StaticBaseR::new();
         let resolved = ResolvedRules::with_config(
-            vec![Box::new(FakeError)],
+            vec![AnyRule::R(Box::new(FakeError))],
             RulesConfig::default(),
             CompatConfig::default(),
         );
@@ -784,7 +1203,7 @@ mod tests {
         let cfg = FileControlFlow::build(&root);
         let symbols = crate::semantic::StaticBaseR::new();
         let resolved = ResolvedRules::with_config(
-            vec![Box::new(FakeError)],
+            vec![AnyRule::R(Box::new(FakeError))],
             RulesConfig::default(),
             CompatConfig::default(),
         );
@@ -807,7 +1226,7 @@ mod tests {
     #[test]
     fn enabled_rules_reflects_the_resolved_set() {
         let resolved = ResolvedRules::with_config(
-            vec![Box::new(FakeError)],
+            vec![AnyRule::R(Box::new(FakeError))],
             RulesConfig::default(),
             CompatConfig::default(),
         );

--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -25,7 +25,7 @@ use rowan::ast::AstNode as _;
 
 use crate::ast::{BinaryExpr, CallExpr};
 use crate::config::{CompatConfig, CompatVersion, LintConfig, RulesConfig};
-use crate::project::description::DescriptionCompat;
+use crate::project::description::{DescriptionCompat, DescriptionFacts};
 use crate::project::{ExternalResolution, FileScope};
 use crate::rindex::provider::CompositeProvider;
 use crate::semantic::{FileControlFlow, PackageOrigin, SemanticModel, SymbolProvider};
@@ -312,6 +312,12 @@ pub struct RuleContext<'a> {
     /// result instead of re-running masking on every keystroke. `None` on the
     /// single-file paths, where the rule falls back to [`RuleContext::symbols`].
     pub resolution: Option<&'a ExternalResolution>,
+    /// The enclosing package's `DESCRIPTION` facts, when the caller already
+    /// resolved them — the cross-file paths read them from the tracked
+    /// `DESCRIPTION` input. `None` on the single-file paths, where
+    /// [`RuleContext::own_package`] and the compat floors fall back to the lazy
+    /// disk walk below.
+    pub package: Option<&'a DescriptionFacts>,
     /// Per-rule option tables from `[lint.rules.<id>]`, resolved once per run and
     /// carried on [`ResolvedRules`]. Rules that take no options ignore this.
     pub config: &'a RulesConfig,
@@ -351,6 +357,9 @@ impl RuleContext<'_> {
     /// a different question from cross-file visibility ([`RuleContext::project`]
     /// answers that, and is `None` on the single-file paths).
     pub fn own_package(&self) -> Option<&str> {
+        if let Some(facts) = self.package {
+            return facts.package.as_deref();
+        }
         self.own_package
             .get_or_init(|| crate::project::description::package_name_for_file(self.path))
             .as_deref()
@@ -378,6 +387,9 @@ impl RuleContext<'_> {
     }
 
     fn description_compat(&self) -> &DescriptionCompat {
+        if let Some(facts) = self.package {
+            return &facts.compat;
+        }
         self.description_compat
             .get_or_init(|| crate::project::description::description_compat_for_file(self.path))
     }
@@ -619,6 +631,7 @@ pub fn run_rules(
     symbols: &dyn SymbolProvider,
     project: Option<&FileScope<'_>>,
     resolution: Option<&ExternalResolution>,
+    package: Option<&DescriptionFacts>,
 ) -> Vec<Diagnostic> {
     let suppressions = SuppressionMap::build(root);
     let ctx = RuleContext {
@@ -629,6 +642,7 @@ pub fn run_rules(
         symbols,
         project,
         resolution,
+        package,
         config: &resolved.rules_config,
         suppressions: &suppressions,
         enabled_rules: &resolved.enabled,
@@ -753,6 +767,7 @@ mod tests {
             &symbols,
             None,
             None,
+            None,
         );
         assert_eq!(diags.len(), 1);
         // Emitted with the `Warning` placeholder; the override stamps `Error`.
@@ -780,6 +795,7 @@ mod tests {
             &model,
             &cfg,
             &symbols,
+            None,
             None,
             None,
         );
@@ -814,6 +830,7 @@ mod tests {
             symbols: &symbols,
             project: None,
             resolution: None,
+            package: None,
             config: &RulesConfig::default(),
             suppressions: &SuppressionMap::default(),
             enabled_rules: &EnabledRules::default(),

--- a/src/linter/rules.rs
+++ b/src/linter/rules.rs
@@ -196,6 +196,7 @@ fn documentation_rules() -> Vec<Box<dyn Rule>> {
 /// `AnyRule`s directly rather than going through [`r_rules`].
 fn packaging_rules() -> Vec<AnyRule> {
     vec![
+        AnyRule::R(Box::new(packaging::UndeclaredDependency)),
         AnyRule::Dcf(Box::new(packaging::DescriptionMissingField)),
         AnyRule::Dcf(Box::new(packaging::DescriptionDuplicateField)),
         AnyRule::Dcf(Box::new(packaging::DescriptionVersionConstraint)),
@@ -319,6 +320,20 @@ pub trait Rule: Send + Sync {
     fn doc_compat(&self) -> CompatConfig {
         CompatConfig::default()
     }
+
+    /// A synthetic package this rule's [`Rule::examples`] are linted *inside*:
+    /// `(relative path, contents)` pairs written to a temporary directory, with
+    /// the example itself placed at `R/example.R`.
+    ///
+    /// The escape hatch for a rule whose subject is a package-level fact.
+    /// `check_document`'s single-file path leaves `RuleContext::package` and
+    /// `project` `None`, so such a rule is silent there by construction — and an
+    /// example that produces no finding is not documentation. Same shape and
+    /// same reason as [`Rule::doc_compat`]. The default is none, which lints the
+    /// example as the loose script it looks like.
+    fn doc_package(&self) -> &'static [(&'static str, &'static str)] {
+        &[]
+    }
 }
 
 /// A rule over the DCF grammar — `DESCRIPTION`, not R.
@@ -354,6 +369,13 @@ pub trait DcfRule: Send + Sync {
 
     /// See [`Rule::doc_select`].
     fn doc_select(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// See [`Rule::doc_package`]. The example itself is placed at the package's
+    /// `DESCRIPTION`, so a fixture only supplies the `R/` sources and NAMESPACE
+    /// the rule reads.
+    fn doc_package(&self) -> &'static [(&'static str, &'static str)] {
         &[]
     }
 
@@ -440,6 +462,13 @@ impl AnyRule {
             Self::Dcf(_) => CompatConfig::default(),
         }
     }
+
+    pub fn doc_package(&self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            Self::R(rule) => rule.doc_package(),
+            Self::Dcf(rule) => rule.doc_package(),
+        }
+    }
 }
 
 /// The rule IDs running in a pass, after `select`/`ignore`. Lets a rule tell
@@ -522,6 +551,24 @@ impl RuleContext<'_> {
         self.own_package
             .get_or_init(|| crate::project::description::package_name_for_file(self.path))
             .as_deref()
+    }
+
+    /// Whether this file is one of its package's R sources — a direct member of
+    /// `<root>/R/`.
+    ///
+    /// R loads `R/*.R` flat (it does not recurse), so the parent directory's
+    /// name plus the presence of package facts is exact. Deliberately narrower
+    /// than "belongs to a package": [`RuleContext::package`] resolves for a
+    /// `tests/testthat/` file too, since it walks up to the package root — and
+    /// a test file is not code R will load, which is exactly the distinction a
+    /// dependency check needs and `internal-function` needs the opposite of.
+    pub fn is_package_r_source(&self) -> bool {
+        self.package.is_some()
+            && self
+                .path
+                .parent()
+                .and_then(Path::file_name)
+                .is_some_and(|dir| dir == "R")
     }
 
     /// The minimum supported R version this file targets, or `None` when no

--- a/src/linter/rules/correctness/undefined_symbol.rs
+++ b/src/linter/rules/correctness/undefined_symbol.rs
@@ -84,23 +84,36 @@ impl UndefinedSymbol {
     /// the [`RuleContext::symbols`] provider directly.
     fn run_standalone(&self, ctx: &RuleContext<'_>, sink: &mut Vec<Diagnostic>) {
         // Fold in packages attached by the file's location (e.g. testthat for a
-        // `tests/testthat/` file), which no `library()` call names. Allocate only
-        // when there is something to add — the common case keeps the model's slice.
+        // `tests/testthat/` file), which no `library()` call names, and the ones
+        // the package's NAMESPACE `import()`s wholesale — every export of those
+        // is in scope here, which for resolution is the same thing as attached.
+        // Allocate only when there is something to add: the common case keeps
+        // the model's slice.
         let implicit = implicit_attached_packages(ctx.path);
-        let augmented: Vec<LoadedPackage>;
-        let loaded: &[LoadedPackage] = if implicit.is_empty() {
+        let wildcards = ctx
+            .project
+            .map(|p| p.wildcard_import_packages().iter().map(String::as_str))
+            .into_iter()
+            .flatten();
+        let augmented: Vec<LoadedPackage> = ctx
+            .model
+            .loaded_packages()
+            .iter()
+            .cloned()
+            .chain(
+                implicit
+                    .iter()
+                    .copied()
+                    .chain(wildcards)
+                    .map(|name| LoadedPackage {
+                        name: SmolStr::new(name),
+                        range: TextRange::default(),
+                    }),
+            )
+            .collect();
+        let loaded: &[LoadedPackage] = if augmented.len() == ctx.model.loaded_packages().len() {
             ctx.model.loaded_packages()
         } else {
-            augmented = ctx
-                .model
-                .loaded_packages()
-                .iter()
-                .cloned()
-                .chain(implicit.iter().map(|name| LoadedPackage {
-                    name: SmolStr::new(name),
-                    range: TextRange::default(),
-                }))
-                .collect();
             &augmented
         };
         // Conservative gate: bail out entirely if any attached package's exports
@@ -118,9 +131,10 @@ impl UndefinedSymbol {
         }) {
             return;
         }
-        // Conservative gate: incomplete cross-file visibility (an unresolved
-        // `source()`, or a wholesale `import(pkg)`) could define any of the
-        // names below.
+        // Conservative gate: cross-file visibility left incomplete by something
+        // nothing can resolve — a dynamic or unanalyzed `source()` — could
+        // define any of the names below. A wholesale `import(pkg)` is *not*
+        // that: it went through the enumerability gate above.
         if ctx.project.is_some_and(|p| p.resolution_incomplete) {
             return;
         }

--- a/src/linter/rules/correctness/undefined_symbol.rs
+++ b/src/linter/rules/correctness/undefined_symbol.rs
@@ -90,32 +90,30 @@ impl UndefinedSymbol {
         // Allocate only when there is something to add: the common case keeps
         // the model's slice.
         let implicit = implicit_attached_packages(ctx.path);
-        let wildcards = ctx
-            .project
-            .map(|p| p.wildcard_import_packages().iter().map(String::as_str))
-            .into_iter()
-            .flatten();
-        let augmented: Vec<LoadedPackage> = ctx
-            .model
-            .loaded_packages()
-            .iter()
-            .cloned()
-            .chain(
-                implicit
+        let wildcards = ctx.project.map(|p| p.wildcard_import_packages());
+        let augmented: Vec<LoadedPackage>;
+        let loaded: &[LoadedPackage] =
+            if implicit.is_empty() && wildcards.is_none_or(|packages| packages.is_empty()) {
+                ctx.model.loaded_packages()
+            } else {
+                augmented = ctx
+                    .model
+                    .loaded_packages()
                     .iter()
-                    .copied()
-                    .chain(wildcards)
-                    .map(|name| LoadedPackage {
-                        name: SmolStr::new(name),
-                        range: TextRange::default(),
-                    }),
-            )
-            .collect();
-        let loaded: &[LoadedPackage] = if augmented.len() == ctx.model.loaded_packages().len() {
-            ctx.model.loaded_packages()
-        } else {
-            &augmented
-        };
+                    .cloned()
+                    .chain(
+                        implicit
+                            .iter()
+                            .copied()
+                            .chain(wildcards.into_iter().flatten().map(String::as_str))
+                            .map(|name| LoadedPackage {
+                                name: SmolStr::new(name),
+                                range: TextRange::default(),
+                            }),
+                    )
+                    .collect();
+                &augmented
+            };
         // Conservative gate: bail out entirely if any attached package's exports
         // are unknown, since such a package could define the unresolved names. A
         // meta-package (e.g. tidyverse) also attaches its core members (the

--- a/src/linter/rules/matchers.rs
+++ b/src/linter/rules/matchers.rs
@@ -96,9 +96,9 @@ pub fn sole_positional(call: &CallExpr) -> Option<SyntaxElement> {
 // --- package loads ---------------------------------------------------------
 
 /// The base callees whose `package` argument names a package, exactly the set
-/// `tools:::.check_packages_used` matches.
-pub const PACKAGE_LOAD_CALLS: [&str; 4] =
-    ["library", "require", "requireNamespace", "loadNamespace"];
+/// `tools:::.check_packages_used` matches. Owned by the semantic layer, which
+/// records the same calls, so the two readings cannot drift.
+pub use crate::semantic::symbols::PACKAGE_LOAD_CALLS;
 
 /// The package `call` names and the token to span, when `call` is one of
 /// [`PACKAGE_LOAD_CALLS`] and its `package` argument is a bare name or a string

--- a/src/linter/rules/matchers.rs
+++ b/src/linter/rules/matchers.rs
@@ -93,6 +93,42 @@ pub fn sole_positional(call: &CallExpr) -> Option<SyntaxElement> {
     only.value
 }
 
+// --- package loads ---------------------------------------------------------
+
+/// The base callees whose `package` argument names a package, exactly the set
+/// `tools:::.check_packages_used` matches.
+pub const PACKAGE_LOAD_CALLS: [&str; 4] =
+    ["library", "require", "requireNamespace", "loadNamespace"];
+
+/// The package `call` names and the token to span, when `call` is one of
+/// [`PACKAGE_LOAD_CALLS`] and its `package` argument is a bare name or a string
+/// literal.
+///
+/// `None` for a computed argument, for `character.only = TRUE` (where a symbol
+/// names a variable holding the package name, not the package), and for R's
+/// `common_names` placeholders — none of which name a package statically, so
+/// matching them could only ever invent a finding.
+pub fn package_load_arg(call: &CallExpr) -> Option<(SmolStr, SyntaxToken)> {
+    if !PACKAGE_LOAD_CALLS.contains(&callee_name(call)?.as_str()) {
+        return None;
+    }
+    // `character.only = TRUE` says the argument is a variable, by contract.
+    if named_arg(call, "character.only").is_some_and(|el| is_true(&el)) {
+        return None;
+    }
+    let value = named_arg(call, "package").or_else(|| nth_arg(call, 0))?;
+    let token = value.as_token()?;
+    let name = match token.kind() {
+        SyntaxKind::IDENT => SmolStr::new(token.text()),
+        SyntaxKind::STRING => SmolStr::new(string_literal(token)?.1),
+        _ => return None,
+    };
+    if name.is_empty() || crate::semantic::symbols::is_package_name_placeholder(&name) {
+        return None;
+    }
+    Some((name, token.clone()))
+}
+
 // --- binary expressions ----------------------------------------------------
 
 /// Split a `BINARY_EXPR` into `(lhs, operator, rhs)` at its top-level operator

--- a/src/linter/rules/packaging.rs
+++ b/src/linter/rules/packaging.rs
@@ -9,7 +9,9 @@
 mod description_duplicate_field;
 mod description_missing_field;
 mod description_version_constraint;
+mod undeclared_dependency;
 
 pub use description_duplicate_field::DescriptionDuplicateField;
 pub use description_missing_field::DescriptionMissingField;
 pub use description_version_constraint::DescriptionVersionConstraint;
+pub use undeclared_dependency::UndeclaredDependency;

--- a/src/linter/rules/packaging.rs
+++ b/src/linter/rules/packaging.rs
@@ -1,0 +1,15 @@
+//! Packaging rules: the package's declared metadata, and whether it matches
+//! its code.
+//!
+//! The one category holding rules over both grammars. That is deliberate: a
+//! dependency the code uses and `DESCRIPTION` does not declare, and one
+//! `DESCRIPTION` declares and no code reaches, are the same defect seen from
+//! two sides, and a reader looking for either should find both in one place.
+
+mod description_duplicate_field;
+mod description_missing_field;
+mod description_version_constraint;
+
+pub use description_duplicate_field::DescriptionDuplicateField;
+pub use description_missing_field::DescriptionMissingField;
+pub use description_version_constraint::DescriptionVersionConstraint;

--- a/src/linter/rules/packaging.rs
+++ b/src/linter/rules/packaging.rs
@@ -10,8 +10,10 @@ mod description_duplicate_field;
 mod description_missing_field;
 mod description_version_constraint;
 mod undeclared_dependency;
+mod unused_dependency;
 
 pub use description_duplicate_field::DescriptionDuplicateField;
 pub use description_missing_field::DescriptionMissingField;
 pub use description_version_constraint::DescriptionVersionConstraint;
 pub use undeclared_dependency::UndeclaredDependency;
+pub use unused_dependency::UnusedDependency;

--- a/src/linter/rules/packaging/description_duplicate_field.rs
+++ b/src/linter/rules/packaging/description_duplicate_field.rs
@@ -1,0 +1,105 @@
+//! `description-duplicate-field`: a `DESCRIPTION` field declared more than once.
+//!
+//! A repeated field is always a mistake, but it is a *silent* one: nothing
+//! errors, and the file keeps whichever value the reader happens to pick. Which
+//! is the problem — the readers disagree. R's `read.dcf` takes the **last**
+//! occurrence; arity takes the **first**, deliberately and consistently
+//! (`dcf::Document::field`). So a duplicated `Version` means R and arity are
+//! reading two different packages, and every tool downstream of either inherits
+//! that split.
+//!
+//! This rule is where the divergence becomes visible instead of silent. It does
+//! not resolve it: which reading is right is a question about the DCF parser,
+//! answered by its own change with the `read.dcf` oracle to prove it (see
+//! `TODO.md`). Until then, saying so at the exact duplicate is worth more than
+//! either reader quietly winning.
+//!
+//! **The span is the later occurrence.** The first is the one arity reads, so
+//! the repeat is the line whose author has to decide.
+//!
+//! Record-blind, like every other `DESCRIPTION` reader: a stray blank line
+//! splits the file into two DCF records, and a field repeated across that split
+//! is still a repeated field.
+//!
+//! **No autofix.** Deleting a duplicate means choosing a value, and the whole
+//! point of the finding is that the two readers do not agree on which one is
+//! already in effect. A fix would silently pick a side.
+
+use std::collections::HashMap;
+
+use crate::linter::diagnostic::{Diagnostic, ViolationData};
+use crate::linter::rules::{DcfRule, DcfRuleContext, Example};
+
+pub struct DescriptionDuplicateField;
+
+const EXAMPLES: &[Example] = &[Example {
+    caption: "A field declared twice, which arity and `read.dcf` read differently:",
+    source: "Package: mypkg\nVersion: 0.1.0\nLicense: MIT + file LICENSE\nVersion: 0.2.0\n",
+}];
+
+impl DcfRule for DescriptionDuplicateField {
+    fn id(&self) -> &'static str {
+        "description-duplicate-field"
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag a `DESCRIPTION` field declared more than once.\n\nA repeated \
+         field is a silent mistake: nothing errors, and the file keeps \
+         whichever value the reader picks—except the readers disagree. R's \
+         `read.dcf` takes the **last** occurrence; arity takes the **first**. A \
+         duplicated `Version` therefore means R and arity are describing two \
+         different packages, and every tool downstream of either inherits the \
+         split.\n\nThe finding is reported on the *later* occurrence, since the \
+         earlier one is what arity already read. Duplicates are detected across \
+         DCF records, so a stray blank line does not hide one.\n\nThere is no \
+         autofix: removing a duplicate means choosing a value, and this rule \
+         exists precisely because it is not settled which value is already in \
+         effect."
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        EXAMPLES
+    }
+
+    fn check_file(&self, ctx: &DcfRuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        let text = ctx.root.text().to_string();
+        // Field name -> the line its first occurrence sits on, which is what
+        // the message points the author back at.
+        let mut first_line: HashMap<String, u32> = HashMap::new();
+
+        for field in ctx.document.fields() {
+            let name = field.name();
+            // A nameless field (`: value`) is the parser's `empty field name`
+            // diagnostic, not a duplicate of anything.
+            if name.is_empty() {
+                continue;
+            }
+            let Some(&first) = first_line.get(name.as_str()) else {
+                first_line.insert(name.to_string(), line_of(&text, field.name_range().start()));
+                continue;
+            };
+            sink.push(Diagnostic {
+                rule: "description-duplicate-field",
+                severity: Default::default(),
+                path: Default::default(),
+                range: field.name_range(),
+                message: ViolationData::new(
+                    "description-duplicate-field",
+                    format!(
+                        "`{name}` is already declared on line {first}; arity reads the \
+                         first occurrence and R's `read.dcf` reads the last, so the two \
+                         disagree about this file"
+                    ),
+                )
+                .with_suggestion(format!("Keep one `{name}` field and delete the other.")),
+                fix: None,
+            });
+        }
+    }
+}
+
+/// The 1-based line `offset` falls on.
+fn line_of(text: &str, offset: rowan::TextSize) -> u32 {
+    let at: usize = offset.into();
+    1 + text[..at.min(text.len())].matches('\n').count() as u32
+}

--- a/src/linter/rules/packaging/description_missing_field.rs
+++ b/src/linter/rules/packaging/description_missing_field.rs
@@ -1,0 +1,126 @@
+//! `description-missing-field`: a `DESCRIPTION` without the fields R requires.
+//!
+//! `R CMD build` refuses a package whose `DESCRIPTION` omits `Package`,
+//! `Version`, `Title`, `Description`, `Author`, `Maintainer`, or `License` —
+//! and `Authors@R`, which modern packages write instead, is what `Author` and
+//! `Maintainer` are derived from, so it satisfies both.
+//!
+//! A field present but empty declares nothing and counts as missing, which is
+//! also what `R CMD check` concludes.
+//!
+//! **One finding, not one per field.** The defect is that this `DESCRIPTION` is
+//! incomplete; stacking five diagnostics on the same line says it five times,
+//! and takes five suppressions to silence.
+//!
+//! A file with no fields at all is left alone: that is not an incomplete
+//! package description, it is not a package description.
+//!
+//! **No autofix.** Every one of these fields needs a value only the author has.
+
+use crate::linter::diagnostic::{Diagnostic, ViolationData};
+use crate::linter::rules::{DcfRule, DcfRuleContext, Example};
+
+pub struct DescriptionMissingField;
+
+/// The fields `R CMD build` requires, in the order R writes them.
+const REQUIRED: [&str; 7] = [
+    "Package",
+    "Version",
+    "Title",
+    "Description",
+    "Author",
+    "Maintainer",
+    "License",
+];
+
+/// `Authors@R` is the modern spelling of these two: `R CMD build` derives both
+/// from it, so declaring it satisfies both.
+const DERIVED_FROM_AUTHORS_AT_R: [&str; 2] = ["Author", "Maintainer"];
+
+const EXAMPLES: &[Example] = &[Example {
+    caption: "A `DESCRIPTION` that `R CMD build` would reject:",
+    source: "Package: mypkg\nVersion: 0.1.0\n",
+}];
+
+impl DcfRule for DescriptionMissingField {
+    fn id(&self) -> &'static str {
+        "description-missing-field"
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag a `DESCRIPTION` missing a field R requires.\n\n`R CMD build` \
+         refuses a package whose `DESCRIPTION` omits `Package`, `Version`, \
+         `Title`, `Description`, `Author`, `Maintainer`, or `License`. \
+         `Authors@R` satisfies `Author` and `Maintainer`, since `R CMD build` \
+         derives both from it. A field that is present but empty declares \
+         nothing and counts as missing.\n\nEvery missing field is reported as \
+         one finding rather than one each: the defect is that the file is \
+         incomplete, and it takes one decision—and one suppression—to \
+         settle.\n\nA file with no fields at all is left alone; that is not an \
+         incomplete package description.\n\nThere is no autofix: each of these \
+         fields needs a value only the author has."
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        EXAMPLES
+    }
+
+    fn check_file(&self, ctx: &DcfRuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        let declared = |name: &str| {
+            ctx.document
+                .field(name)
+                .is_some_and(|field| !field.folded_value().trim().is_empty())
+        };
+
+        // Nothing declared at all: not a package description, so not an
+        // incomplete one.
+        let Some(first) = ctx.document.fields().find(|f| !f.name().is_empty()) else {
+            return;
+        };
+
+        let has_authors_at_r = declared("Authors@R");
+        let missing: Vec<&str> = REQUIRED
+            .into_iter()
+            .filter(|name| {
+                if has_authors_at_r && DERIVED_FROM_AUTHORS_AT_R.contains(name) {
+                    return false;
+                }
+                !declared(name)
+            })
+            .collect();
+        if missing.is_empty() {
+            return;
+        }
+
+        let list = missing
+            .iter()
+            .map(|name| format!("`{name}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let plural = if missing.len() == 1 {
+            "field"
+        } else {
+            "fields"
+        };
+        sink.push(Diagnostic {
+            rule: "description-missing-field",
+            severity: Default::default(),
+            path: Default::default(),
+            // Nothing marks an absence, so the finding points at the first
+            // field — the head of the record the missing ones belong to.
+            range: first.name_range(),
+            message: ViolationData::new(
+                "description-missing-field",
+                format!("DESCRIPTION is missing the required {plural} {list}"),
+            )
+            .with_suggestion(if missing.iter().any(|name| {
+                DERIVED_FROM_AUTHORS_AT_R.contains(name)
+            }) {
+                format!("Add the {plural} {list}, or declare `Authors@R` in place of `Author` and `Maintainer`.")
+            } else {
+                format!("Add the {plural} {list}.")
+            }),
+            fix: None,
+        });
+    }
+}

--- a/src/linter/rules/packaging/description_version_constraint.rs
+++ b/src/linter/rules/packaging/description_version_constraint.rs
@@ -1,0 +1,100 @@
+//! `description-version-constraint`: a dependency entry whose parenthesized
+//! part is not a version constraint.
+//!
+//! R reads `pkg (>= 1.0.0)` — an operator and a version. Anything else in those
+//! parentheses (`dplyr (1.0.0)`, `dplyr (>=)`, `dplyr (latest)`) states no
+//! bound, and R's own dependency check simply does not enforce it. The
+//! declaration reads as a requirement and behaves as none, which is the whole
+//! defect: the package installs against a version its author believed was
+//! excluded.
+//!
+//! The fact comes straight off the grammar
+//! ([`DependencyEntry::malformed_constraint`]): the parser deliberately keeps
+//! the package name when the constraint fails to parse, so a broken constraint
+//! never hides a dependency from resolution — and leaves reporting it to a
+//! lint, which is this one.
+//!
+//! Checked in all five dependency fields, `R` included: `Depends: R (>= 4.1)`
+//! is the most common constraint in any `DESCRIPTION`, and a typo there is
+//! worth exactly as much attention.
+//!
+//! **The span is the whole entry**, parentheses included. The name alone would
+//! point away from the part that is wrong.
+//!
+//! **No autofix.** `dplyr (1.0.0)` most likely means `>=`, but it could mean
+//! `==` or `>`; guessing an operator would silently invent a requirement.
+//!
+//! Known limit: an entry with two constraints of which only one parses
+//! (`(>= 1.0, whatever)`) is not flagged, because the entry does state a bound.
+//!
+//! [`DependencyEntry::malformed_constraint`]: crate::dcf::DependencyEntry::malformed_constraint
+
+use crate::dcf::deps::{dependency_entries, is_dependency_field};
+use crate::linter::diagnostic::{Diagnostic, ViolationData};
+use crate::linter::rules::{DcfRule, DcfRuleContext, Example};
+
+pub struct DescriptionVersionConstraint;
+
+const EXAMPLES: &[Example] = &[Example {
+    caption: "A version requirement R will not enforce:",
+    source: "Package: mypkg\nDepends: R (4.1)\nImports: dplyr (1.0.0)\n",
+}];
+
+impl DcfRule for DescriptionVersionConstraint {
+    fn id(&self) -> &'static str {
+        "description-version-constraint"
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag a dependency entry whose parenthesized part is not a version \
+         constraint.\n\nR reads `pkg (>= 1.0.0)`: an operator and a version. \
+         Anything else—`dplyr (1.0.0)`, `dplyr (>=)`, `dplyr (latest)`—states no \
+         bound at all, and R's dependency check enforces nothing. The line \
+         reads as a requirement and behaves as none, so the package installs \
+         against exactly the versions its author meant to \
+         exclude.\n\nChecked in all five dependency fields, `R` included: \
+         `Depends: R (>= 4.1)` is the most common constraint in any \
+         `DESCRIPTION`.\n\nThere is no autofix. `dplyr (1.0.0)` most likely \
+         means `>=`, but it could mean `==` or `>`, and guessing would invent a \
+         requirement the author never wrote."
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        EXAMPLES
+    }
+
+    fn check_file(&self, ctx: &DcfRuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        for field in ctx.document.fields() {
+            if !is_dependency_field(&field.name()) {
+                continue;
+            }
+            for entry in dependency_entries(&field) {
+                if !entry.malformed_constraint() {
+                    continue;
+                }
+                let name = &entry.name;
+                sink.push(Diagnostic {
+                    rule: "description-version-constraint",
+                    severity: Default::default(),
+                    path: Default::default(),
+                    range: entry.range,
+                    message: ViolationData::new(
+                        "description-version-constraint",
+                        format!(
+                            "the version constraint on `{name}` states no bound, so R \
+                             enforces nothing here"
+                        ),
+                    )
+                    // No package name in the suggestion: `R (>= 1.0.0)` would
+                    // be nonsense advice for the one entry that is not a
+                    // package.
+                    .with_suggestion(
+                        "Write a comparison operator and a version, as in `(>= 1.0.0)`."
+                            .to_string(),
+                    ),
+                    fix: None,
+                });
+            }
+        }
+    }
+}

--- a/src/linter/rules/packaging/undeclared_dependency.rs
+++ b/src/linter/rules/packaging/undeclared_dependency.rs
@@ -1,0 +1,179 @@
+//! `undeclared-dependency`: package code reaches a package `DESCRIPTION` never
+//! declares.
+//!
+//! `dplyr::filter()` in `R/` works on the author's machine because `dplyr`
+//! happens to be installed there. On a clean machine it is a load-time error,
+//! and `R CMD check` says so ("Namespace dependency not required"). The
+//! declaration is what makes the dependency *installed*, so its absence is a
+//! bug that only ever shows up somewhere else.
+//!
+//! The exempt set is R's, read off `tools:::.check_packages_used`: everything
+//! `DESCRIPTION` declares in any of the five fields, the package's own name,
+//! and the base-priority packages R ships — **minus `methods` and `stats4`,
+//! which R still expects a package to declare**
+//! ([`symbols::is_implicitly_available`]). That list is deliberately not
+//! `default_packages()`, which answers a different question (what a fresh
+//! session *attaches*) and differs in both directions.
+//!
+//! **Only `R/` is package code.** `package_facts_for` resolves for a
+//! `tests/testthat/` file too, since it walks up to the package root, but a
+//! test's dependencies belong in `Suggests` and R does not scan `tests/` for
+//! this check either ([`RuleContext::is_package_r_source`]).
+//!
+//! **`Suggests` exempts.** R exempts it here as well. Flagging *unconditional*
+//! use of a suggested package is a genuinely different question — is this call
+//! reachable without `requireNamespace()` having succeeded? — that belongs to
+//! the control-flow graph, not to a name set, and getting it wrong would flag
+//! the one idiom careful authors write.
+//!
+//! Every site is reported, like `internal-function`: each is separately
+//! suppressible, and one `DESCRIPTION` line clears them all.
+//!
+//! **No autofix, structurally.** A [`Fix`] is a contiguous replacement in the
+//! diagnostic's own file, and the repair is a line in a different one.
+//!
+//! [`Fix`]: crate::linter::diagnostic::Fix
+//! [`symbols::is_implicitly_available`]: crate::semantic::symbols::is_implicitly_available
+//! [`RuleContext::is_package_r_source`]: crate::linter::rules::RuleContext::is_package_r_source
+
+use rowan::ast::AstNode as _;
+
+use crate::ast::{BinaryExpr, CallExpr};
+use crate::linter::diagnostic::{Diagnostic, ViolationData};
+use crate::linter::rules::matchers;
+use crate::linter::rules::{Example, Rule, RuleContext};
+use crate::semantic::symbols::is_implicitly_available;
+use crate::syntax::{SyntaxElement, SyntaxKind, SyntaxToken};
+
+pub struct UndeclaredDependency;
+
+const EXAMPLES: &[Example] = &[Example {
+    caption: "In `R/` of a package whose `DESCRIPTION` declares only `Imports: rlang`:",
+    source: "summarize <- function(data) {\n  dplyr::group_by(data, id)\n}\n",
+}];
+
+/// The package the example is linted inside. `undeclared-dependency` is a fact
+/// about a package, so its example has to be one.
+const EXAMPLE_PACKAGE: &[(&str, &str)] = &[(
+    "DESCRIPTION",
+    "Package: mypkg\nVersion: 0.1.0\nImports: rlang\n",
+)];
+
+impl Rule for UndeclaredDependency {
+    fn id(&self) -> &'static str {
+        "undeclared-dependency"
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag package code that reaches a package its `DESCRIPTION` never \
+         declares.\n\n`dplyr::filter()` in `R/` works on the author's machine \
+         because `dplyr` happens to be installed there; on a clean machine it \
+         is a load-time error, and `R CMD check` reports it. Declaring the \
+         dependency is what causes it to be installed, so leaving it out is a \
+         bug that only ever surfaces somewhere else.\n\nThe rule matches \
+         `pkg::name`, `pkg:::name`, and the package argument of `library`, \
+         `require`, `requireNamespace`, and `loadNamespace`—at any depth, since \
+         the conditional-dependency idiom lives inside a function body.\n\nThe \
+         exempt set is R's own: everything declared in any of `Depends`, \
+         `Imports`, `Suggests`, `LinkingTo`, or `Enhances`, the package's own \
+         name, and the packages R ships at base priority—except `methods` and \
+         `stats4`, which `R CMD check` still expects a package to declare. Only \
+         files directly in `R/` are checked: a test's or a vignette's \
+         dependencies belong in `Suggests`, and R does not scan those \
+         directories for this check either.\n\nThere is no autofix. A fix is an \
+         edit to the file the finding is in, and the repair here is a line in \
+         `DESCRIPTION`."
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        EXAMPLES
+    }
+
+    fn doc_package(&self) -> &'static [(&'static str, &'static str)] {
+        EXAMPLE_PACKAGE
+    }
+
+    fn interests(&self) -> &'static [SyntaxKind] {
+        &[SyntaxKind::BINARY_EXPR, SyntaxKind::CALL_EXPR]
+    }
+
+    fn check(&self, el: &SyntaxElement, ctx: &RuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        if !ctx.is_package_r_source() {
+            return;
+        }
+        let facts = ctx.package.expect("gated by is_package_r_source");
+        // An unreadable or nameless DESCRIPTION derives all-default facts, which
+        // would make every package in the file look undeclared.
+        let Some(own) = facts.package.as_deref() else {
+            return;
+        };
+        let Some(node) = el.as_node() else {
+            return;
+        };
+
+        let (name, token, how) = match el.kind() {
+            SyntaxKind::BINARY_EXPR => {
+                let Some(access) =
+                    BinaryExpr::cast(node.clone()).and_then(|b| b.namespace_access())
+                else {
+                    return;
+                };
+                (access.package, access.package_token, How::Qualified)
+            }
+            SyntaxKind::CALL_EXPR => {
+                let Some(call) = CallExpr::cast(node.clone()) else {
+                    return;
+                };
+                let Some((name, token)) = matchers::package_load_arg(&call) else {
+                    return;
+                };
+                (name, token, How::Attached)
+            }
+            _ => return,
+        };
+
+        if name == own || is_implicitly_available(&name) {
+            return;
+        }
+        // A linear scan over a list that is a dozen entries long, rather than
+        // `declared_packages()`, which builds a fresh `BTreeSet` per call.
+        if facts.dependencies.iter().any(|d| d.name == name) {
+            return;
+        }
+
+        sink.push(diagnostic(&name, &token, how));
+    }
+}
+
+/// How the file reached the package — which decides only the wording.
+#[derive(Clone, Copy)]
+enum How {
+    /// `pkg::name` / `pkg:::name`.
+    Qualified,
+    /// `library(pkg)` and friends.
+    Attached,
+}
+
+fn diagnostic(name: &str, token: &SyntaxToken, how: How) -> Diagnostic {
+    let suggestion = match how {
+        How::Qualified => format!("Add `{name}` to `Imports:` in DESCRIPTION."),
+        How::Attached => format!(
+            "Add `{name}` to `Imports:` in DESCRIPTION, and reach it with `{name}::` \
+             rather than attaching it from package code."
+        ),
+    };
+    Diagnostic {
+        rule: "undeclared-dependency",
+        severity: Default::default(),
+        path: Default::default(),
+        // The package name alone: it *is* the violation, unlike
+        // `internal-function`, where the pair is.
+        range: token.text_range(),
+        message: ViolationData::new(
+            "undeclared-dependency",
+            format!("package `{name}` is used here but is not declared in DESCRIPTION"),
+        )
+        .with_suggestion(suggestion),
+        fix: None,
+    }
+}

--- a/src/linter/rules/packaging/unused_dependency.rs
+++ b/src/linter/rules/packaging/unused_dependency.rs
@@ -7,10 +7,10 @@
 //!
 //! **`Imports` only.** `Depends` is an API decision (`Depends: R6` re-exports a
 //! world to the *user*), and a package's own code may legitimately never name
-//! it. `Suggests` is by definition reached from tests, vignettes, and examples,
-//! which the usage set does not cover. `LinkingTo` is C or C++ headers and
-//! `Enhances` is optional by definition, both structurally invisible to
-//! R-source analysis.
+//! it. `Suggests` is optional by definition, reached from tests, vignettes, and
+//! examples rather than from the package's own code. `LinkingTo` is C or C++
+//! headers and `Enhances` is optional by definition, both structurally
+//! invisible to R-source analysis.
 //!
 //! **This rule reports on absence**, which is a much stronger claim than every
 //! other rule makes, and a wrong one leads a maintainer to delete a dependency
@@ -33,9 +33,16 @@
 //! - **`methods`.** An S4 or reference class needs it with nothing naming it,
 //!   which is why [`PackageReferences::uses_methods`] exists.
 //!
-//! What is **accepted and documented rather than fixed**: a package used only
-//! from `tests/`, vignettes, `inst/`, or `data-raw/` is flagged. R agrees — such
-//! a dependency belongs in `Suggests`.
+//! **What counts as "the package" is the run's file set.** Usage is folded over
+//! every analyzed member under the package root
+//! ([`package_usage`](crate::project::package_usage)), so a `tests/`,
+//! `inst/`, or `data-raw/` file counts as a use whenever the run covers it — as
+//! `arity lint .` does. Narrow the run to `R/` and the same entry is reported.
+//! Both readings are defensible (R would want a test-only dependency in
+//! `Suggests`), and the quieter one falls out of the default, which is the right
+//! way round for a rule that reports on absence. A vignette is never analyzed at
+//! all — `.Rmd` is not an R source — so a dependency used only there is
+//! reported.
 //!
 //! **No autofix**, for three independent reasons. The edit is not local
 //! (deleting a middle entry leaves a dangling comma; deleting the only one
@@ -99,10 +106,15 @@ impl DcfRule for UnusedDependency {
          class, and any package whose name appears as a plain string (a dynamic \
          `do.call(\"::\", …)` or `system.file(package = …)`).\n\nOnly `Imports` \
          is checked. `Depends` is an API decision the package's own code may \
-         never name; `Suggests` is for tests, vignettes, and examples, which \
-         this analysis does not cover; `LinkingTo` and `Enhances` are invisible \
-         to R-source analysis. A package used *only* from `tests/` or a \
-         vignette **is** flagged—it belongs in `Suggests`.\n\nIt reports on \
+         never name; `Suggests` is for tests, vignettes, and examples, reached \
+         from outside the package's own code; `LinkingTo` and `Enhances` are \
+         invisible to R-source analysis.\n\nUsage is folded over every R file \
+         the run analyzed under the package root, so a package reached only \
+         from `tests/`, `inst/`, or `data-raw/` counts as used when those files \
+         are in the run (`arity lint .`) and is reported when they are not \
+         (`arity lint R/`). A vignette's R code is never analyzed either way, \
+         so a dependency used only there is reported—it belongs in \
+         `Suggests`.\n\nIt reports on \
          *absence*, and a wrong finding would have a maintainer delete a \
          dependency their package needs, so it stays silent unless the run \
          analyzed the package's whole `R/` source set and read its \

--- a/src/linter/rules/packaging/unused_dependency.rs
+++ b/src/linter/rules/packaging/unused_dependency.rs
@@ -1,0 +1,177 @@
+//! `unused-dependency`: an `Imports:` entry nothing in the package reaches.
+//!
+//! An `Imports` entry is a promise that installing this package installs that
+//! one. An entry no code reaches costs every user of the package a download, a
+//! build, and a version constraint to satisfy, for nothing — and `R CMD check`
+//! reports it.
+//!
+//! **`Imports` only.** `Depends` is an API decision (`Depends: R6` re-exports a
+//! world to the *user*), and a package's own code may legitimately never name
+//! it. `Suggests` is by definition reached from tests, vignettes, and examples,
+//! which the usage set does not cover. `LinkingTo` is C or C++ headers and
+//! `Enhances` is optional by definition, both structurally invisible to
+//! R-source analysis.
+//!
+//! **This rule reports on absence**, which is a much stronger claim than every
+//! other rule makes, and a wrong one leads a maintainer to delete a dependency
+//! their package needs — a package that still installs locally and fails on a
+//! clean machine. Hence: default-off, a completeness guard, and a deliberately
+//! over-broad notion of "reaches".
+//!
+//! [`PackageUsage::complete`] is that guard. The rule stays silent unless the
+//! run analyzed the package's whole R source set, read its NAMESPACE, and found
+//! at least one source — so a single-file lint, a package with a parse error in
+//! `R/`, and one mid-`document()` all report nothing rather than everything.
+//!
+//! The exemptions each close a named false positive:
+//!
+//! - **`LinkingTo`.** `Imports: Rcpp` + `LinkingTo: Rcpp` with no R-side
+//!   reference is the canonical Rcpp/cpp11 skeleton; the entry exists so the
+//!   shared library loads.
+//! - **A string mention.** `do.call("::", …)`, `system.file(package = "pkg")`,
+//!   and `rlang::check_installed("pkg")` all name a package as a plain string.
+//! - **`methods`.** An S4 or reference class needs it with nothing naming it,
+//!   which is why [`PackageReferences::uses_methods`] exists.
+//!
+//! What is **accepted and documented rather than fixed**: a package used only
+//! from `tests/`, vignettes, `inst/`, or `data-raw/` is flagged. R agrees — such
+//! a dependency belongs in `Suggests`.
+//!
+//! **No autofix**, for three independent reasons. The edit is not local
+//! (deleting a middle entry leaves a dangling comma; deleting the only one
+//! leaves an empty field). The finding is deliberately heuristic, and encoding a
+//! heuristic as a destructive edit to package metadata inverts the fix bar. And
+//! DESCRIPTION is rewritten by `usethis`, `devtools`, and `R CMD build`, which
+//! is why even *formatting* it is opt-in. The seam is that formatter: once a
+//! dependency field can be re-emitted canonically, "the field minus one entry"
+//! becomes correct by construction.
+//!
+//! [`PackageUsage::complete`]: crate::project::PackageUsage::complete
+//! [`PackageReferences::uses_methods`]: crate::project::PackageReferences::uses_methods
+
+use std::collections::BTreeSet;
+
+use crate::dcf::deps::dependency_entries;
+use crate::linter::diagnostic::{Diagnostic, ViolationData};
+use crate::linter::rules::{DcfRule, DcfRuleContext, Example};
+use crate::project::DependencyField;
+
+pub struct UnusedDependency;
+
+const EXAMPLES: &[Example] = &[Example {
+    caption: "In a package whose only R source is `f <- function() rlang::abort(\"no\")`:",
+    source: "Package: mypkg\nVersion: 0.1.0\nImports: rlang, tibble\n",
+}];
+
+/// The package the example's `DESCRIPTION` describes. Without a real package
+/// around it the completeness guard would (correctly) keep the rule silent.
+const EXAMPLE_PACKAGE: &[(&str, &str)] = &[
+    ("NAMESPACE", "export(f)\n"),
+    ("R/a.R", "f <- function() rlang::abort(\"no\")\n"),
+];
+
+impl DcfRule for UnusedDependency {
+    fn id(&self) -> &'static str {
+        "unused-dependency"
+    }
+
+    fn default_enabled(&self) -> bool {
+        // Every other rule reports on something present in the file it is
+        // looking at. This one claims nothing anywhere reaches an entry — a
+        // claim whose truth depends on the shape of the run, on NAMESPACE
+        // freshness, and on several over-approximations. And acting on a wrong
+        // one yields a package that installs fine locally and fails on a clean
+        // machine. Opt in.
+        false
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag an `Imports:` entry that nothing in the package reaches.\n\nAn \
+         `Imports` entry promises that installing this package installs that \
+         one, so an entry no code reaches costs every user a download, a build, \
+         and a constraint to satisfy for nothing. `R CMD check` reports it \
+         too.\n\nA package counts as reached by `pkg::`, `pkg:::`, a `library`, \
+         `require`, `requireNamespace`, or `loadNamespace` call at any depth, a \
+         NAMESPACE `import()`/`importFrom()`/`importClassesFrom()`/\
+         `importMethodsFrom()`, or a roxygen `@import`/`@importFrom` tag. \
+         Exempt on top of that: anything also in `LinkingTo` (the Rcpp \
+         skeleton), `methods` when the package defines an S4 or reference \
+         class, and any package whose name appears as a plain string (a dynamic \
+         `do.call(\"::\", …)` or `system.file(package = …)`).\n\nOnly `Imports` \
+         is checked. `Depends` is an API decision the package's own code may \
+         never name; `Suggests` is for tests, vignettes, and examples, which \
+         this analysis does not cover; `LinkingTo` and `Enhances` are invisible \
+         to R-source analysis. A package used *only* from `tests/` or a \
+         vignette **is** flagged—it belongs in `Suggests`.\n\nIt reports on \
+         *absence*, and a wrong finding would have a maintainer delete a \
+         dependency their package needs, so it stays silent unless the run \
+         analyzed the package's whole `R/` source set and read its \
+         NAMESPACE—which is also why it is off by default.\n\nThere is no \
+         autofix: removing an \
+         entry from a comma-separated list is not a local edit, and this is not \
+         a claim a tool should act on destructively."
+    }
+
+    fn examples(&self) -> &'static [Example] {
+        EXAMPLES
+    }
+
+    fn doc_package(&self) -> &'static [(&'static str, &'static str)] {
+        EXAMPLE_PACKAGE
+    }
+
+    fn check_file(&self, ctx: &DcfRuleContext<'_>, sink: &mut Vec<Diagnostic>) {
+        // Silent on the single-file paths, and on any run that did not analyze
+        // the whole package. Reporting on absence is only sound when the run
+        // has actually seen everything.
+        let Some(usage) = ctx.usage.filter(|usage| usage.complete) else {
+            return;
+        };
+        let Some(own) = ctx.facts.package.as_deref() else {
+            return;
+        };
+        let Some(field) = ctx.document.field(DependencyField::Imports.name()) else {
+            return;
+        };
+
+        let linking_to: BTreeSet<&str> = ctx
+            .facts
+            .in_field(DependencyField::LinkingTo)
+            .map(|d| d.name.as_str())
+            .collect();
+
+        // Spans are re-derived from the CST: `DescriptionFacts` is range-free by
+        // construction, being the salsa backdating firewall for DESCRIPTION.
+        for entry in dependency_entries(&field) {
+            let name = entry.name.as_str();
+            if name == "R" || name == own {
+                continue;
+            }
+            if usage.used.contains(name)
+                || usage.mentioned.contains(name)
+                || linking_to.contains(name)
+            {
+                continue;
+            }
+            sink.push(Diagnostic {
+                rule: "unused-dependency",
+                severity: Default::default(),
+                path: Default::default(),
+                // The name, not the version constraint: the constraint is not
+                // part of what is unused.
+                range: entry.name_range,
+                message: ViolationData::new(
+                    "unused-dependency",
+                    format!(
+                        "`{name}` is declared in `Imports:` but nothing in the package uses it"
+                    ),
+                )
+                .with_suggestion(format!(
+                    "Remove `{name}` from `Imports:`, or move it to `Suggests:` if only \
+                     tests, vignettes, or examples need it."
+                )),
+                fix: None,
+            });
+        }
+    }
+}

--- a/src/linter/suppression.rs
+++ b/src/linter/suppression.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 
 use rowan::{NodeOrToken, TextRange};
 
+use crate::dcf;
 use crate::syntax::{SyntaxKind, SyntaxNode};
 
 use super::diagnostic::Diagnostic;
@@ -114,6 +115,30 @@ impl SuppressionMap {
     pub fn build(root: &SyntaxNode) -> Self {
         let mut map = Self::default();
         visit(root, &mut map);
+        map
+    }
+
+    /// Build from a `DESCRIPTION` document: every `COMMENT` token, which in DCF
+    /// only ever sits under a `COMMENT_LINE`.
+    ///
+    /// DCF has no trailing comments — a `#` mid-value is value text — so a
+    /// directive is always a line of its own at column zero. What a node-scope
+    /// directive attaches to follows from where that line sits: see
+    /// [`next_meaningful_dcf_sibling`].
+    pub fn build_dcf(root: &dcf::SyntaxNode) -> Self {
+        let mut map = Self::default();
+        for el in root.descendants_with_tokens() {
+            if let NodeOrToken::Token(tok) = el
+                && tok.kind() == dcf::SyntaxKind::COMMENT
+            {
+                classify_comment_with(
+                    tok.text(),
+                    tok.text_range(),
+                    || next_meaningful_dcf_sibling(&tok),
+                    &mut map,
+                );
+            }
+        }
         map
     }
 
@@ -205,8 +230,28 @@ fn visit(node: &SyntaxNode, map: &mut SuppressionMap) {
 }
 
 fn classify_comment(tok: &rowan::SyntaxToken<crate::syntax::RLanguage>, map: &mut SuppressionMap) {
-    let text = tok.text();
-    let base = tok.text_range().start();
+    classify_comment_with(
+        tok.text(),
+        tok.text_range(),
+        || next_meaningful_sibling(tok),
+        map,
+    );
+}
+
+/// Parse one `#` comment into a directive, grammar-free.
+///
+/// `target` is invoked only for the node-scope form, so the common case (a
+/// file-scope directive, and every comment that is not a directive at all)
+/// never pays for the sibling walk. That laziness is the whole reason this
+/// function is split out: it is what lets both grammars share the parsing
+/// without sharing a tree type.
+fn classify_comment_with(
+    text: &str,
+    comment: TextRange,
+    target: impl FnOnce() -> Option<TextRange>,
+    map: &mut SuppressionMap,
+) {
+    let base = comment.start();
     // Byte offset of the comment body within the token, so a `RuleRef` range is
     // absolute in the file.
     let Some(body_start) = text.find('#').map(|i| i + 1) else {
@@ -225,7 +270,7 @@ fn classify_comment(tok: &rowan::SyntaxToken<crate::syntax::RLanguage>, map: &mu
                     kind: DirectiveKind::FileAll,
                     rule: None,
                     reason: clean_reason(reason),
-                    comment: tok.text_range(),
+                    comment,
                     target: None,
                     raw: text.to_string(),
                 },
@@ -239,7 +284,7 @@ fn classify_comment(tok: &rowan::SyntaxToken<crate::syntax::RLanguage>, map: &mu
                 kind: DirectiveKind::File,
                 rule: parse_rule(rest, rest_offset, base),
                 reason: parse_reason(rest),
-                comment: tok.text_range(),
+                comment,
                 target: None,
                 raw: text.to_string(),
             },
@@ -256,8 +301,8 @@ fn classify_comment(tok: &rowan::SyntaxToken<crate::syntax::RLanguage>, map: &mu
                 kind: DirectiveKind::Node,
                 rule: parse_rule(rest, rest_offset, base),
                 reason: parse_reason(rest),
-                comment: tok.text_range(),
-                target: next_meaningful_sibling(tok),
+                comment,
+                target: target(),
                 raw: text.to_string(),
             },
         );
@@ -320,6 +365,62 @@ fn parse_reason(rest: &str) -> Option<String> {
 fn clean_reason(reason: &str) -> Option<String> {
     let trimmed = reason.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// What a node-scope directive in a `DESCRIPTION` attaches to: the next thing,
+/// same as in R, but "next" has to be read off a tree where a comment line is a
+/// child of the field it follows.
+///
+/// A `COMMENT_LINE` lands under whatever node is open, and a `FIELD` stays open
+/// across its continuation lines. So a comment between two fields is a child of
+/// the *earlier* one — which is not what its author meant. The distinction that
+/// matters is therefore whether a value line still follows inside that field:
+///
+/// - **A value line follows** — the comment interrupts a multi-line value, the
+///   case `read.dcf` skips before *resuming* the field. It attaches to the
+///   whole enclosing field, which is the only useful answer: a finding on one
+///   dependency entry lies inside that field's range.
+/// - **Otherwise** — the comment is trailing, and points past its field at
+///   whatever line comes next.
+///
+/// `None` when nothing follows, which leaves the directive dangling exactly as
+/// in R. A comment never opens a record, so it can never bridge two.
+fn next_meaningful_dcf_sibling(tok: &dcf::SyntaxToken) -> Option<TextRange> {
+    let line = tok.parent()?;
+    let field = line.parent().filter(|p| p.kind() == dcf::SyntaxKind::FIELD);
+    if let Some(field) = field {
+        let interrupts_value = line
+            .siblings(rowan::Direction::Next)
+            .skip(1)
+            .any(|sibling| sibling.kind() == dcf::SyntaxKind::VALUE_LINE);
+        if interrupts_value {
+            return Some(field.text_range());
+        }
+        return next_dcf_sibling_of(&field);
+    }
+    next_dcf_sibling_of(&line)
+}
+
+/// The range a directive sitting immediately before `node`'s successor covers.
+fn next_dcf_sibling_of(node: &dcf::SyntaxNode) -> Option<TextRange> {
+    let next = next_dcf_line(node.siblings(rowan::Direction::Next).skip(1))?;
+    // A comment above the first field sits under ROOT (it opens no record), so
+    // the sibling found there is the whole RECORD. Descend into it rather than
+    // silently widening a next-item directive to the entire file.
+    if next.kind() == dcf::SyntaxKind::RECORD {
+        return Some(next_dcf_line(next.children())?.text_range());
+    }
+    Some(next.text_range())
+}
+
+/// The first line node in `lines` that is neither a comment nor blank.
+fn next_dcf_line(mut lines: impl Iterator<Item = dcf::SyntaxNode>) -> Option<dcf::SyntaxNode> {
+    lines.find(|node| {
+        !matches!(
+            node.kind(),
+            dcf::SyntaxKind::COMMENT_LINE | dcf::SyntaxKind::BLANK_LINE
+        )
+    })
 }
 
 fn next_meaningful_sibling(

--- a/src/lsp/lint_thread.rs
+++ b/src/lsp/lint_thread.rs
@@ -348,16 +348,39 @@ impl LintWorker {
         };
         relint |= member_changed;
 
-        if batch.package_meta_changed && !member_changed {
-            self.db.refresh_package_graph();
-            relint = true;
+        if !member_changed {
+            // Refresh only what actually moved. A `NAMESPACE` change reshapes
+            // the package graph, and so does a `DESCRIPTION` for a root we do
+            // not track yet — it may have just turned a directory into a
+            // package. A `DESCRIPTION` edit for a known root needs nothing but
+            // its own text re-read.
+            let mut refresh_graph = false;
+            for (path, kind) in &batch.meta_changed {
+                match kind {
+                    WatchedKind::Namespace => refresh_graph = true,
+                    WatchedKind::Description => match path
+                        .parent()
+                        .filter(|root| self.db.lookup_description(root).is_some())
+                    {
+                        Some(root) => {
+                            let root = root.to_path_buf();
+                            relint |= self.db.refresh_description(&root);
+                        }
+                        None => refresh_graph = true,
+                    },
+                    _ => {}
+                }
+            }
+            if refresh_graph {
+                relint |= self.db.refresh_package_graph();
+            }
         }
 
         // A `DESCRIPTION` (or `man/roxygen/meta.R`) edit may flip the
         // package-wide roxygen markdown default; re-resolve it for every
         // tracked file. Unchanged resolutions write nothing, so the common
-        // case invalidates no parse.
-        if batch.package_meta_changed {
+        // case invalidates no parse. A `NAMESPACE` change cannot flip it.
+        if batch.touches_roxygen_options() {
             relint |= self.db.refresh_roxygen_markdown();
         }
 

--- a/src/lsp/lint_thread.rs
+++ b/src/lsp/lint_thread.rs
@@ -513,12 +513,16 @@ impl LintWorker {
         // `auto_build` reads the buffer + the current salsa index and mutates
         // `index_attempts`, so it stays on the lint thread; it spawns its own
         // background build, whose result is installed back here on `build_rx`.
+        // The enclosing package's declared dependencies count as referenced even
+        // when no `.R` file mentions them: they are exactly what the file is
+        // entitled to use, and the undefined-symbol gates need them enumerable.
+        let declared = self.declared_packages_for(&req.path);
         if req.index_config.auto_build {
-            self.maybe_build(&anchor, &req.index_config, req.buffer.text());
+            self.maybe_build(&anchor, &req.index_config, req.buffer.text(), &declared);
         }
         // Fetch names-only exports for referenced packages the offline tiers don't
         // cover, when a sidecar URL is configured. Background, like `maybe_build`.
-        self.maybe_fetch_remote(&anchor, &req.index_config, req.buffer.text());
+        self.maybe_fetch_remote(&anchor, &req.index_config, req.buffer.text(), &declared);
 
         // Read-phase on the read pool, holding a db clone. A superseding edit (or any
         // write) trips `salsa::Cancelled`, caught here so a canceled analyze
@@ -617,11 +621,34 @@ impl LintWorker {
     /// Spawn a background harvest for the document's unknown packages. On success
     /// the freshly-loaded index is sent back on `build_tx` for the lint thread to
     /// install. The "already indexed?" check reads the current salsa index.
-    fn maybe_build(&mut self, anchor: &Path, cfg: &IndexConfig, source: &str) {
+    /// The packages the `DESCRIPTION` of the package enclosing `path` declares.
+    /// Pure: it reads the tracked `DESCRIPTION` input, never disk. Empty for a
+    /// loose script outside any package.
+    fn declared_packages_for(&self, path: &Path) -> Vec<SmolStr> {
+        let Some(root) = crate::project::package_root(path) else {
+            return Vec::new();
+        };
+        let Some(file) = self.db.lookup_description(&root) else {
+            return Vec::new();
+        };
+        crate::incremental::description_facts(&self.db, file)
+            .declared_packages()
+            .iter()
+            .map(SmolStr::new)
+            .collect()
+    }
+
+    fn maybe_build(
+        &mut self,
+        anchor: &Path,
+        cfg: &IndexConfig,
+        source: &str,
+        declared: &[SmolStr],
+    ) {
         let current = self.db.library_data();
         let empty = IndexedProvider::empty();
         let indexed = current.as_deref().unwrap_or(&empty);
-        let to_build = packages_to_build(&mut self.index_attempts, indexed, source);
+        let to_build = packages_to_build(&mut self.index_attempts, indexed, source, declared);
         if to_build.is_empty() {
             return;
         }
@@ -688,7 +715,13 @@ impl LintWorker {
     /// that the offline tiers (base, harvested, bundled) don't already cover. On
     /// success the fetched names-only batch is sent back on `remote_tx` for the
     /// lint thread to merge and install. No-op unless a sidecar URL is configured.
-    fn maybe_fetch_remote(&mut self, anchor: &Path, cfg: &IndexConfig, source: &str) {
+    fn maybe_fetch_remote(
+        &mut self,
+        anchor: &Path,
+        cfg: &IndexConfig,
+        source: &str,
+        declared: &[SmolStr],
+    ) {
         let Some(url) = cfg.remote_url.as_deref() else {
             return;
         };
@@ -698,7 +731,8 @@ impl LintWorker {
         let empty_remote = RemoteExports::new();
         let remote = self.db.remote_exports();
         let remote = remote.as_deref().unwrap_or(&empty_remote);
-        let to_fetch = packages_to_fetch(&mut self.remote_attempts, index, remote, source);
+        let to_fetch =
+            packages_to_fetch(&mut self.remote_attempts, index, remote, source, declared);
         if to_fetch.is_empty() {
             return;
         }
@@ -737,8 +771,10 @@ impl LintWorker {
     }
 }
 
-/// Packages to fetch from the sidecar for `source`: everything it references
-/// minus what the offline tiers already cover (base/default packages, locally
+/// Packages to fetch from the sidecar for `source`: everything it references —
+/// plus everything the enclosing package's `DESCRIPTION` declares, which is why
+/// a dependency mentioned in no `.R` file still gets fetched — minus what the
+/// offline tiers already cover (base/default packages, locally
 /// harvested packages, and the bundled CRAN list — all captured by
 /// [`package_indexed`]) and minus what we've already attempted this session.
 /// Marks the returned packages as attempted so they aren't fetched twice.
@@ -747,15 +783,18 @@ pub(crate) fn packages_to_fetch(
     indexed: &IndexedProvider,
     remote: &RemoteExports,
     source: &str,
+    declared: &[SmolStr],
 ) -> Vec<SmolStr> {
     referenced_in_source(source)
         .into_iter()
+        .chain(declared.iter().cloned())
         .filter(|pkg| !package_indexed(indexed, remote, pkg) && attempts.insert(pkg.clone()))
         .collect()
 }
 
 /// Packages to harvest for `source`: the always-attached default packages plus
-/// everything `source` references, minus what we already hold a *harvested*
+/// everything `source` references and everything the enclosing package
+/// declares, minus what we already hold a *harvested*
 /// index for and minus what we've already attempted this session. Marks the
 /// returned packages as attempted so they aren't built twice.
 ///
@@ -767,6 +806,7 @@ pub(crate) fn packages_to_build(
     attempts: &mut HashSet<SmolStr>,
     indexed: &IndexedProvider,
     source: &str,
+    declared: &[SmolStr],
 ) -> Vec<SmolStr> {
     // A referenced meta-package also attaches its members (harvested attach
     // set, static table fallback), and the undefined-symbol gates require each
@@ -775,7 +815,11 @@ pub(crate) fn packages_to_build(
     // pass 1 harvests the meta, the installed index triggers a re-lint, and
     // pass 2 sees the meta's attaches (its members weren't marked attempted).
     let mut candidates: Vec<SmolStr> = Vec::new();
-    for pkg in with_default_packages(referenced_in_source(source)) {
+    let referenced: Vec<SmolStr> = referenced_in_source(source)
+        .into_iter()
+        .chain(declared.iter().cloned())
+        .collect();
+    for pkg in with_default_packages(referenced) {
         for member in attach_members(indexed, &pkg) {
             let member = SmolStr::new(member);
             if !candidates.contains(&member) {
@@ -906,7 +950,7 @@ mod tests {
         // referenced-but-unharvested package (stats is a default; notarealpkg
         // is neither default nor harvested) still need a build for rich data.
         let src = "library(dplyr)\nlibrary(stats)\nlibrary(notarealpkg)\n";
-        let first = packages_to_build(&mut attempts, &indexed, src);
+        let first = packages_to_build(&mut attempts, &indexed, src, &[]);
         assert!(
             !first.contains(&SmolStr::new("dplyr")),
             "harvested dep skipped"
@@ -919,7 +963,7 @@ mod tests {
         }
         assert!(first.contains(&SmolStr::new("notarealpkg")));
         // A second pass returns nothing — every package was already attempted.
-        let second = packages_to_build(&mut attempts, &indexed, src);
+        let second = packages_to_build(&mut attempts, &indexed, src, &[]);
         assert!(second.is_empty(), "expected no re-attempt, got {second:?}");
     }
 
@@ -941,7 +985,7 @@ mod tests {
         };
         let indexed = IndexedProvider::from_indices([meta]);
         let mut attempts = HashSet::new();
-        let got = packages_to_build(&mut attempts, &indexed, "library(metaverse)\n");
+        let got = packages_to_build(&mut attempts, &indexed, "library(metaverse)\n", &[]);
         assert!(
             got.contains(&SmolStr::new("helperpkg")),
             "harvested attach member should be queued, got {got:?}"
@@ -958,6 +1002,7 @@ mod tests {
             &mut attempts,
             &IndexedProvider::empty(),
             "library(tidyverse)\n",
+            &[],
         );
         assert!(got.contains(&SmolStr::new("tidyverse")));
         assert!(
@@ -975,7 +1020,7 @@ mod tests {
         // dplyr: locally harvested. data.table: bundled. stats: a default package.
         // alreadyremote: already in the sidecar. notonremote: genuinely uncovered.
         let src = "library(dplyr)\nlibrary(data.table)\nlibrary(stats)\nlibrary(alreadyremote)\nlibrary(notonremote)\n";
-        let first = packages_to_fetch(&mut attempts, &indexed, &remote, src);
+        let first = packages_to_fetch(&mut attempts, &indexed, &remote, src, &[]);
         assert!(
             first.contains(&SmolStr::new("notonremote")),
             "uncovered package fetched, got {first:?}"
@@ -987,7 +1032,7 @@ mod tests {
             );
         }
         // Second pass: nothing left to attempt.
-        let second = packages_to_fetch(&mut attempts, &indexed, &remote, src);
+        let second = packages_to_fetch(&mut attempts, &indexed, &remote, src, &[]);
         assert!(second.is_empty(), "expected no re-attempt, got {second:?}");
     }
 }

--- a/src/lsp/lint_thread.rs
+++ b/src/lsp/lint_thread.rs
@@ -324,8 +324,9 @@ impl LintWorker {
     /// Apply a `workspace/didChangeWatchedFiles` batch to the db, then re-lint if
     /// anything changed. `.R` content changes to tracked-but-unopened files refresh
     /// their text; `.R` create/delete adjusts membership (which cascades a package
-    /// graph refresh); a bare `DESCRIPTION`/`NAMESPACE` edit refreshes the graph on
-    /// its own. See [`WatchedFilesBatch`].
+    /// graph refresh); a bare `NAMESPACE` edit, or a `DESCRIPTION` event that moves
+    /// package-ness, refreshes the graph on its own, while an edit to a tracked
+    /// root's `DESCRIPTION` re-reads only that file. See [`WatchedFilesBatch`].
     fn on_watched_files(&mut self, batch: WatchedFilesBatch) {
         let mut relint = false;
 
@@ -350,23 +351,25 @@ impl LintWorker {
 
         if !member_changed {
             // Refresh only what actually moved. A `NAMESPACE` change reshapes
-            // the package graph, and so does a `DESCRIPTION` for a root we do
-            // not track yet — it may have just turned a directory into a
-            // package. A `DESCRIPTION` edit for a known root needs nothing but
-            // its own text re-read.
+            // the package graph, and so does a `DESCRIPTION` whose arrival or
+            // departure changes which directories are packages
+            // ([`description_edit_is_local`]). An edit to a known root's
+            // `DESCRIPTION` needs nothing but its own text re-read.
             let mut refresh_graph = false;
             for (path, kind) in &batch.meta_changed {
                 match kind {
                     WatchedKind::Namespace => refresh_graph = true,
-                    WatchedKind::Description => match path
-                        .parent()
-                        .filter(|root| self.db.lookup_description(root).is_some())
-                    {
-                        Some(root) => {
+                    WatchedKind::Description => match path.parent() {
+                        Some(root)
+                            if description_edit_is_local(
+                                path,
+                                self.db.lookup_description(root).is_some(),
+                            ) =>
+                        {
                             let root = root.to_path_buf();
                             relint |= self.db.refresh_description(&root);
                         }
-                        None => refresh_graph = true,
+                        _ => refresh_graph = true,
                     },
                     _ => {}
                 }
@@ -859,6 +862,21 @@ pub(crate) fn packages_to_build(
         .collect()
 }
 
+/// Whether a watched `DESCRIPTION` event can be applied by re-reading that one
+/// file, instead of refreshing the whole package graph.
+///
+/// `tracked` is whether the db already holds an input for the file's root. Both
+/// halves are about *package-ness* moving, which is what the graph records:
+///
+/// - **An untracked root** may have just become a package — the file is new.
+/// - **A file no longer on disk** may have just stopped being one. The watcher
+///   collapses create/change/delete into one event, so a deletion arrives here
+///   looking exactly like an edit; without the disk check it would only blank
+///   the tracked text and leave the graph pointing at a package that is gone.
+fn description_edit_is_local(path: &Path, tracked: bool) -> bool {
+    tracked && path.is_file()
+}
+
 /// Format a package count for a progress message, pluralizing the noun
 /// ("1 package", "3 packages").
 fn package_count(n: usize) -> String {
@@ -875,6 +893,32 @@ pub(crate) fn now_unix_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The watcher reports a create, an edit, and a delete as the same event, so
+    /// the decision has to be read off the disk state, not off the event.
+    #[test]
+    fn a_description_delete_is_not_a_local_edit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("DESCRIPTION");
+        std::fs::write(&path, "Package: p\n").expect("DESCRIPTION");
+
+        assert!(
+            description_edit_is_local(&path, true),
+            "an edit to a tracked root's DESCRIPTION only re-reads that file"
+        );
+        assert!(
+            !description_edit_is_local(&path, false),
+            "an untracked root may have just become a package"
+        );
+
+        // The regression this guards: a deleted DESCRIPTION means the directory
+        // may no longer be a package at all, which only the graph refresh sees.
+        std::fs::remove_file(&path).expect("remove");
+        assert!(
+            !description_edit_is_local(&path, true),
+            "a deleted DESCRIPTION reshapes package roots, tracked or not"
+        );
+    }
 
     #[test]
     fn guard_contains_a_panic_and_reports_completion() {

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -26,9 +26,11 @@ pub(crate) struct WatchedFilesBatch {
     /// editor — re-`upsert_file` from disk. Open buffers are authoritative, so the
     /// classifier filters them out here (see [`classify_watched_files`]).
     pub(crate) r_changed: Vec<PathBuf>,
-    /// A `DESCRIPTION`/`NAMESPACE` was created, changed, or deleted — refresh the
-    /// package graph (re-reads that metadata from disk).
-    pub(crate) package_meta_changed: bool,
+    /// Package metadata that changed on disk, with what each path is. Carrying
+    /// the paths rather than a single bool is what lets the lint thread refresh
+    /// only what moved: a `DESCRIPTION` edit for a known root re-reads that one
+    /// file, where a `NAMESPACE` change still reshapes the package graph.
+    pub(crate) meta_changed: Vec<(PathBuf, WatchedKind)>,
 }
 
 impl WatchedFilesBatch {
@@ -37,7 +39,16 @@ impl WatchedFilesBatch {
         self.r_created.is_empty()
             && self.r_deleted.is_empty()
             && self.r_changed.is_empty()
-            && !self.package_meta_changed
+            && self.meta_changed.is_empty()
+    }
+
+    /// Whether anything here can flip the package-wide roxygen markdown
+    /// default: the `Roxygen` field of a `DESCRIPTION`, or `man/roxygen/meta.R`.
+    /// A `NAMESPACE` change cannot, so it must not trigger the re-resolve.
+    pub(crate) fn touches_roxygen_options(&self) -> bool {
+        self.meta_changed
+            .iter()
+            .any(|(_, kind)| matches!(kind, WatchedKind::Description | WatchedKind::RoxygenMeta))
     }
 }
 
@@ -52,11 +63,16 @@ pub(crate) struct WatchedClassification {
 }
 
 /// What a watched path is, by name/extension.
-enum WatchedKind {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WatchedKind {
     /// An R source (`.R`/`.r`).
     RSource,
-    /// `DESCRIPTION` or `NAMESPACE` (package metadata).
-    PackageMeta,
+    /// A package `DESCRIPTION`.
+    Description,
+    /// A package `NAMESPACE`.
+    Namespace,
+    /// `man/roxygen/meta.R` — roxygen2 *options*, not source.
+    RoxygenMeta,
     /// `arity.toml` (configuration).
     Config,
     /// Anything else (ignored — a watcher glob may over-match).
@@ -68,14 +84,15 @@ fn classify_path(path: &Path) -> WatchedKind {
     // by extension. Name wins (a file literally named `NAMESPACE` has no ext).
     match path.file_name().and_then(|n| n.to_str()) {
         Some("arity.toml") => return WatchedKind::Config,
-        Some("DESCRIPTION") | Some("NAMESPACE") => return WatchedKind::PackageMeta,
+        Some("DESCRIPTION") => return WatchedKind::Description,
+        Some("NAMESPACE") => return WatchedKind::Namespace,
         _ => {}
     }
     // `man/roxygen/meta.R` is an `.R` file by extension but carries roxygen2
     // *options* (it can flip the package-wide markdown default), not source:
     // treat it as package metadata so an edit re-resolves the flag.
     if path.ends_with("man/roxygen/meta.R") {
-        return WatchedKind::PackageMeta;
+        return WatchedKind::RoxygenMeta;
     }
     match path.extension().and_then(|e| e.to_str()) {
         Some("R") | Some("r") => WatchedKind::RSource,
@@ -108,9 +125,11 @@ pub(crate) fn classify_watched_files(
                     batch.r_changed.push(path);
                 }
             }
-            // A create/change/delete of package metadata all reduce to the same
-            // refresh; the graph re-reads whatever is (or is not) on disk now.
-            WatchedKind::PackageMeta => batch.package_meta_changed = true,
+            // A create/change/delete all reduce to the same refresh; the db
+            // re-reads whatever is (or is not) on disk now.
+            kind @ (WatchedKind::Description
+            | WatchedKind::Namespace
+            | WatchedKind::RoxygenMeta) => batch.meta_changed.push((path, kind)),
             WatchedKind::Config => config_changed = true,
             WatchedKind::Other => {}
         }
@@ -209,7 +228,7 @@ mod tests {
         assert_eq!(c.batch.r_created.len(), 1);
         assert_eq!(c.batch.r_deleted.len(), 1);
         assert_eq!(c.batch.r_changed.len(), 1);
-        assert!(!c.batch.package_meta_changed);
+        assert!(c.batch.meta_changed.is_empty());
         assert!(!c.config_changed);
     }
 
@@ -229,10 +248,31 @@ mod tests {
     }
 
     #[test]
-    fn description_and_namespace_set_package_meta() {
-        for name in ["DESCRIPTION", "NAMESPACE"] {
+    fn package_metadata_is_classified_by_kind() {
+        // The kinds stay apart so the lint thread can refresh only what moved:
+        // a NAMESPACE reshapes the package graph, a DESCRIPTION usually does not,
+        // and only the latter two can flip the roxygen markdown default.
+        let cases = [
+            ("DESCRIPTION", WatchedKind::Description, true),
+            ("NAMESPACE", WatchedKind::Namespace, false),
+            ("man/roxygen/meta.R", WatchedKind::RoxygenMeta, true),
+        ];
+        for (name, kind, roxygen) in cases {
             let c = classify(vec![event(name, FileChangeType::CHANGED)], &[]);
-            assert!(c.batch.package_meta_changed, "{name} sets package meta");
+            assert_eq!(
+                c.batch
+                    .meta_changed
+                    .iter()
+                    .map(|(_, k)| *k)
+                    .collect::<Vec<_>>(),
+                vec![kind],
+                "{name}"
+            );
+            assert_eq!(
+                c.batch.touches_roxygen_options(),
+                roxygen,
+                "{name} roxygen options"
+            );
             assert!(!c.config_changed);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -982,6 +982,10 @@ fn run_lint(
 /// Discover `.R` files under `paths` and apply autofixes in place. Returns
 /// `Some(exit_code)` only on a hard error (discovery / IO); on success returns
 /// `None` so the caller falls through to the normal reporting pass.
+///
+/// Deliberately `collect_r_files`, not `collect_lint_files`: no `DESCRIPTION`
+/// rule ships a fix, and reading one here would only invite feeding it to the R
+/// parser. The day a DCF fix lands, this has to widen.
 fn apply_fixes_to_paths(
     paths: &[PathBuf],
     config: &LintConfig,

--- a/src/project.rs
+++ b/src/project.rs
@@ -21,10 +21,10 @@ pub use description::{
 };
 pub use exports::{DefKind, file_def_sites, file_exports, file_free_reads, file_qualified_reads};
 pub use graph::{
-    ClassIndex, DefIndex, ExternalResolution, PackageCollation, PackageInfo, Project,
-    ProjectMember, ReadIndex, ReverseSources, Visibility, discover_packages, expected_r_sources,
-    external_resolution, project_classes, project_defs, project_graph, project_reads,
-    reverse_source_edges, visible_symbols, workspace_project,
+    ClassIndex, DefIndex, ExternalResolution, PackageCollation, PackageDeclarations, PackageInfo,
+    Project, ProjectMember, ReadIndex, ReverseSources, Visibility, attached_names,
+    discover_packages, expected_r_sources, external_resolution, project_classes, project_defs,
+    project_graph, project_reads, reverse_source_edges, visible_symbols, workspace_project,
 };
 pub use scope::{FileFacts, FileScope, ProjectScope, ReadBinding, ReadSite, package_root};
 pub use sequence::{collect_top_level_events, collect_top_level_events_spanned};

--- a/src/project.rs
+++ b/src/project.rs
@@ -23,8 +23,9 @@ pub use exports::{DefKind, file_def_sites, file_exports, file_free_reads, file_q
 pub use graph::{
     ClassIndex, DefIndex, ExternalResolution, PackageCollation, PackageDeclarations, PackageInfo,
     Project, ProjectMember, ReadIndex, ReverseSources, Visibility, attached_names,
-    discover_packages, expected_r_sources, external_resolution, project_classes, project_defs,
-    project_graph, project_reads, reverse_source_edges, visible_symbols, workspace_project,
+    discover_packages, expected_r_sources, external_resolution, package_facts_for, project_classes,
+    project_defs, project_graph, project_reads, reverse_source_edges, visible_symbols,
+    workspace_project,
 };
 pub use scope::{FileFacts, FileScope, ProjectScope, ReadBinding, ReadSite, package_root};
 pub use sequence::{collect_top_level_events, collect_top_level_events_spanned};

--- a/src/project.rs
+++ b/src/project.rs
@@ -6,6 +6,7 @@
 //! feeds cross-file name resolution.
 
 pub mod classes;
+pub mod deps;
 pub mod description;
 pub mod exports;
 pub mod graph;
@@ -16,16 +17,17 @@ pub mod source;
 pub use classes::{
     ClassDef, ClassLocation, ClassSystem, class_name_at_offset, file_class_defs, locate_class_def,
 };
+pub use deps::{PackageReferences, file_package_references};
 pub use description::{
     Dependency, DependencyField, DescriptionCache, DescriptionCompat, DescriptionFacts,
 };
 pub use exports::{DefKind, file_def_sites, file_exports, file_free_reads, file_qualified_reads};
 pub use graph::{
     ClassIndex, DefIndex, ExternalResolution, PackageCollation, PackageDeclarations, PackageInfo,
-    Project, ProjectMember, ReadIndex, ReverseSources, Visibility, attached_names,
-    discover_packages, expected_r_sources, external_resolution, package_facts_for, project_classes,
-    project_defs, project_graph, project_reads, reverse_source_edges, visible_symbols,
-    workspace_project,
+    PackageUsage, Project, ProjectMember, ReadIndex, ReverseSources, Visibility, attached_names,
+    discover_packages, expected_r_sources, external_resolution, package_facts_for, package_usage,
+    package_usage_for, project_classes, project_defs, project_graph, project_reads,
+    reverse_source_edges, visible_symbols, workspace_project,
 };
 pub use scope::{
     FileFacts, FileScope, ProjectScope, ReadBinding, ReadSite, is_package_root, package_root,

--- a/src/project.rs
+++ b/src/project.rs
@@ -27,7 +27,9 @@ pub use graph::{
     project_defs, project_graph, project_reads, reverse_source_edges, visible_symbols,
     workspace_project,
 };
-pub use scope::{FileFacts, FileScope, ProjectScope, ReadBinding, ReadSite, package_root};
+pub use scope::{
+    FileFacts, FileScope, ProjectScope, ReadBinding, ReadSite, is_package_root, package_root,
+};
 pub use sequence::{collect_top_level_events, collect_top_level_events_spanned};
 pub use source::{
     LinkLiteral, SourceEdge, SourceEdgeKey, SourceLiteralEdge, SourceTarget, StringLiteral,

--- a/src/project.rs
+++ b/src/project.rs
@@ -16,6 +16,9 @@ pub mod source;
 pub use classes::{
     ClassDef, ClassLocation, ClassSystem, class_name_at_offset, file_class_defs, locate_class_def,
 };
+pub use description::{
+    Dependency, DependencyField, DescriptionCache, DescriptionCompat, DescriptionFacts,
+};
 pub use exports::{DefKind, file_def_sites, file_exports, file_free_reads, file_qualified_reads};
 pub use graph::{
     ClassIndex, DefIndex, ExternalResolution, PackageCollation, PackageInfo, Project,

--- a/src/project/deps.rs
+++ b/src/project/deps.rs
@@ -1,0 +1,273 @@
+//! Every way one R file can name a package.
+//!
+//! The per-file half of the cross-file question `unused-dependency` asks: does
+//! *anything* in this package reach the package this `DESCRIPTION` declares?
+//! Answering it needs the union over a package's whole R source set, so the
+//! per-file part is a range-free `Eq` projection — the backdating-firewall
+//! shape the project layer uses everywhere (`.claude/rules/semantic.md`).
+//! Editing a function body changes the model but leaves this set equal, so
+//! neither the union above it nor the rule re-runs.
+//!
+//! What counts as reaching a package is deliberately broad, because the
+//! consumer reports on *absence*: a missed signal is a maintainer told to
+//! delete a dependency their package needs. So the collector over-approximates
+//! on purpose and keeps the weakest signal — a bare string that looks like a
+//! package name — in [its own field](PackageReferences::string_mentions), where
+//! the trade stays visible and revocable.
+
+use std::collections::BTreeSet;
+
+use rowan::ast::AstNode as _;
+
+use crate::ast::{CallExpr, RoxygenBlock};
+use crate::semantic::SemanticModel;
+use crate::syntax::{SyntaxKind, SyntaxNode};
+
+/// The roxygen tags that name a package, and how many of their words do.
+///
+/// `@importFrom pkg a b` names one package and then symbols; `@import a b`
+/// names only packages. `@rawNamespace` carries arbitrary directive text, so
+/// every word in it is treated as a candidate — over-approximating, which for
+/// this consumer means staying quiet rather than accusing.
+const PACKAGE_TAGS: [(&str, Words); 6] = [
+    ("import", Words::All),
+    ("importFrom", Words::First),
+    ("importClassesFrom", Words::First),
+    ("importMethodsFrom", Words::First),
+    ("rawNamespace", Words::All),
+    ("depends", Words::All),
+];
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Words {
+    First,
+    All,
+}
+
+/// The `methods` generics whose presence means a package needs `Imports:
+/// methods` with no textual reference to `methods` anywhere.
+///
+/// R's own check (`tools:::.check_packages_used`) looks for `setClass` and
+/// `setMethod`; the other three are the same fact and are included because this
+/// list only ever *silences* a finding.
+const METHODS_CALLS: [&str; 5] = [
+    "setClass",
+    "setMethod",
+    "setGeneric",
+    "setRefClass",
+    "setValidity",
+];
+
+/// Every package one R file names, as a range-free `Eq` projection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PackageReferences {
+    /// Packages the code reaches directly: the left of every `::` / `:::`, and
+    /// the package argument of every `library` / `require` / `requireNamespace`
+    /// / `loadNamespace` call — **at any depth**.
+    ///
+    /// Depth matters: `requireNamespace()` inside a function body is *the*
+    /// conditional-dependency idiom, and `SemanticModel::loaded_packages` is
+    /// deliberately top-level-only because it models *attachment*, a narrower
+    /// fact. Reading this off attachment would turn the most careful way to
+    /// depend on a package into a report that it is unused.
+    pub direct: BTreeSet<String>,
+    /// Packages named by a roxygen `@import`/`@importFrom`/`@importClassesFrom`
+    /// /`@importMethodsFrom`/`@rawNamespace` tag.
+    ///
+    /// Redundant with NAMESPACE *when NAMESPACE is current* — and the point is
+    /// that it may not be: mid-`document()`, right after `use_package()`, or in
+    /// a package whose NAMESPACE is generated at build time.
+    pub roxygen_imports: BTreeSet<String>,
+    /// Every string literal shaped like a package name. **Not a reference** —
+    /// the over-approximation a consumer consults so a dynamic use
+    /// (`do.call("::", …)`, `requireNamespace(pkg_name)`,
+    /// `system.file(package = "pkg")`, a "please install pkg" message) can
+    /// never produce a false report of disuse.
+    pub string_mentions: BTreeSet<String>,
+    /// Whether the file defines an S4 or reference class or method — R's own
+    /// `uses_methods` flag, which makes `Imports: methods` mandatory with no
+    /// textual reference to `methods` anywhere.
+    pub uses_methods: bool,
+}
+
+/// Derive [`PackageReferences`] for one file.
+///
+/// Pure, and deliberately in the project layer rather than in a rule: it walks
+/// the tree, and no lint rule may do that outside the driver's shared walk.
+pub fn file_package_references(root: &SyntaxNode, model: &SemanticModel) -> PackageReferences {
+    let mut refs = PackageReferences {
+        direct: model
+            .referenced_packages()
+            .iter()
+            .map(|pkg| pkg.to_string())
+            .chain(
+                model
+                    .loaded_packages()
+                    .iter()
+                    .map(|pkg| pkg.name.to_string()),
+            )
+            .collect(),
+        ..Default::default()
+    };
+
+    for node in root.descendants() {
+        match node.kind() {
+            SyntaxKind::ROXYGEN_BLOCK => {
+                let Some(block) = RoxygenBlock::cast(node.clone()) else {
+                    continue;
+                };
+                collect_roxygen_imports(&block, &mut refs.roxygen_imports);
+            }
+            SyntaxKind::CALL_EXPR => {
+                if let Some(call) = CallExpr::cast(node.clone())
+                    && call
+                        .callee_name()
+                        .is_some_and(|name| METHODS_CALLS.contains(&name.as_str()))
+                {
+                    refs.uses_methods = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for token in root
+        .descendants_with_tokens()
+        .filter_map(|el| el.into_token())
+        .filter(|token| token.kind() == SyntaxKind::STRING)
+    {
+        let text = token.text();
+        let inner = text
+            .strip_prefix(['"', '\''])
+            .and_then(|rest| rest.get(..rest.len().saturating_sub(1)))
+            .unwrap_or(text);
+        if is_package_shaped(inner) {
+            refs.string_mentions.insert(inner.to_string());
+        }
+    }
+
+    refs
+}
+
+fn collect_roxygen_imports(block: &RoxygenBlock, out: &mut BTreeSet<String>) {
+    for section in block.sections() {
+        let Some(tag) = section.tag() else {
+            continue;
+        };
+        let Some(name) = tag.name() else {
+            continue;
+        };
+        let Some((_, words)) = PACKAGE_TAGS
+            .iter()
+            .find(|(known, _)| *known == name.as_str())
+        else {
+            continue;
+        };
+        // The parser splits an arg-bearing tag into `arg` + `text`, and which
+        // side a word lands on depends on the tag; joining them back is what
+        // makes one word-splitting rule cover every shape here.
+        let arg = tag.arg().map(|t| t.text().to_string()).unwrap_or_default();
+        let text = tag.text().map(|t| t.text().to_string()).unwrap_or_default();
+        let joined = format!("{arg} {text}");
+        let mut candidates = joined
+            .split(|c: char| c.is_whitespace() || matches!(c, ',' | '(' | ')' | '"' | '\''))
+            .filter(|word| is_package_shaped(word));
+        match words {
+            Words::First => out.extend(candidates.next().map(str::to_string)),
+            Words::All => out.extend(candidates.map(str::to_string)),
+        }
+    }
+}
+
+/// Whether `name` could be an R package name: R requires at least two
+/// characters, starting with a letter, and only letters, digits, and dots.
+fn is_package_shaped(name: &str) -> bool {
+    name.len() >= 2
+        && name.starts_with(|c: char| c.is_ascii_alphabetic())
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn refs(source: &str) -> PackageReferences {
+        let parsed = crate::parser::parse(source);
+        let model = SemanticModel::build(&parsed.cst);
+        file_package_references(&parsed.cst, &model)
+    }
+
+    #[test]
+    fn qualified_access_is_direct() {
+        assert!(refs("dplyr::filter(x)\n").direct.contains("dplyr"));
+        assert!(refs("dplyr:::internal(x)\n").direct.contains("dplyr"));
+    }
+
+    #[test]
+    fn attaching_is_direct() {
+        assert!(refs("library(dplyr)\n").direct.contains("dplyr"));
+        assert!(refs("require(dplyr)\n").direct.contains("dplyr"));
+    }
+
+    /// The conditional-dependency idiom. `loaded_packages` is top-level-only,
+    /// so reading this off attachment would miss the most careful way to depend
+    /// on a package.
+    #[test]
+    fn a_load_inside_a_function_body_is_direct() {
+        let source = "f <- function() {\n  requireNamespace(\"dplyr\")\n}\n";
+        assert!(refs(source).direct.contains("dplyr"));
+        assert!(
+            refs("f <- function() loadNamespace(\"dplyr\")\n")
+                .direct
+                .contains("dplyr")
+        );
+    }
+
+    #[test]
+    fn roxygen_import_tags_name_packages() {
+        let source = "#' @importFrom dplyr filter select\nf <- function() 1\n";
+        let found = refs(source);
+        assert!(found.roxygen_imports.contains("dplyr"));
+        // Only the first word of `@importFrom` is a package.
+        assert!(!found.roxygen_imports.contains("filter"));
+    }
+
+    #[test]
+    fn roxygen_import_names_every_package() {
+        let source = "#' @import dplyr rlang\nf <- function() 1\n";
+        let found = refs(source);
+        assert!(found.roxygen_imports.contains("dplyr"));
+        assert!(found.roxygen_imports.contains("rlang"));
+    }
+
+    #[test]
+    fn s4_definitions_use_methods() {
+        assert!(refs("setClass(\"A\", representation(x = \"numeric\"))\n").uses_methods);
+        assert!(refs("setMethod(\"show\", \"A\", function(object) NULL)\n").uses_methods);
+        assert!(!refs("f <- function() 1\n").uses_methods);
+    }
+
+    #[test]
+    fn package_shaped_strings_are_mentions_not_references() {
+        let found = refs("do.call(\"::\", list(\"dplyr\", \"filter\"))\n");
+        assert!(found.string_mentions.contains("dplyr"));
+        assert!(!found.direct.contains("dplyr"));
+    }
+
+    /// A whole string has to look like a package name, so prose does not
+    /// silence every dependency the package declares. That also means a package
+    /// named only inside a sentence is not a mention — which is right: the
+    /// dynamic idioms this guard exists for all pass the name as its own
+    /// string.
+    #[test]
+    fn prose_is_not_a_package_mention() {
+        let found = refs("message(\"could not find the file\")\n");
+        assert!(found.string_mentions.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn a_package_argument_is_a_mention() {
+        let found = refs("system.file(\"extdata\", package = \"dplyr\")\n");
+        assert!(found.string_mentions.contains("dplyr"));
+    }
+}

--- a/src/project/description.rs
+++ b/src/project/description.rs
@@ -17,23 +17,192 @@
 //! that compute their markdown flag at roxygenize time — it never *invents* a
 //! markdown default.
 
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use crate::ast::{Arg, AstNode, CallExpr, HasArgList};
 use crate::config::CompatVersion;
+use crate::dcf::deps::dependency_entries;
 use crate::parser::parse;
 use crate::project::scope::package_root;
 use crate::syntax::SyntaxKind;
+
+/// Which field declared a dependency. The five carry different R semantics and
+/// consumers must not conflate them — see [`DescriptionFacts::attached_packages`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DependencyField {
+    Depends,
+    Imports,
+    Suggests,
+    LinkingTo,
+    Enhances,
+}
+
+impl DependencyField {
+    /// Every field, in R's canonical order.
+    pub const ALL: [DependencyField; 5] = [
+        DependencyField::Depends,
+        DependencyField::Imports,
+        DependencyField::Suggests,
+        DependencyField::LinkingTo,
+        DependencyField::Enhances,
+    ];
+
+    /// The DCF field name.
+    pub fn name(self) -> &'static str {
+        match self {
+            DependencyField::Depends => "Depends",
+            DependencyField::Imports => "Imports",
+            DependencyField::Suggests => "Suggests",
+            DependencyField::LinkingTo => "LinkingTo",
+            DependencyField::Enhances => "Enhances",
+        }
+    }
+}
+
+/// One declared dependency: a package, and the version floor its entry states.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dependency {
+    pub field: DependencyField,
+    pub name: String,
+    /// The lower bound (`>=`/`>`) the entry declares, verbatim. Other operators
+    /// state no floor and are dropped, exactly as the R floor always was.
+    pub version: Option<String>,
+}
+
+/// Everything a package's `DESCRIPTION` contributes to analysis, derived once.
+///
+/// **Range-free on purpose.** This rides in salsa, and the project layer's rule
+/// is that a projection carrying spans cannot backdate — a `DESCRIPTION` save
+/// would then cost a full project-graph rebuild. Spans live in the DCF CST,
+/// where a consumer that needs them (a diagnostic, a hover) re-derives them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DescriptionFacts {
+    /// The `Package` field, when non-empty.
+    pub package: Option<String>,
+    /// Every declared dependency, in field then source order. **`R` is not
+    /// here**: it names the language, not a package, and its floor is
+    /// [`compat`](Self::compat). Letting it reach an attach set would be
+    /// catastrophic — no index can enumerate a package called `R`, so the
+    /// conservative gate would silence every diagnostic in the package.
+    pub dependencies: Vec<Dependency>,
+    /// The tool-version floors the version-aware lint rules read.
+    pub compat: DescriptionCompat,
+    /// The `Roxygen` field's value, as R source.
+    pub roxygen: Option<String>,
+    /// Every `Collate*` field's entries.
+    pub collate: BTreeSet<String>,
+}
+
+impl DescriptionFacts {
+    /// Derive the facts from `DESCRIPTION` text. The parser's diagnostics are
+    /// dropped here: this is the *analysis* reader, and reporting a malformed
+    /// `DESCRIPTION` is a lint's job, not a side effect of asking for a floor.
+    pub fn from_text(text: &str) -> Self {
+        Self::from_document(&crate::dcf::parse(text).document())
+    }
+
+    /// [`from_text`](Self::from_text) over an already-parsed document.
+    pub fn from_document(document: &crate::dcf::Document) -> Self {
+        let get = |name: &str| document.field(name).map(|field| field.folded_value());
+
+        let mut dependencies = Vec::new();
+        let mut r_floor = None;
+        let mut seen_r = false;
+        for field in DependencyField::ALL {
+            // First occurrence wins, matching `Document::field` and every
+            // scalar reader here. R's `read.dcf` takes the last; closing that
+            // divergence is its own deliberate change.
+            let Some(node) = document.field(field.name()) else {
+                continue;
+            };
+            for entry in dependency_entries(&node) {
+                if entry.name == "R" {
+                    // Only the first `R` entry of `Depends` states the floor —
+                    // and an entry with no constraint states none, rather than
+                    // deferring to a later one.
+                    if field == DependencyField::Depends && !seen_r {
+                        seen_r = true;
+                        r_floor = entry
+                            .lower_bound()
+                            .and_then(|c| CompatVersion::parse(c.version.trim()));
+                    }
+                    continue;
+                }
+                dependencies.push(Dependency {
+                    field,
+                    name: entry.name.to_string(),
+                    version: entry.lower_bound().map(|c| c.version.to_string()),
+                });
+            }
+        }
+
+        // `fields()` is record-blind on purpose: a stray blank line splits a
+        // DESCRIPTION into two DCF records, and a `Collate` after that split
+        // still names files R will load. R picks an OS-specific
+        // `Collate@unix`/`Collate@windows` over plain `Collate`; we union every
+        // `Collate*`, since over-including only tightens completeness.
+        let mut collate = BTreeSet::new();
+        for field in document.fields() {
+            if !field.name().starts_with("Collate") {
+                continue;
+            }
+            for entry in field.folded_value().split_whitespace() {
+                let name = entry.trim_matches(['\'', '"']);
+                if !name.is_empty() {
+                    collate.insert(name.to_string());
+                }
+            }
+        }
+
+        DescriptionFacts {
+            package: get("Package").filter(|name| !name.is_empty()),
+            dependencies,
+            compat: DescriptionCompat {
+                r: r_floor,
+                roxygen2: get("Config/roxygen2/version")
+                    .or_else(|| get("RoxygenNote"))
+                    .and_then(|v| CompatVersion::parse(v.trim())),
+            },
+            roxygen: get("Roxygen"),
+            collate,
+        }
+    }
+
+    /// The dependencies declared by one field.
+    pub fn in_field(&self, field: DependencyField) -> impl Iterator<Item = &Dependency> {
+        self.dependencies.iter().filter(move |d| d.field == field)
+    }
+
+    /// Packages **attached** to the search path when this package loads, so
+    /// their exports resolve as bare names.
+    ///
+    /// `Depends` only. An `Imports` package is *not* attached — R reaches it
+    /// solely through `pkg::` or a NAMESPACE `importFrom`/`import`, both of
+    /// which the project layer already models. Adding `Imports` here would
+    /// resolve names that fail under `R CMD check`.
+    pub fn attached_packages(&self) -> BTreeSet<String> {
+        self.in_field(DependencyField::Depends)
+            .map(|d| d.name.clone())
+            .collect()
+    }
+
+    /// Every declared package, whatever the field. *Referenced* — worth
+    /// harvesting and fetching — but not attached.
+    pub fn declared_packages(&self) -> BTreeSet<String> {
+        self.dependencies.iter().map(|d| d.name.clone()).collect()
+    }
+}
 
 /// The package-wide roxygen markdown default for the package at `root`
 /// (a directory holding `DESCRIPTION`): `man/roxygen/meta.R` when statically
 /// resolvable, else the `Roxygen` field of `DESCRIPTION`, else `false`
 /// (roxygen2's default). Touches disk.
 pub fn roxygen_markdown_default(root: &Path) -> bool {
-    let desc = std::fs::read_to_string(root.join("DESCRIPTION"))
-        .ok()
-        .and_then(|text| roxygen_field(&text))
-        .and_then(|expr| markdown_from_r_text(&expr));
+    let desc = facts_at(root)
+        .roxygen
+        .as_deref()
+        .and_then(markdown_from_r_text);
     let meta = std::fs::read_to_string(root.join("man/roxygen/meta.R"))
         .ok()
         .and_then(|text| markdown_from_r_text(&text));
@@ -85,12 +254,20 @@ impl MarkdownDefaultResolver {
 /// (a directory holding one). `None` when there is no readable DESCRIPTION or
 /// it declares no `Package`. Touches disk.
 pub fn package_name(root: &Path) -> Option<String> {
-    let text = std::fs::read_to_string(root.join("DESCRIPTION")).ok()?;
-    crate::dcf::parse(&text)
-        .document()
-        .field("Package")
-        .map(|field| field.folded_value())
-        .filter(|name| !name.is_empty())
+    facts_at(root).package
+}
+
+/// The [`DescriptionFacts`] of the package at `root` (a directory holding
+/// `DESCRIPTION`). All-default when there is no readable one. Touches disk.
+///
+/// This is the single disk-reading entry point for DESCRIPTION facts. Callers
+/// walking a whole package should go through [`DescriptionCache`] instead, so
+/// the file is read and parsed once per root rather than once per question.
+pub fn facts_at(root: &Path) -> DescriptionFacts {
+    match std::fs::read_to_string(root.join("DESCRIPTION")) {
+        Ok(text) => DescriptionFacts::from_text(&text),
+        Err(_) => DescriptionFacts::default(),
+    }
 }
 
 /// [`package_name`] resolved for a single file: walk up to the enclosing
@@ -102,15 +279,6 @@ pub fn package_name(root: &Path) -> Option<String> {
 /// which is exactly the case that matters for `internal-function`.
 pub fn package_name_for_file(path: &Path) -> Option<String> {
     package_root(path).and_then(|root| package_name(&root))
-}
-
-/// The `Roxygen` field's value from DESCRIPTION text (continuation lines
-/// joined), if present.
-fn roxygen_field(description: &str) -> Option<String> {
-    crate::dcf::parse(description)
-        .document()
-        .field("Roxygen")
-        .map(|field| field.folded_value())
 }
 
 /// The tool-version facts a package's `DESCRIPTION` declares, for the
@@ -131,17 +299,7 @@ pub struct DescriptionCompat {
 /// holding `DESCRIPTION`). One disk read for both fields; all-`None` when
 /// there is no readable `DESCRIPTION`. Touches disk.
 pub fn description_compat(root: &Path) -> DescriptionCompat {
-    let Ok(text) = std::fs::read_to_string(root.join("DESCRIPTION")) else {
-        return DescriptionCompat::default();
-    };
-    let document = crate::dcf::parse(&text).document();
-    let get = |name: &str| document.field(name).map(|field| field.folded_value());
-    DescriptionCompat {
-        r: get("Depends").as_deref().and_then(r_depends_floor),
-        roxygen2: get("Config/roxygen2/version")
-            .or_else(|| get("RoxygenNote"))
-            .and_then(|v| CompatVersion::parse(v.trim())),
-    }
+    facts_at(root).compat
 }
 
 /// [`description_compat`] resolved for a single file: walk up to the enclosing
@@ -154,29 +312,38 @@ pub fn description_compat_for_file(path: &Path) -> DescriptionCompat {
         .unwrap_or_default()
 }
 
-/// The R version floor a `Depends` field declares: the comma-separated entry
-/// naming exactly `R`, with a parenthesized `>=`/`>` constraint (any other
-/// operator states no floor). `Depends: R (>= 4.1.0), stats` → `4.1.0`.
-fn r_depends_floor(depends: &str) -> Option<CompatVersion> {
-    for entry in depends.split(',') {
-        let entry = entry.trim();
-        let (name, constraint) = match entry.find('(') {
-            Some(open) => (
-                entry[..open].trim(),
-                entry[open + 1..].trim_end().strip_suffix(')'),
-            ),
-            None => (entry, None),
-        };
-        if name != "R" {
-            continue;
-        }
-        let constraint = constraint?.trim();
-        let version = constraint
-            .strip_prefix(">=")
-            .or_else(|| constraint.strip_prefix('>'))?;
-        return CompatVersion::parse(version.trim());
+/// A per-package-root memo over [`facts_at`], for the batch walks (format,
+/// lint, `arity index`) that have no salsa database and would otherwise read
+/// and parse one `DESCRIPTION` per question per file.
+///
+/// The salsa paths do not use this — they read the tracked `DESCRIPTION` input
+/// instead, so an edit invalidates rather than going stale.
+#[derive(Debug, Default)]
+pub struct DescriptionCache {
+    by_root: std::collections::HashMap<std::path::PathBuf, std::sync::Arc<DescriptionFacts>>,
+}
+
+impl DescriptionCache {
+    pub fn new() -> Self {
+        Self::default()
     }
-    None
+
+    /// The facts for the package at `root`, read once per root.
+    pub fn at(&mut self, root: &Path) -> std::sync::Arc<DescriptionFacts> {
+        self.by_root
+            .entry(root.to_path_buf())
+            .or_insert_with(|| std::sync::Arc::new(facts_at(root)))
+            .clone()
+    }
+
+    /// The facts for the package enclosing `file`, or all-default when it is
+    /// outside any package.
+    pub fn for_file(&mut self, file: &Path) -> std::sync::Arc<DescriptionFacts> {
+        match package_root(file) {
+            Some(root) => self.at(&root),
+            None => std::sync::Arc::new(DescriptionFacts::default()),
+        }
+    }
 }
 
 /// Statically resolve the `markdown` element of the R text's value: the text's
@@ -287,7 +454,14 @@ mod tests {
 
     #[test]
     fn r_depends_floor_parses_constraint_shapes() {
-        let floor = |s: &str| r_depends_floor(s);
+        // Unchanged from when this was a bespoke string splitter: the floor is
+        // now a projection of `dcf::deps`, and these cases are what prove the
+        // generalization changed no behavior.
+        let floor = |s: &str| {
+            DescriptionFacts::from_text(&format!("Package: p\nDepends: {s}\n"))
+                .compat
+                .r
+        };
         assert_eq!(floor("R (>= 4.1)"), CompatVersion::parse("4.1"));
         assert_eq!(floor("R (> 4.0.5)"), CompatVersion::parse("4.0.5"));
         assert_eq!(
@@ -299,6 +473,84 @@ mod tests {
         assert_eq!(floor("R (== 4.1)"), None);
         assert_eq!(floor("Rcpp (>= 1.0)"), None);
         assert_eq!(floor(""), None);
+    }
+
+    #[test]
+    fn r_is_never_a_dependency() {
+        // `R` names the language. If it reached an attach set, `package_indexed`
+        // would fail for it and suppress every diagnostic in the package.
+        let facts = DescriptionFacts::from_text("Package: p\nDepends: R (>= 4.1), stats\n");
+        assert_eq!(facts.attached_packages(), ["stats".to_string()].into());
+        assert_eq!(facts.declared_packages(), ["stats".to_string()].into());
+        assert_eq!(facts.compat.r, CompatVersion::parse("4.1"));
+    }
+
+    #[test]
+    fn every_dependency_field_is_parsed() {
+        let facts = DescriptionFacts::from_text(
+            "Package: p\n\
+             Depends: R (>= 4.1), stats\n\
+             Imports: dplyr (>= 1.0.0), rlang\n\
+             Suggests: testthat\n\
+             LinkingTo: cpp11\n\
+             Enhances: data.table\n",
+        );
+        let named = |field: DependencyField| {
+            facts
+                .in_field(field)
+                .map(|d| d.name.as_str())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(named(DependencyField::Depends), ["stats"]);
+        assert_eq!(named(DependencyField::Imports), ["dplyr", "rlang"]);
+        assert_eq!(named(DependencyField::Suggests), ["testthat"]);
+        assert_eq!(named(DependencyField::LinkingTo), ["cpp11"]);
+        assert_eq!(named(DependencyField::Enhances), ["data.table"]);
+
+        // Only `Depends` attaches; everything is declared.
+        assert_eq!(facts.attached_packages(), ["stats".to_string()].into());
+        assert_eq!(facts.declared_packages().len(), 6);
+
+        let dplyr = facts
+            .in_field(DependencyField::Imports)
+            .next()
+            .expect("dplyr");
+        assert_eq!(dplyr.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn facts_collect_collate_and_roxygen() {
+        let facts = DescriptionFacts::from_text(
+            "Package: p\n\
+             Roxygen: list(markdown = TRUE)\n\
+             Collate: 'a.R' b.R\n\
+             Collate@windows: c.R\n",
+        );
+        assert_eq!(facts.package.as_deref(), Some("p"));
+        assert_eq!(facts.roxygen.as_deref(), Some("list(markdown = TRUE)"));
+        assert_eq!(
+            facts.collate,
+            ["a.R".to_string(), "b.R".to_string(), "c.R".to_string()].into()
+        );
+    }
+
+    #[test]
+    fn facts_are_all_default_without_a_description() {
+        let loose = tempfile::tempdir().expect("tempdir");
+        assert_eq!(facts_at(loose.path()), DescriptionFacts::default());
+    }
+
+    #[test]
+    fn description_cache_reads_once_per_root() {
+        let dir = package("Package: mypkg\nImports: dplyr\n");
+        let mut cache = DescriptionCache::new();
+        let first = cache.for_file(&dir.path().join("R/a.R"));
+        // Delete the file: a second lookup that re-read disk would come back
+        // empty, so an unchanged answer is what proves the memo.
+        std::fs::remove_file(dir.path().join("DESCRIPTION")).expect("remove");
+        let second = cache.at(dir.path());
+        assert_eq!(first.package.as_deref(), Some("mypkg"));
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/src/project/graph.rs
+++ b/src/project/graph.rs
@@ -190,25 +190,7 @@ pub fn expected_r_sources(root: &Path) -> BTreeSet<String> {
             }
         }
     }
-    if let Ok(text) = std::fs::read_to_string(root.join("DESCRIPTION")) {
-        // `fields()` is record-blind on purpose: a stray blank line in a
-        // DESCRIPTION splits it into two DCF records, and a `Collate` after
-        // that split still names files R will load.
-        for field in crate::dcf::parse(&text).document().fields() {
-            // R picks an OS-specific `Collate@unix`/`Collate@windows` over plain
-            // `Collate`; we union every `Collate*` field, since over-including
-            // only tightens completeness (the safe direction).
-            if field.name().starts_with("Collate") {
-                let value = field.folded_value();
-                for entry in value.split_whitespace() {
-                    let name = entry.trim_matches(['\'', '"']);
-                    if !name.is_empty() {
-                        expected.insert(name.to_string());
-                    }
-                }
-            }
-        }
-    }
+    expected.extend(crate::project::description::facts_at(root).collate);
     expected
 }
 

--- a/src/project/graph.rs
+++ b/src/project/graph.rs
@@ -23,11 +23,12 @@ use rowan::TextRange;
 use smol_str::SmolStr;
 
 use crate::incremental::{
-    IncrementalDb, LibraryIndex, PackageGraph, QueryKind, QueryLogEntry, SourceFile, Workspace,
-    file_class_defs, file_def_sites, file_exports, file_free_reads, file_qualified_reads,
-    loaded_names, parse_diagnostics, source_edges, top_level_events,
+    Descriptions, IncrementalDb, LibraryIndex, PackageGraph, QueryKind, QueryLogEntry, SourceFile,
+    Workspace, description_facts, file_class_defs, file_def_sites, file_exports, file_free_reads,
+    file_qualified_reads, loaded_names, parse_diagnostics, source_edges, top_level_events,
 };
 use crate::project::classes::ClassSystem;
+use crate::project::description::DescriptionFacts;
 use crate::project::exports::DefKind;
 use crate::project::scope::{FileFacts, FileScope, ProjectScope, package_root};
 use crate::project::source::{SourceEdgeKey, SourceTarget};
@@ -73,9 +74,13 @@ pub struct PackageInfo {
     pub root: PathBuf,
     /// The root's `NAMESPACE` text, or `None` when the file is absent.
     pub namespace: Option<String>,
-    /// The R source *basenames* the package will load ([`expected_r_sources`]):
-    /// the union of the `R/*.[RrSsQq]` listing and any `DESCRIPTION` `Collate:`.
-    pub expected_sources: BTreeSet<String>,
+    /// The R source *basenames* on disk under `R/` ([`r_dir_sources`]).
+    ///
+    /// The `Collate:` half of the expected source set deliberately lives in
+    /// [`description_facts`](crate::incremental::description_facts) instead: a
+    /// `Collate` edit then reaches the graph through the backdating firewall,
+    /// while an unrelated `DESCRIPTION` edit does not reach it at all.
+    pub dir_sources: BTreeSet<String>,
 }
 
 /// A project as an interned membership snapshot: the set of member files, the
@@ -128,7 +133,10 @@ impl Visibility {
 /// Discover the [`PackageInfo`] for every distinct package root among
 /// `member_paths`, sorted by root. **The sole filesystem reader** behind the
 /// project graph: it walks each member to its [`package_root`] and, per root,
-/// reads `NAMESPACE` and computes [`expected_r_sources`]. Run in the write-phase
+/// reads `NAMESPACE` and lists [`r_dir_sources`]. It deliberately does *not*
+/// read `DESCRIPTION` — that file is its own tracked input
+/// ([`DescriptionFile`](crate::incremental::DescriptionFile)), so its facts
+/// reach the graph through a query that backdates. Run in the write-phase
 /// (see [`refresh_package_graph`](crate::incremental::IncrementalDatabase::refresh_package_graph));
 /// the result is stored in the [`PackageGraph`](crate::incremental::PackageGraph)
 /// input so [`workspace_project`] stays pure.
@@ -141,7 +149,7 @@ pub fn discover_packages(member_paths: &[PathBuf]) -> Vec<PackageInfo> {
         .into_iter()
         .map(|root| PackageInfo {
             namespace: std::fs::read_to_string(root.join("NAMESPACE")).ok(),
-            expected_sources: expected_r_sources(&root),
+            dir_sources: r_dir_sources(&root),
             root,
         })
         .collect()
@@ -175,6 +183,14 @@ const R_SOURCE_EXTS: [&str; 6] = ["R", "r", "S", "s", "Q", "q"];
 /// `Collate:` nor an unlisted file can shrink the expected set and let an
 /// incomplete package pass. Touches disk.
 pub fn expected_r_sources(root: &Path) -> BTreeSet<String> {
+    let mut expected = r_dir_sources(root);
+    expected.extend(crate::project::description::facts_at(root).collate);
+    expected
+}
+
+/// The R source *basenames* on disk under `root/R`. The disk-listing half of
+/// [`expected_r_sources`]; the `Collate:` half comes from the DESCRIPTION facts.
+pub fn r_dir_sources(root: &Path) -> BTreeSet<String> {
     let mut expected: BTreeSet<String> = BTreeSet::new();
     if let Ok(entries) = std::fs::read_dir(root.join("R")) {
         for entry in entries.flatten() {
@@ -263,12 +279,23 @@ pub fn workspace_project<'db>(db: &'db dyn IncrementalDb) -> Project<'db> {
         })
         .collect();
     namespaces.sort_by(|a, b| a.0.cmp(&b.0));
+    // The expected source set is the `R/` listing (from the graph input) union
+    // the `Collate:` entries (from the DESCRIPTION facts) — union, not
+    // intersection, so neither a stale `Collate:` nor an unlisted file can
+    // shrink it and let an incomplete package pass.
+    let facts_by_root = description_facts_by_root(db);
     let collations: Vec<PackageCollation> = analyzed
         .into_iter()
         .map(|(root, analyzed_names)| {
             let complete = by_root.get(&root).is_some_and(|info| {
-                info.expected_sources
+                let collate = facts_by_root
+                    .get(&root)
+                    .map(|facts| facts.collate.iter())
+                    .into_iter()
+                    .flatten();
+                info.dir_sources
                     .iter()
+                    .chain(collate)
                     .all(|name| analyzed_names.contains(name))
             });
             PackageCollation { root, complete }
@@ -276,6 +303,21 @@ pub fn workspace_project<'db>(db: &'db dyn IncrementalDb) -> Project<'db> {
         .collect();
 
     Project::new(db, members, namespaces, collations)
+}
+
+/// Every tracked package root's [`DescriptionFacts`], keyed by root.
+///
+/// Pure: it reads the [`Descriptions`] input's handles and goes through
+/// [`description_facts`], so an unrelated `DESCRIPTION` edit backdates there
+/// and never reaches this caller.
+fn description_facts_by_root(db: &dyn IncrementalDb) -> HashMap<PathBuf, &DescriptionFacts> {
+    let Some(set) = Descriptions::try_get(db) else {
+        return HashMap::new();
+    };
+    set.files(db)
+        .iter()
+        .map(|&file| (file.root(db).clone(), description_facts(db, file)))
+        .collect()
 }
 
 /// The cross-file scope for `project`, built from the per-file firewall queries.

--- a/src/project/graph.rs
+++ b/src/project/graph.rs
@@ -349,6 +349,28 @@ pub fn workspace_project<'db>(db: &'db dyn IncrementalDb) -> Project<'db> {
     Project::new(db, members, namespaces, collations, declarations)
 }
 
+/// The [`DescriptionFacts`] of the package enclosing `path`, from the tracked
+/// `DESCRIPTION` inputs. `None` for a file outside any tracked package.
+///
+/// Pure — it touches no disk, which is the point: the lint rules used to walk
+/// to the package root (stat-ing for `DESCRIPTION` and `R/`) and then re-read
+/// and re-parse `DESCRIPTION`, per file and per question. The root is resolved
+/// against the *tracked* roots via [`package_root_in`], the same disk-free walk
+/// [`workspace_project`] uses.
+pub fn package_facts_for<'db>(
+    db: &'db dyn IncrementalDb,
+    path: &Path,
+) -> Option<&'db DescriptionFacts> {
+    let set = Descriptions::try_get(db)?;
+    let files = set.files(db);
+    let roots: BTreeSet<&PathBuf> = files.iter().map(|file| file.root(db)).collect();
+    let root = package_root_in(path, &roots)?;
+    files
+        .iter()
+        .find(|file| file.root(db) == &root)
+        .map(|&file| description_facts(db, file))
+}
+
 /// Every tracked package root's [`DescriptionFacts`], keyed by root.
 ///
 /// Pure: it reads the [`Descriptions`] input's handles and goes through

--- a/src/project/graph.rs
+++ b/src/project/graph.rs
@@ -136,6 +136,13 @@ pub struct Visibility {
     /// The subset of `namespace_exports` registered via `S3method()` — reached
     /// by dispatch, so no direct call to the name is expected.
     pub s3_methods: BTreeSet<String>,
+    /// Packages this file's NAMESPACE `import()`s wholesale. Range-free and
+    /// `Eq`, so this projection still backdates across a body edit.
+    pub wildcard_imports: BTreeSet<String>,
+    /// An unresolved `source()` left cross-file visibility incomplete. A
+    /// wildcard import is *not* expressed here — it is an entry in
+    /// `wildcard_imports` that the consumer (which holds the library index)
+    /// finds unenumerable.
     pub incomplete: bool,
 }
 
@@ -147,6 +154,7 @@ impl Visibility {
             &self.read_by_others,
             &self.namespace_exports,
             &self.s3_methods,
+            &self.wildcard_imports,
             self.incomplete,
         )
     }
@@ -420,6 +428,7 @@ pub fn visible_symbols<'db>(
         read_by_others: scope.read_names().clone(),
         namespace_exports: scope.namespace_export_names().clone(),
         s3_methods: scope.s3_method_names().clone(),
+        wildcard_imports: scope.wildcard_import_packages().clone(),
         incomplete: scope.resolution_incomplete,
     }
 }
@@ -657,6 +666,14 @@ pub fn attached_names<'db>(
         file: Some(file),
     });
     let mut names = loaded_names(db, file).clone();
+    // A NAMESPACE `import(pkg)` puts every export of pkg in this file's scope,
+    // which for name resolution is indistinguishable from attaching it.
+    names.extend(
+        visible_symbols(db, project, file)
+            .wildcard_imports
+            .iter()
+            .cloned(),
+    );
     let root = project
         .members(db)
         .iter()
@@ -704,6 +721,11 @@ pub fn external_resolution<'db>(
     // (e.g. tidyverse) also attaches its core members (harvested attach set,
     // static table as fallback), so each of those must be indexed too, or one
     // of them could be the otherwise-unresolved name's home.
+    //
+    // This gate is also where a wholesale `import(pkg)` lands: `attached_names`
+    // folds those packages in, so an unenumerable one suppresses here — the old
+    // unconditional poison, now conditional on the index, and therefore lifting
+    // the moment the sidecar can enumerate the package.
     if loaded.iter().any(|pkg| {
         !package_indexed(index, remote, pkg)
             || attach_members(index, pkg).any(|m| !package_indexed(index, remote, m))
@@ -712,8 +734,8 @@ pub fn external_resolution<'db>(
     }
 
     let visibility = visible_symbols(db, project, file);
-    // Gate: incomplete cross-file visibility (an unresolved `source()` or a
-    // wholesale `import(pkg)`) could supply otherwise-unresolved names.
+    // Gate: cross-file visibility left incomplete by something nothing can
+    // resolve — a dynamic or unanalyzed `source()` — could supply any name.
     if visibility.incomplete {
         return ExternalResolution::default();
     }

--- a/src/project/graph.rs
+++ b/src/project/graph.rs
@@ -83,12 +83,32 @@ pub struct PackageInfo {
     pub dir_sources: BTreeSet<String>,
 }
 
+/// One package root's *resolution-relevant* declarations, frozen into the
+/// interned [`Project`] so the graph queries stay pure.
+///
+/// Deliberately a strict subset of
+/// [`DescriptionFacts`](crate::project::DescriptionFacts): the compat floors and
+/// the `Roxygen` field affect no cross-file scope, so keeping them out means a
+/// `RoxygenNote:` bump re-interns to the *same* `Project` id and the
+/// [`project_graph`] memo survives it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PackageDeclarations {
+    pub root: PathBuf,
+    /// `Depends`, minus `R` — the packages R **attaches** to the search path
+    /// when this package loads, so their exports resolve as bare names.
+    pub attached: BTreeSet<String>,
+    /// Every declared package, any field. *Referenced* — worth harvesting and
+    /// fetching — but **not** attached: an `Imports` package is reachable only
+    /// through `pkg::` or a NAMESPACE `importFrom`/`import`.
+    pub declared: BTreeSet<String>,
+}
+
 /// A project as an interned membership snapshot: the set of member files, the
-/// NAMESPACE texts of the packages they belong to, and each package root's
-/// collation/completeness verdict. Interning dedups by value, so an unchanged
-/// membership yields the same id across lints (a body edit doesn't change the
-/// set) and the graph memo survives. Callers must sort `members`, `namespaces`,
-/// and `collations` for a stable, dedup-friendly key.
+/// NAMESPACE texts of the packages they belong to, each package root's
+/// collation/completeness verdict, and its declared dependencies. Interning
+/// dedups by value, so an unchanged membership yields the same id across lints
+/// (a body edit doesn't change the set) and the graph memo survives. Callers
+/// must sort every field for a stable, dedup-friendly key.
 #[salsa::interned]
 pub struct Project<'db> {
     #[returns(ref)]
@@ -97,6 +117,8 @@ pub struct Project<'db> {
     pub namespaces: Vec<(PathBuf, String)>,
     #[returns(ref)]
     pub collations: Vec<PackageCollation>,
+    #[returns(ref)]
+    pub declarations: Vec<PackageDeclarations>,
 }
 
 /// One file's owned view of its project: the names it can see, the names of its
@@ -302,7 +324,21 @@ pub fn workspace_project<'db>(db: &'db dyn IncrementalDb) -> Project<'db> {
         })
         .collect();
 
-    Project::new(db, members, namespaces, collations)
+    // Restricted to roots with an analyzed member, like `namespaces`, and
+    // sorted for a stable interning key.
+    let mut declarations: Vec<PackageDeclarations> = collations
+        .iter()
+        .filter_map(|c| {
+            facts_by_root.get(&c.root).map(|facts| PackageDeclarations {
+                root: c.root.clone(),
+                attached: facts.attached_packages(),
+                declared: facts.declared_packages(),
+            })
+        })
+        .collect();
+    declarations.sort_by(|a, b| a.root.cmp(&b.root));
+
+    Project::new(db, members, namespaces, collations, declarations)
 }
 
 /// Every tracked package root's [`DescriptionFacts`], keyed by root.
@@ -597,6 +633,43 @@ pub struct ExternalResolution {
     pub unresolved: BTreeSet<String>,
 }
 
+/// Every package whose exports resolve as **bare names** in `file`.
+///
+/// The union of two provenances: the file's own `library()`/`require()` calls
+/// and location-implied attaches ([`loaded_names`], a per-file firewall), and
+/// the `Depends` its package declares (this project's interned declarations).
+///
+/// Deliberately **not** `Imports`: R does not attach an `Imports` package, and
+/// resolving its exports as bare names here would accept code that fails under
+/// `R CMD check`. Those reach a file only through `pkg::` or a NAMESPACE
+/// `importFrom`/`import`, all of which the project layer models separately.
+///
+/// A `BTreeSet<String>` like `loaded_names`, so it backdates: a body edit
+/// leaves it equal and [`external_resolution`] is not re-run.
+#[salsa::tracked(returns(ref))]
+pub fn attached_names<'db>(
+    db: &'db dyn IncrementalDb,
+    project: Project<'db>,
+    file: SourceFile,
+) -> BTreeSet<String> {
+    db.record_query(QueryLogEntry {
+        kind: QueryKind::AttachedNames,
+        file: Some(file),
+    });
+    let mut names = loaded_names(db, file).clone();
+    let root = project
+        .members(db)
+        .iter()
+        .find(|m| m.file == file)
+        .and_then(|m| m.package_root.as_ref());
+    if let Some(root) = root
+        && let Some(decl) = project.declarations(db).iter().find(|d| &d.root == root)
+    {
+        names.extend(decl.attached.iter().cloned());
+    }
+    names
+}
+
 /// Resolve a file's free reads against the project graph and the
 /// HIGH-durability [`LibraryIndex`], yielding the `undefined-symbol` candidate
 /// names.
@@ -624,7 +697,7 @@ pub fn external_resolution<'db>(
 
     let index: &crate::rindex::provider::IndexedProvider = manifest.data(db);
     let remote: &crate::rindex::remote::RemoteExports = manifest.remote(db);
-    let loaded = loaded_names(db, file);
+    let loaded = attached_names(db, project, file);
 
     // Gate: an attached package whose exports we don't fully know could define
     // any of the unresolved names — suppress the whole file. A meta-package

--- a/src/project/graph.rs
+++ b/src/project/graph.rs
@@ -25,7 +25,8 @@ use smol_str::SmolStr;
 use crate::incremental::{
     Descriptions, IncrementalDb, LibraryIndex, PackageGraph, QueryKind, QueryLogEntry, SourceFile,
     Workspace, description_facts, file_class_defs, file_def_sites, file_exports, file_free_reads,
-    file_qualified_reads, loaded_names, parse_diagnostics, source_edges, top_level_events,
+    file_qualified_reads, loaded_names, package_references, parse_diagnostics, source_edges,
+    top_level_events,
 };
 use crate::project::classes::ClassSystem;
 use crate::project::description::DescriptionFacts;
@@ -369,6 +370,107 @@ pub fn package_facts_for<'db>(
         .iter()
         .find(|file| file.root(db) == &root)
         .map(|&file| description_facts(db, file))
+}
+
+/// One package root's dependency-usage verdict: every package its own code
+/// reaches, and whether the run is entitled to conclude anything from a
+/// package's *absence* from that set.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PackageUsage {
+    /// Every package this root's R sources, NAMESPACE, and roxygen tags reach.
+    pub used: BTreeSet<String>,
+    /// Package-shaped string literals anywhere in the root's sources. Not a
+    /// reference — the guard a consumer consults so a dynamic use cannot become
+    /// a false report of disuse
+    /// ([`PackageReferences::string_mentions`](crate::project::PackageReferences::string_mentions)).
+    pub mentioned: BTreeSet<String>,
+    /// **The guard that makes reporting on absence safe.** `true` only when the
+    /// run actually analyzed every R source this package will load, read its
+    /// NAMESPACE, and found at least one source.
+    ///
+    /// Without it, `arity lint R/one.R` would declare every dependency the
+    /// other files use unused. In practice single-file runs are still complete
+    /// — the driver adds a package's whole expected `R/` set as scope-only
+    /// members — so this is the backstop for an unrelated directory, for a
+    /// package with a parse error in `R/`, and for a package mid-`document()`
+    /// with no NAMESPACE yet.
+    pub complete: bool,
+}
+
+/// Every tracked package root's [`PackageUsage`], keyed by root.
+///
+/// Keyed on the interned [`Project`] and folded from the backdated per-file
+/// [`package_references`], so it backdates across a body edit exactly like
+/// [`project_graph`]: editing inside a function changes neither the packages a
+/// file names nor the membership, so this is not re-executed.
+#[salsa::tracked(returns(ref))]
+pub fn package_usage<'db>(
+    db: &'db dyn IncrementalDb,
+    project: Project<'db>,
+) -> BTreeMap<PathBuf, PackageUsage> {
+    db.record_query(QueryLogEntry {
+        kind: QueryKind::PackageUsage,
+        file: None,
+    });
+
+    let mut usage: BTreeMap<PathBuf, PackageUsage> = BTreeMap::new();
+    let mut sources: BTreeMap<PathBuf, usize> = BTreeMap::new();
+    for member in project.members(db) {
+        let Some(root) = member.package_root.clone() else {
+            continue;
+        };
+        let refs = package_references(db, member.file);
+        let entry = usage.entry(root.clone()).or_default();
+        entry.used.extend(refs.direct.iter().cloned());
+        entry.used.extend(refs.roxygen_imports.iter().cloned());
+        entry.mentioned.extend(refs.string_mentions.iter().cloned());
+        if refs.uses_methods {
+            // R's own `uses_methods`: an S4 or reference class makes
+            // `Imports: methods` mandatory with nothing naming it.
+            entry.used.insert("methods".to_string());
+        }
+        *sources.entry(root).or_default() += 1;
+    }
+
+    // A NAMESPACE `import()`/`importFrom()` reaches its package as surely as a
+    // `::` does, and for many packages it is the *only* thing that does.
+    for (root, namespace) in project.namespaces(db) {
+        let info = crate::rindex::harvest::parse_namespace(namespace, &[]);
+        let entry = usage.entry(root.clone()).or_default();
+        entry.used.extend(info.imported_packages);
+        entry.used.extend(info.imported_from_packages);
+    }
+
+    let complete_roots: BTreeSet<&PathBuf> = project
+        .collations(db)
+        .iter()
+        .filter(|collation| collation.complete)
+        .map(|collation| &collation.root)
+        .collect();
+    let with_namespace: BTreeSet<&PathBuf> = project
+        .namespaces(db)
+        .iter()
+        .map(|(root, _)| root)
+        .collect();
+    for (root, entry) in &mut usage {
+        entry.complete = complete_roots.contains(root)
+            && with_namespace.contains(root)
+            && sources.get(root).is_some_and(|count| *count > 0);
+    }
+    usage
+}
+
+/// The [`PackageUsage`] of the package enclosing `path` — a `DESCRIPTION`, or
+/// any file under a package root. `None` outside every tracked package.
+pub fn package_usage_for<'db>(
+    db: &'db dyn IncrementalDb,
+    project: Project<'db>,
+    path: &Path,
+) -> Option<&'db PackageUsage> {
+    let usage = package_usage(db, project);
+    let roots: BTreeSet<&PathBuf> = usage.keys().collect();
+    let root = package_root_in(path, &roots)?;
+    usage.get(&root)
 }
 
 /// Every tracked package root's [`DescriptionFacts`], keyed by root.

--- a/src/project/scope.rs
+++ b/src/project/scope.rs
@@ -87,10 +87,10 @@ pub struct ProjectScope {
     /// Per package file: the subset of `namespace_exports` registered as S3
     /// methods (`S3method(...)`). Reached by dispatch, never by a direct call.
     s3_methods: HashMap<PathBuf, BTreeSet<String>>,
-    /// Files whose cross-file visibility is incomplete (unresolved `source()`).
     /// Per file: the packages its NAMESPACE `import()`s wholesale. Recorded
     /// rather than resolved — see [`FileScope::wildcard_import_packages`].
     wildcard_imports: HashMap<PathBuf, BTreeSet<String>>,
+    /// Files whose cross-file visibility is incomplete (unresolved `source()`).
     dynamic: HashSet<PathBuf>,
     /// Per file: the set of *other* files it can see (package siblings, plus the
     /// transitive non-local `source()` closure). Directional: `a` sourcing `b`

--- a/src/project/scope.rs
+++ b/src/project/scope.rs
@@ -750,12 +750,22 @@ fn source_dependency(edge: &SourceEdgeKey) -> Dependency<'_> {
     }
 }
 
+/// Whether `dir` is an R package root: it holds both a `DESCRIPTION` file and an
+/// `R/` subdirectory. Touches the filesystem.
+///
+/// The one statement of what arity considers a package. File discovery asks it
+/// directly (to tell a package's `DESCRIPTION` from an `inst/extdata` fixture of
+/// the same name), and [`package_root`] is the walk-upward form.
+pub fn is_package_root(dir: &Path) -> bool {
+    dir.join("DESCRIPTION").is_file() && dir.join("R").is_dir()
+}
+
 /// Walk up from `path` to find an enclosing R package root: a directory with
 /// both a `DESCRIPTION` file and an `R/` subdirectory. Touches the filesystem.
 pub fn package_root(path: &Path) -> Option<PathBuf> {
     let mut dir = path.parent();
     while let Some(d) = dir {
-        if d.join("DESCRIPTION").is_file() && d.join("R").is_dir() {
+        if is_package_root(d) {
             return Some(d.to_path_buf());
         }
         dir = d.parent();

--- a/src/project/scope.rs
+++ b/src/project/scope.rs
@@ -19,10 +19,16 @@
 //! top-level binding as used (it's public API).
 //!
 //! Visibility can be *incomplete* — a `source()` target that can't be resolved
-//! (dynamic argument, or a path outside the analyzed set), or a wholesale
-//! `import(pkg)` whose exports we can't enumerate. Then
+//! (dynamic argument, or a path outside the analyzed set). Then
 //! [`FileScope::resolution_incomplete`] is set and callers must stay
 //! conservative (no `undefined-symbol` findings).
+//!
+//! A wholesale `import(pkg)` is deliberately **not** expressed that way. It is
+//! reported as-is by [`FileScope::wildcard_import_packages`], because "can we
+//! enumerate pkg's exports" is a question for the library index and this module
+//! is pure — that purity is what the project-graph memo depends on. The
+//! consumer that holds the index decides, so the file stops being suppressed
+//! the moment the package becomes enumerable.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -82,6 +88,9 @@ pub struct ProjectScope {
     /// methods (`S3method(...)`). Reached by dispatch, never by a direct call.
     s3_methods: HashMap<PathBuf, BTreeSet<String>>,
     /// Files whose cross-file visibility is incomplete (unresolved `source()`).
+    /// Per file: the packages its NAMESPACE `import()`s wholesale. Recorded
+    /// rather than resolved — see [`FileScope::wildcard_import_packages`].
+    wildcard_imports: HashMap<PathBuf, BTreeSet<String>>,
     dynamic: HashSet<PathBuf>,
     /// Per file: the set of *other* files it can see (package siblings, plus the
     /// transitive non-local `source()` closure). Directional: `a` sourcing `b`
@@ -157,9 +166,20 @@ pub struct FileScope<'a> {
     read_by_others: &'a BTreeSet<String>,
     namespace_exports: &'a BTreeSet<String>,
     s3_methods: &'a BTreeSet<String>,
-    /// Cross-file visibility is incomplete — an unresolved `source()` or a
-    /// wholesale `import(pkg)` could supply otherwise-unresolved names — so
-    /// callers must not flag them.
+    /// Packages this file's NAMESPACE `import()`s wholesale.
+    ///
+    /// Every export of such a package is in scope here, which for resolution is
+    /// indistinguishable from being attached. Whether those exports are
+    /// *enumerable* is a question only the library index can answer, and
+    /// [`ProjectScope::build`] is pure — so the packages are reported and the
+    /// verdict is left to the caller, which holds the index. Reintroducing an
+    /// index lookup inside `build` would look like a simplification and would
+    /// silently break the purity the project-graph memo depends on.
+    wildcard_imports: &'a BTreeSet<String>,
+    /// Cross-file visibility is incomplete for a reason nothing can resolve: a
+    /// dynamic or unanalyzed `source()` could supply any name, so callers must
+    /// not flag them. **No longer set by `import(pkg)`** — see
+    /// [`wildcard_import_packages`](Self::wildcard_import_packages).
     pub resolution_incomplete: bool,
 }
 
@@ -172,6 +192,7 @@ impl<'a> FileScope<'a> {
         read_by_others: &'a BTreeSet<String>,
         namespace_exports: &'a BTreeSet<String>,
         s3_methods: &'a BTreeSet<String>,
+        wildcard_imports: &'a BTreeSet<String>,
         resolution_incomplete: bool,
     ) -> Self {
         Self {
@@ -179,8 +200,14 @@ impl<'a> FileScope<'a> {
             read_by_others,
             namespace_exports,
             s3_methods,
+            wildcard_imports,
             resolution_incomplete,
         }
+    }
+
+    /// The packages this file's NAMESPACE `import()`s wholesale.
+    pub fn wildcard_import_packages(&self) -> &BTreeSet<String> {
+        self.wildcard_imports
     }
 
     /// The names visible to this file from the rest of the project.
@@ -311,6 +338,7 @@ impl ProjectScope {
         // For each file, the set of *other* files it can see.
         let mut sees: HashMap<PathBuf, HashSet<PathBuf>> = HashMap::new();
         let mut dynamic: HashSet<PathBuf> = HashSet::new();
+        let mut wildcard_imports: HashMap<PathBuf, BTreeSet<String>> = HashMap::new();
         for f in files {
             let mut seen: HashSet<PathBuf> = HashSet::new();
             if let Some(root) = &f.package_root {
@@ -383,9 +411,10 @@ impl ProjectScope {
         }
 
         // Fold NAMESPACE declarations into the same two directions: imported
-        // names resolve (visible), exported names count as used (via
-        // `namespace_exports`), and a wholesale `import(pkg)` makes resolution
-        // incomplete.
+        // names resolve (visible) and exported names count as used (via
+        // `namespace_exports`). A wholesale `import(pkg)` is *recorded*, not
+        // resolved: whether pkg's exports are enumerable needs the library
+        // index, which this pure builder does not have.
         for (root, text) in namespaces {
             let Some(members) = package_members.get(root.as_path()) else {
                 continue;
@@ -398,7 +427,7 @@ impl ProjectScope {
             let info = parse_namespace(text, &object_names);
             let exported: BTreeSet<String> = info.exports.iter().cloned().collect();
             let imported: BTreeSet<String> = info.imported_names.iter().cloned().collect();
-            let incomplete = !info.imported_packages.is_empty();
+            let wildcards: BTreeSet<String> = info.imported_packages.iter().cloned().collect();
 
             for member in members {
                 let path = member.to_path_buf();
@@ -413,8 +442,11 @@ impl ProjectScope {
                 if let Some(vis) = visible.get_mut(&path) {
                     vis.extend(imported.iter().cloned());
                 }
-                if incomplete {
-                    dynamic.insert(path);
+                if !wildcards.is_empty() {
+                    wildcard_imports
+                        .entry(path)
+                        .or_default()
+                        .extend(wildcards.iter().cloned());
                 }
             }
         }
@@ -424,6 +456,7 @@ impl ProjectScope {
             read_by_others,
             namespace_exports,
             s3_methods,
+            wildcard_imports,
             dynamic,
             sees,
             package_siblings,
@@ -442,6 +475,7 @@ impl ProjectScope {
             read_by_others: self.read_by_others.get(path).unwrap_or(&EMPTY),
             namespace_exports: self.namespace_exports.get(path).unwrap_or(&EMPTY),
             s3_methods: self.s3_methods.get(path).unwrap_or(&EMPTY),
+            wildcard_imports: self.wildcard_imports.get(path).unwrap_or(&EMPTY),
             resolution_incomplete: self.dynamic.contains(path),
         }
     }
@@ -1025,14 +1059,21 @@ mod tests {
     }
 
     #[test]
-    fn namespace_wholesale_import_marks_resolution_incomplete() {
+    fn namespace_wholesale_import_is_recorded_not_poisoned() {
+        // `import(pkg)` used to poison the file unconditionally. It now reports
+        // the package instead: whether pkg's exports are enumerable needs the
+        // library index, which this pure builder deliberately does not have.
         let files = [facts("/pkg/R/a.R", &[], &["abort"], vec![], Some("/pkg"))];
         let ns = namespaces(&[("/pkg", "import(rlang)\n")]);
         let scope = ProjectScope::build(&files, &ns, &HashMap::new());
+        let a = scope.for_file(Path::new("/pkg/R/a.R"));
+        assert_eq!(
+            a.wildcard_import_packages(),
+            &["rlang".to_string()].into_iter().collect()
+        );
         assert!(
-            scope
-                .for_file(Path::new("/pkg/R/a.R"))
-                .resolution_incomplete
+            !a.resolution_incomplete,
+            "a wildcard import is a question for the index, not an unresolvable"
         );
     }
 

--- a/src/rindex/discover.rs
+++ b/src/rindex/discover.rs
@@ -1,7 +1,13 @@
 //! Discover which packages a project references, so `arity index` harvests
 //! only those. A package is "referenced" if it is attached via
 //! `library()`/`require()`/`requireNamespace()` or named via `pkg::` / `pkg:::`
-//! anywhere in the project's `.R` files.
+//! anywhere in the project's `.R` files, **or** if the enclosing package's
+//! `DESCRIPTION` declares it as a dependency.
+//!
+//! The DESCRIPTION half matters because a package's R code reaches an `Imports`
+//! dependency through a NAMESPACE `importFrom` that names no package in any
+//! `.R` file — so scanning sources alone would leave exactly the dependencies
+//! the project is entitled to use unharvested.
 
 use std::collections::BTreeSet;
 
@@ -21,6 +27,13 @@ pub fn referenced_packages(
 ) -> Result<Vec<SmolStr>, FileDiscoveryError> {
     let files = collect_r_files(paths, exclude)?;
     let mut set: BTreeSet<SmolStr> = BTreeSet::new();
+    let mut descriptions = crate::project::DescriptionCache::new();
+    for file in &files {
+        // The enclosing package's declared dependencies, read once per root.
+        for pkg in descriptions.for_file(file).declared_packages() {
+            set.insert(SmolStr::new(pkg));
+        }
+    }
     for file in files {
         let Ok(text) = std::fs::read_to_string(&file) else {
             continue;
@@ -84,6 +97,32 @@ mod tests {
         for expected in ["dplyr", "tidyr", "purrr", "rlang", "stringr"] {
             assert!(pkgs.contains(&expected), "missing {expected} in {pkgs:?}");
         }
+    }
+
+    #[test]
+    fn declared_dependencies_are_referenced() {
+        use std::fs;
+        // The case source-scanning alone misses: a package whose R code reaches
+        // its `Imports` through a NAMESPACE `importFrom`, so no `.R` file names
+        // it. It is still exactly what the package is entitled to use.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("R")).unwrap();
+        fs::write(root.join("R/a.R"), "foo <- function() filter(1)\n").unwrap();
+        fs::write(
+            root.join("DESCRIPTION"),
+            "Package: mypkg\nDepends: R (>= 4.1)\nImports: dplyr\nSuggests: testthat\n",
+        )
+        .unwrap();
+
+        let found = referenced_packages(&[root.to_path_buf()], &ExcludeFilter::none()).unwrap();
+        let pkgs: Vec<&str> = found.iter().map(|s| s.as_str()).collect();
+        assert!(pkgs.contains(&"dplyr"), "declared Imports: {pkgs:?}");
+        assert!(pkgs.contains(&"testthat"), "declared Suggests: {pkgs:?}");
+        assert!(
+            !pkgs.contains(&"R"),
+            "`R` names the language, not a package: {pkgs:?}"
+        );
     }
 
     #[test]

--- a/src/rindex/harvest.rs
+++ b/src/rindex/harvest.rs
@@ -441,9 +441,12 @@ pub fn parse_namespace(namespace: &str, object_names: &[String]) -> NamespaceInf
                     }
                 }
             }
-            "importFrom" => {
+            "importFrom" | "importClassesFrom" | "importMethodsFrom" => {
                 // `importFrom(pkg, a, b, ...)`: the first arg is the package, the
-                // rest are the imported names.
+                // rest are the imported names. The S4 forms have the same shape
+                // and reference `pkg` just as surely; their names go into the
+                // same set, which can only ever *suppress* an
+                // `undefined-symbol` — the conservative direction.
                 let mut args = directive.values();
                 if let Some(package) = args.next() {
                     info.imported_from_packages.insert(package);
@@ -532,6 +535,8 @@ const RECOGNIZED: &[&str] = &[
     "exportMethods",
     "export",
     "importFrom",
+    "importClassesFrom",
+    "importMethodsFrom",
     "import",
     "S3method",
 ];
@@ -1008,6 +1013,22 @@ mod tests {
         assert_eq!(
             info.imported_names,
             ["filter".to_string(), "select".to_string()].into()
+        );
+    }
+
+    /// The S4 forms reference their package exactly as `importFrom` does. An S4
+    /// package whose only reference to a dependency is one of these would
+    /// otherwise look unused.
+    #[test]
+    fn s4_import_forms_record_the_package_they_name() {
+        let info = parse_namespace(
+            "importClassesFrom(Matrix, dgCMatrix)\nimportMethodsFrom(Matrix, crossprod)\n",
+            &[],
+        );
+        assert_eq!(info.imported_from_packages, ["Matrix".to_string()].into());
+        assert_eq!(
+            info.imported_names,
+            ["dgCMatrix".to_string(), "crossprod".to_string()].into()
         );
     }
 

--- a/src/rindex/harvest.rs
+++ b/src/rindex/harvest.rs
@@ -393,6 +393,12 @@ pub struct NamespaceInfo {
     /// package is in scope, so without that package's index any unresolved name
     /// could come from it.
     pub imported_packages: BTreeSet<String>,
+    /// Packages named by `importFrom(pkg, ...)`. A *reference* to `pkg` just as
+    /// `import(pkg)` is — and the fact stage 3's `unused-dependency` asks for —
+    /// but kept apart because the names it brings in are already enumerated in
+    /// [`imported_names`](Self::imported_names), so it never leaves resolution
+    /// incomplete.
+    pub imported_from_packages: BTreeSet<String>,
     /// The subset of [`exports`](Self::exports) registered via `S3method()`
     /// rather than `export()`. Still exports (they are in the namespace, so name
     /// resolution must see them), but reached by *dispatch*, never by a direct
@@ -411,13 +417,14 @@ pub fn parse_namespace(namespace: &str, object_names: &[String]) -> NamespaceInf
     for directive in NamespaceDirectives::new(namespace) {
         match directive.name {
             "export" | "exportMethods" | "exportClasses" => {
-                info.exports.extend(directive.args);
+                info.exports.extend(directive.values());
             }
             "S3method" => {
                 // `S3method(generic, class)` registers the method `generic.class`;
                 // the three-arg form `S3method(generic, class, method)` binds the
                 // explicitly named `method` instead.
-                let method = match directive.args.as_slice() {
+                let args: Vec<String> = directive.values().collect();
+                let method = match args.as_slice() {
                     [_, _, method] => Some(method.clone()),
                     [generic, class] => Some(format!("{generic}.{class}")),
                     _ => None,
@@ -428,7 +435,7 @@ pub fn parse_namespace(namespace: &str, object_names: &[String]) -> NamespaceInf
                 }
             }
             "exportPattern" | "exportClassPattern" => {
-                for arg in directive.args {
+                for arg in directive.values() {
                     if let Some(re) = compile_r_pattern(&arg) {
                         patterns.push(re);
                     }
@@ -437,13 +444,18 @@ pub fn parse_namespace(namespace: &str, object_names: &[String]) -> NamespaceInf
             "importFrom" => {
                 // `importFrom(pkg, a, b, ...)`: the first arg is the package, the
                 // rest are the imported names.
-                let mut args = directive.args.into_iter();
-                if args.next().is_some() {
+                let mut args = directive.values();
+                if let Some(package) = args.next() {
+                    info.imported_from_packages.insert(package);
                     info.imported_names.extend(args);
                 }
             }
             "import" => {
-                info.imported_packages.extend(directive.args);
+                // R drops `except` and treats every remaining argument as a
+                // package, so only the *positional* arguments name packages. A
+                // kept `except = c(a, b)` would enter the set as a package no
+                // index can enumerate.
+                info.imported_packages.extend(directive.positional());
             }
             _ => {}
         }
@@ -479,7 +491,31 @@ fn compile_r_pattern(pattern: &str) -> Option<regex::Regex> {
 
 struct NamespaceDirective {
     name: &'static str,
-    args: Vec<String>,
+    args: Vec<NamespaceArg>,
+}
+
+impl NamespaceDirective {
+    /// Every argument's value, named or not.
+    fn values(self) -> impl Iterator<Item = String> {
+        self.args.into_iter().map(|arg| arg.value)
+    }
+
+    /// Only the *positional* arguments' values. `import(pkg, except = ...)`
+    /// names packages positionally and options by keyword, so this is how the
+    /// two are told apart after the fact.
+    fn positional(self) -> impl Iterator<Item = String> {
+        self.args
+            .into_iter()
+            .filter(|arg| arg.name.is_none())
+            .map(|arg| arg.value)
+    }
+}
+
+/// One argument of a NAMESPACE directive.
+struct NamespaceArg {
+    /// The keyword, for `name = value`.
+    name: Option<String>,
+    value: String,
 }
 
 /// Iterator over the recognized top-level NAMESPACE directives. Tolerant of
@@ -599,20 +635,24 @@ fn matching_paren(text: &str, open: usize) -> Option<usize> {
 /// Parse the comma-separated arguments of a directive, unquoting string
 /// literals and interpreting R string escapes. Keyword arguments
 /// (`name = value`) are reduced to their value.
-fn parse_args(inner: &str) -> Vec<String> {
+fn parse_args(inner: &str) -> Vec<NamespaceArg> {
     let mut args = Vec::new();
     for raw in split_top_level_commas(inner) {
         let raw = raw.trim();
         if raw.is_empty() {
             continue;
         }
-        // Drop a leading `name =` for things like `pattern = "..."`.
-        let value = match raw.split_once('=') {
-            Some((lhs, rhs)) if !lhs.trim_end().ends_with(['<', '>', '!']) => rhs.trim(),
-            _ => raw,
+        // Split a leading `name =` off things like `pattern = "..."`. The
+        // keyword is kept rather than discarded: `import(pkg, except = ...)`
+        // needs it to tell a package from an option.
+        let (name, value) = match raw.split_once('=') {
+            Some((lhs, rhs)) if !lhs.trim_end().ends_with(['<', '>', '!']) => {
+                (Some(lhs.trim().to_string()), rhs.trim())
+            }
+            _ => (None, raw),
         };
-        if let Some(s) = unquote(value) {
-            args.push(s);
+        if let Some(value) = unquote(value) {
+            args.push(NamespaceArg { name, value });
         }
     }
     args
@@ -937,6 +977,38 @@ mod tests {
         // The package name is not itself an imported name.
         assert!(!info.imported_names.contains("dplyr"));
         assert!(info.imported_packages.contains("rlang"));
+    }
+
+    #[test]
+    fn import_keeps_only_the_packages_it_names() {
+        // R's `import()` drops its `except` argument and treats every remaining
+        // argument as a package. Keeping `except`'s value would invent a
+        // package named `c(filter, lag)` — and since no index can enumerate
+        // that, a consumer gating on "are these exports knowable" would
+        // suppress the file permanently.
+        let info = parse_namespace("import(dplyr, except = c(filter, lag))\n", &[]);
+        assert_eq!(info.imported_packages, ["dplyr".to_string()].into());
+
+        // Several packages in one directive is legal and must all be kept.
+        let info = parse_namespace("import(stats, utils)\n", &[]);
+        assert_eq!(
+            info.imported_packages,
+            ["stats".to_string(), "utils".to_string()].into()
+        );
+    }
+
+    #[test]
+    fn import_from_records_the_package_it_names() {
+        // `importFrom(pkg, x)` references `pkg` as surely as `import(pkg)` does.
+        // It is tracked apart because its names are already enumerated, so it
+        // never makes resolution incomplete.
+        let info = parse_namespace("importFrom(dplyr, filter, select)\n", &[]);
+        assert_eq!(info.imported_from_packages, ["dplyr".to_string()].into());
+        assert!(info.imported_packages.is_empty());
+        assert_eq!(
+            info.imported_names,
+            ["filter".to_string(), "select".to_string()].into()
+        );
     }
 
     #[test]

--- a/src/rindex/provider.rs
+++ b/src/rindex/provider.rs
@@ -19,7 +19,7 @@ use crate::rindex::remote::RemoteExports;
 use crate::rindex::schema::{PackageIndex, SymbolEntry};
 use crate::semantic::symbols::{
     BundledPackages, LoadedPackage, PackageOrigin, StaticBaseR, SymbolProvider,
-    meta_package_members,
+    meta_package_members, unbacktick,
 };
 
 /// R's default-package export lists. A compile-time constant (baked-in symbol
@@ -237,6 +237,7 @@ impl IndexedProvider {
 
     /// The rich entry for `pkg::name`, if indexed.
     pub fn lookup(&self, package: &str, name: &str) -> Option<&SymbolEntry> {
+        let name = unbacktick(name);
         self.indices
             .get(package)?
             .symbols
@@ -259,7 +260,7 @@ impl IndexedProvider {
     fn exports(&self, package: &str, name: &str) -> bool {
         self.pkg_exports
             .get(package)
-            .is_some_and(|set| set.contains(name))
+            .is_some_and(|set| set.contains(unbacktick(name)))
     }
 }
 
@@ -661,6 +662,52 @@ mod tests {
         // ...but the rich per-symbol data is deliberately not loaded.
         assert!(lean.lookup("dplyr", "filter").is_none());
         assert!(lean.package("dplyr").is_none());
+    }
+
+    #[test]
+    fn backtick_quoted_name_resolves_through_every_tier() {
+        // Export lists — baked-in, harvested, remote, and bundled alike — store
+        // operator names unquoted, but a reference to one is a single IDENT
+        // token with the backticks inside it.
+        let p = CompositeProvider::base_only();
+        assert!(p.is_base("`%in%`"));
+        assert_eq!(
+            p.origin("`:`", &[]),
+            PackageOrigin::Resolved(SmolStr::new("base"))
+        );
+        // Harvested index.
+        let p = CompositeProvider::with_index(IndexedProvider::from_indices([pkg(
+            "magrittr",
+            &["%>%"],
+        )]));
+        assert_eq!(
+            p.origin("`%>%`", &[loaded("magrittr")]),
+            PackageOrigin::Resolved(SmolStr::new("magrittr"))
+        );
+        // Remote sidecar.
+        let p = CompositeProvider::base_only().with_remote(remote(&[("tinytable", &["%op%"])]));
+        assert_eq!(
+            p.origin("`%op%`", &[loaded("tinytable")]),
+            PackageOrigin::Resolved(SmolStr::new("tinytable"))
+        );
+        // Bundled CRAN list.
+        let p = CompositeProvider::base_only();
+        assert_eq!(
+            p.origin("`%>%`", &[loaded("dplyr")]),
+            PackageOrigin::Resolved(SmolStr::new("dplyr"))
+        );
+        // A backtick-quoted name that no tier exports is still Unknown.
+        assert_eq!(
+            p.origin("`not_a_real_export_xyz`", &[loaded("dplyr")]),
+            PackageOrigin::Unknown
+        );
+    }
+
+    #[test]
+    fn lookup_accepts_a_backtick_quoted_name() {
+        let provider = IndexedProvider::from_indices([pkg("magrittr", &["%>%"])]);
+        assert!(provider.lookup("magrittr", "`%>%`").is_some());
+        assert!(provider.lookup("magrittr", "`nope`").is_none());
     }
 
     #[test]

--- a/src/rindex/remote.rs
+++ b/src/rindex/remote.rs
@@ -28,6 +28,8 @@ use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
+use crate::semantic::symbols::unbacktick;
+
 /// Names-only export lists for packages fetched from the remote sidecar, keyed
 /// by package name. Owned (not `&'static`) because it is built dynamically from
 /// the disk cache and network fetches, unlike the compile-time bundled lists.
@@ -68,7 +70,7 @@ impl RemoteExports {
     pub fn exports(&self, package: &str, name: &str) -> bool {
         self.exports
             .get(package)
-            .is_some_and(|set| set.contains(name))
+            .is_some_and(|set| set.contains(unbacktick(name)))
     }
 
     /// Iterate a package's export names, if it is in the sidecar (for

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -58,10 +58,18 @@ pub struct SemanticModel {
     /// Identifier *read* sites. Definition sites are recorded as `Binding`s.
     idents: Vec<IdentRef>,
     loaded_packages: Vec<LoadedPackage>,
-    /// Packages named on the left of `::` / `:::`. Unlike `loaded_packages`,
-    /// these are *not* attached to the search path — `pkg::name` is a direct
-    /// reference — so they never affect bare-name resolution. They drive
-    /// which packages the introspection index should harvest.
+    /// Packages this file *names*: the left of every `::` / `:::`, and the
+    /// package argument of every
+    /// [`PACKAGE_LOAD_CALLS`](symbols::PACKAGE_LOAD_CALLS) call **at any
+    /// depth**.
+    ///
+    /// Deliberately wider than `loaded_packages`, which is top-level-only
+    /// because it models *attachment*: a `requireNamespace()` inside a function
+    /// body is the conditional-dependency idiom, and it references a package
+    /// without attaching it. Naming a package never affects bare-name
+    /// resolution, so this set only drives which packages the introspection
+    /// index should harvest and which ones a package's code can be said to
+    /// reach.
     referenced_packages: Vec<SmolStr>,
     /// Names accessed on the right of `::` / `:::` (`pkg::name` -> `name`). Kept
     /// out of [`idents`](Self::idents) so they never resolve locally or reach
@@ -157,8 +165,10 @@ impl SemanticModel {
         self.attaches_opaque_env
     }
 
-    /// Packages referenced via `pkg::name` / `pkg:::name`, in source order
-    /// (with duplicates preserved as encountered).
+    /// Packages named via `pkg::name` / `pkg:::name` or by a `library` /
+    /// `require` / `requireNamespace` / `loadNamespace` call at any depth, in
+    /// source order (with duplicates preserved as encountered). See the field
+    /// doc for why this is wider than [`loaded_packages`](Self::loaded_packages).
     pub fn referenced_packages(&self) -> &[SmolStr] {
         &self.referenced_packages
     }

--- a/src/semantic/builder.rs
+++ b/src/semantic/builder.rs
@@ -510,10 +510,7 @@ fn handle_call(ctx: &mut BuildCtx<'_>, node: &SyntaxNode, scope: ScopeId) {
     // deliberately top-level-only because attachment is the narrower fact.
     if let Some(call) = CallExpr::cast(node.clone())
         && let Some(callee) = call_callee_ident(&call)
-        && matches!(
-            callee.as_str(),
-            "library" | "require" | "requireNamespace" | "loadNamespace"
-        )
+        && crate::semantic::symbols::PACKAGE_LOAD_CALLS.contains(&callee.as_str())
         && let Some((pkg_name, _)) = first_string_or_ident_arg(&call)
     {
         ctx.model.referenced_packages.push(pkg_name);

--- a/src/semantic/builder.rs
+++ b/src/semantic/builder.rs
@@ -504,6 +504,21 @@ fn handle_assignment(ctx: &mut BuildCtx<'_>, node: &SyntaxNode, scope: ScopeId) 
 }
 
 fn handle_call(ctx: &mut BuildCtx<'_>, node: &SyntaxNode, scope: ScopeId) {
+    // Naming a package in a load call *references* it, wherever the call sits —
+    // `requireNamespace()` inside a function body is the conditional-dependency
+    // idiom. Recorded separately from the attach set below, which is
+    // deliberately top-level-only because attachment is the narrower fact.
+    if let Some(call) = CallExpr::cast(node.clone())
+        && let Some(callee) = call_callee_ident(&call)
+        && matches!(
+            callee.as_str(),
+            "library" | "require" | "requireNamespace" | "loadNamespace"
+        )
+        && let Some((pkg_name, _)) = first_string_or_ident_arg(&call)
+    {
+        ctx.model.referenced_packages.push(pkg_name);
+    }
+
     // Detect a top-level `library(pkg)` / `require(pkg)` / `requireNamespace("pkg")`.
     if ctx.function_depth == 0
         && let Some(call) = CallExpr::cast(node.clone())

--- a/src/semantic/symbols.rs
+++ b/src/semantic/symbols.rs
@@ -38,6 +38,17 @@ const DEFAULT_PACKAGES: &[&str] = &[
     PACKAGE_GRAPHICS,
 ];
 
+/// The base callees whose package argument *names* a package: exactly the set
+/// `tools:::.check_packages_used` matches.
+///
+/// One list rather than one per consumer, because two would drift: the semantic
+/// builder records what these calls name at any depth, and the linter's
+/// `matchers::package_load_arg` re-reads the same calls to span one. Note this
+/// is deliberately wider than the *attach* set the builder's top-level branch
+/// matches — `loadNamespace` references a package without attaching it.
+pub const PACKAGE_LOAD_CALLS: [&str; 4] =
+    ["library", "require", "requireNamespace", "loadNamespace"];
+
 /// The bare name a package export list would store for `name`: a matched pair
 /// of surrounding backticks removed, everything else returned unchanged.
 ///

--- a/src/semantic/symbols.rs
+++ b/src/semantic/symbols.rs
@@ -38,6 +38,21 @@ const DEFAULT_PACKAGES: &[&str] = &[
     PACKAGE_GRAPHICS,
 ];
 
+/// The bare name a package export list would store for `name`: a matched pair
+/// of surrounding backticks removed, everything else returned unchanged.
+///
+/// A backtick-quoted reference lexes as a *single* `IDENT` token with the
+/// backticks inside it, and that is load-bearing — the semantic builder records
+/// a user operator's binding backtick-quoted so its references match. Export
+/// lists, on the other hand, store `:` and `%in%` unquoted, so every provider
+/// lookup has to bridge the two. Strip here, at the lookup, never at the
+/// binding.
+pub fn unbacktick(name: &str) -> &str {
+    name.strip_prefix('`')
+        .and_then(|rest| rest.strip_suffix('`'))
+        .unwrap_or(name)
+}
+
 /// A `library()` / `require()` / `requireNamespace()` call discovered in the
 /// file, in source order.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -537,7 +552,7 @@ impl StaticBaseR {
     /// default packages export it), if any.
     pub fn package_of(&self, name: &str) -> Option<&SmolStr> {
         self.name_to_packages
-            .get(name)
+            .get(unbacktick(name))
             .and_then(|pkgs| pkgs.first())
     }
 }
@@ -545,7 +560,7 @@ impl StaticBaseR {
 impl SymbolProvider for StaticBaseR {
     fn origin(&self, name: &str, loaded: &[LoadedPackage]) -> PackageOrigin {
         let mut candidates: Vec<SmolStr> = Vec::new();
-        if let Some(pkgs) = self.name_to_packages.get(name) {
+        if let Some(pkgs) = self.name_to_packages.get(unbacktick(name)) {
             candidates.extend(pkgs.iter().cloned());
         }
         // Non-default `library()` calls add nothing this pass — no manifest yet.
@@ -558,7 +573,7 @@ impl SymbolProvider for StaticBaseR {
     }
 
     fn is_base(&self, name: &str) -> bool {
-        self.base_names.contains(name)
+        self.base_names.contains(unbacktick(name))
     }
 
     fn package_indexed(&self, pkg: &str) -> bool {
@@ -629,7 +644,7 @@ impl BundledPackages {
     pub fn exports(&self, package: &str, name: &str) -> bool {
         self.exports
             .get(package)
-            .is_some_and(|set| set.contains(name))
+            .is_some_and(|set| set.contains(unbacktick(name)))
     }
 
     /// Iterate a bundled package's export names, if it is in the set (for
@@ -735,5 +750,44 @@ mod tests {
         let bundled = BundledPackages::new();
         assert!(bundled.exports("rlang", "abort"));
         assert!(!base.is_base("abort"));
+    }
+
+    #[test]
+    fn unbacktick_strips_only_a_matched_pair() {
+        assert_eq!(unbacktick("`%in%`"), "%in%");
+        assert_eq!(unbacktick("`a b`"), "a b");
+        assert_eq!(unbacktick("mean"), "mean");
+        // Unmatched or degenerate input is left alone.
+        assert_eq!(unbacktick("`c"), "`c");
+        assert_eq!(unbacktick("c`"), "c`");
+        assert_eq!(unbacktick("`"), "`");
+        assert_eq!(unbacktick(""), "");
+    }
+
+    #[test]
+    fn backtick_quoted_names_resolve_against_base() {
+        // A backtick-quoted reference is a single IDENT token, backticks
+        // included; the export lists store the bare name.
+        let p = StaticBaseR::new();
+        assert!(p.is_base("`%in%`"));
+        assert!(p.is_base("`[`"));
+        assert_eq!(
+            p.origin("`:`", &[]),
+            PackageOrigin::Resolved(SmolStr::new("base"))
+        );
+        assert_eq!(p.package_of("`length`").map(|s| s.as_str()), Some("base"));
+        // Stripping must not invent a name.
+        assert_eq!(
+            p.origin("`not_a_real_symbol_xyz`", &[]),
+            PackageOrigin::Unknown
+        );
+        assert!(!p.is_base("`c"));
+    }
+
+    #[test]
+    fn backtick_quoted_names_resolve_against_bundled() {
+        let b = BundledPackages::new();
+        assert!(b.exports("dplyr", "`%>%`"));
+        assert!(!b.exports("dplyr", "`definitely_not_a_real_export`"));
     }
 }

--- a/src/semantic/symbols.rs
+++ b/src/semantic/symbols.rs
@@ -586,6 +586,61 @@ pub fn default_packages() -> &'static [&'static str] {
     DEFAULT_PACKAGES
 }
 
+/// Every package R ships at `Priority: base` — the set R itself keeps in
+/// `tools:::.get_standard_package_names()$base` (checked against R 4.6.1 by the
+/// `deps-oracle` task).
+///
+/// **Not the same list as [`default_packages`]**, and conflating the two is
+/// wrong in both directions: `parallel`, `tools`, `grid`, `splines`, `stats4`,
+/// `tcltk`, and `compiler` ship with R but are not attached to a fresh
+/// session's search path, while `methods` is attached and yet, per `R CMD
+/// check`, still has to be declared by a package that uses it. This list
+/// answers "does R ship it", [`default_packages`] answers "is it attached".
+const BASE_PRIORITY_PACKAGES: &[&str] = &[
+    "base",
+    "tools",
+    "utils",
+    "grDevices",
+    "graphics",
+    "stats",
+    "datasets",
+    "methods",
+    "grid",
+    "splines",
+    "stats4",
+    "tcltk",
+    "compiler",
+    "parallel",
+];
+
+/// The two base-priority packages `R CMD check` still expects a package to
+/// declare (`tools:::.check_packages_used`).
+const DECLARED_BASE_PACKAGES: &[&str] = &["methods", "stats4"];
+
+/// See [`BASE_PRIORITY_PACKAGES`].
+pub fn base_priority_packages() -> &'static [&'static str] {
+    BASE_PRIORITY_PACKAGES
+}
+
+/// Whether `pkg` needs no `DESCRIPTION` entry to be reachable: R ships it at
+/// base priority, and it is not one of the two `R CMD check` nonetheless
+/// requires a package to declare.
+///
+/// This is `tools:::.check_packages_used`'s `standard_package_names`, and it is
+/// the exemption set a "you used an undeclared package" check must use.
+pub fn is_implicitly_available(pkg: &str) -> bool {
+    BASE_PRIORITY_PACKAGES.contains(&pkg) && !DECLARED_BASE_PACKAGES.contains(&pkg)
+}
+
+/// Identifier spellings R treats as a *variable* holding a package name rather
+/// than as a package: `library(pkg)` inside a helper that takes `pkg` as an
+/// argument. R's own `common_names`, and the same conservative reason —
+/// a name matched here is unresolvable statically, so treating it as a package
+/// could only ever invent a finding.
+pub fn is_package_name_placeholder(name: &str) -> bool {
+    matches!(name, "pkg" | "pkgName" | "package" | "pos" | "dep_name")
+}
+
 /// Names-only export lists for the top-N CRAN packages by download count,
 /// baked in from `cran/exports.txt` and parsed once.
 ///

--- a/tests/deps_oracle.rs
+++ b/tests/deps_oracle.rs
@@ -1,0 +1,105 @@
+//! Differential oracle: arity's dependency-exemption sets against R's own.
+//!
+//! `undeclared-dependency` decides what needs declaring by copying `R CMD
+//! check`. The two lists it copies are data that changes with R itself — a new
+//! base-priority package would silently become a false positive — so they are
+//! checked against R rather than asserted in a comment:
+//!
+//! - `tools:::.get_standard_package_names()$base` is
+//!   [`base_priority_packages`].
+//! - That set minus `methods` and `stats4` — the `standard_package_names` local
+//!   in `tools:::.check_packages_used` — is [`is_implicitly_available`].
+//!
+//! `#[ignore]`d because it needs R: run via `task deps-oracle`. A missing
+//! `Rscript` is a skip, never a failure, exactly as in `dcf_oracle`.
+//!
+//! [`base_priority_packages`]: arity::semantic::symbols::base_priority_packages
+//! [`is_implicitly_available`]: arity::semantic::symbols::is_implicitly_available
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::process::Command;
+
+use arity::semantic::symbols::{base_priority_packages, is_implicitly_available};
+
+#[test]
+#[ignore = "needs R; run via `task deps-oracle`"]
+fn base_priority_packages_match_r() {
+    let Some(rscript) = locate_rscript() else {
+        eprintln!("deps-oracle: `Rscript` not found on PATH; skipping (this is not a failure).");
+        return;
+    };
+
+    let ours: BTreeSet<&str> = base_priority_packages().iter().copied().collect();
+    let theirs = r_names(
+        &rscript,
+        "cat(tools:::.get_standard_package_names()$base, sep = \"\\n\")",
+    );
+    assert_eq!(
+        ours,
+        theirs.iter().map(String::as_str).collect::<BTreeSet<_>>(),
+        "`base_priority_packages` has drifted from this R's base-priority set",
+    );
+}
+
+/// The exemption set proper. Pinned separately from the list it derives from,
+/// because the `methods`/`stats4` carve-out is R's own decision and not
+/// something we could re-derive.
+#[test]
+#[ignore = "needs R; run via `task deps-oracle`"]
+fn the_exempt_set_matches_r_cmd_check() {
+    let Some(rscript) = locate_rscript() else {
+        eprintln!("deps-oracle: `Rscript` not found on PATH; skipping (this is not a failure).");
+        return;
+    };
+
+    let theirs = r_names(
+        &rscript,
+        "cat(setdiff(tools:::.get_standard_package_names()$base, \
+         c(\"methods\", \"stats4\")), sep = \"\\n\")",
+    );
+    let ours: BTreeSet<&str> = base_priority_packages()
+        .iter()
+        .copied()
+        .filter(|pkg| is_implicitly_available(pkg))
+        .collect();
+    assert_eq!(
+        ours,
+        theirs.iter().map(String::as_str).collect::<BTreeSet<_>>(),
+        "`is_implicitly_available` has drifted from `tools:::.check_packages_used`",
+    );
+    // The carve-out itself, stated so a drift in either direction is legible.
+    assert!(!is_implicitly_available("methods"));
+    assert!(!is_implicitly_available("stats4"));
+}
+
+fn r_names(rscript: &PathBuf, expr: &str) -> BTreeSet<String> {
+    let output = Command::new(rscript)
+        .arg("-e")
+        .arg(expr)
+        .output()
+        .expect("Rscript should run");
+    assert!(
+        output.status.success(),
+        "Rscript failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn locate_rscript() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("ARITY_RSCRIPT") {
+        return Some(PathBuf::from(path));
+    }
+    Command::new("Rscript")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+        .then(|| PathBuf::from("Rscript"))
+}

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -1450,6 +1450,31 @@ fn undefined_symbol_flags_base_only_typo() {
 }
 
 #[test]
+fn undefined_symbol_resolves_backtick_quoted_base_names() {
+    // Backticks are part of the IDENT token, but the export lists store the
+    // bare name, so the provider lookup has to try the stripped form.
+    let p = CompositeProvider::base_only();
+    let msgs = undefined_with(
+        "f <- function(imp, topic) {\n  \
+           e <- new.env()\n  \
+           e$a <- `:`\n  \
+           vapply(imp, `%in%`, logical(1), x = topic)\n\
+         }\n",
+        &p,
+    );
+    assert!(msgs.is_empty(), "expected no findings, got {msgs:?}");
+}
+
+#[test]
+fn undefined_symbol_flags_backtick_quoted_unknown_name() {
+    // Stripping the backticks must not make every quoted name resolve.
+    let p = CompositeProvider::base_only();
+    let msgs = undefined_with("`no such thing`()\n", &p);
+    assert_eq!(msgs.len(), 1, "expected one finding, got {msgs:?}");
+    assert!(msgs[0].contains("no such thing"));
+}
+
+#[test]
 fn undefined_symbol_gated_off_when_attached_package_unindexed() {
     // `library(somepkg)` with somepkg un-indexed: the rule stays silent for the
     // whole file because somepkg could export `bogus`.

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -9,6 +9,17 @@ use arity::linter::{
 };
 use tempfile::tempdir;
 
+/// A `DESCRIPTION` complete enough that the `packaging` rules have nothing to
+/// say about it, so a package fixture only ever reports what its test is about.
+const TEST_DESCRIPTION: &str = "\
+Package: testpkg
+Version: 0.1.0
+Title: A Test Package
+Description: Fixture data for arity's own tests.
+License: MIT + file LICENSE
+Authors@R: person(\"Test\", \"User\", role = c(\"aut\", \"cre\"))
+";
+
 /// Rule ids reported for the file named `file_name` in `result`.
 fn rules_for<'a>(result: &'a LintResult, file_name: &str) -> Vec<&'a str> {
     result
@@ -297,7 +308,7 @@ fn package_resolves_bindings_across_files() {
     // resolves from b.R (no undefined-symbol) and counts as used (no
     // unused-binding in a.R).
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(r_dir.join("a.R"), "foo <- function() 1\n").unwrap();
@@ -319,7 +330,7 @@ fn excluded_generated_file_still_contributes_bindings() {
     // every caller is a false `undefined-symbol`. (The exclude only suppresses
     // findings *in* the generated file, not its contribution to scope.)
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(
@@ -367,7 +378,7 @@ fn excluded_generated_file_still_contributes_bindings() {
 /// `tests/testthat/test-foo.R`.
 fn lint_pkg_with_test(r_file: &str, test_file: &str, indexed: IndexedProvider) -> LintResult {
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(r_dir.join("foo.R"), r_file).unwrap();
@@ -597,7 +608,7 @@ fn shadowed_builtin_ignores_parameters() {
 /// Write a minimal package (DESCRIPTION + NAMESPACE + R/a.R) and lint it.
 fn lint_package(namespace: &str, a_r: &str) -> LintResult {
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     std::fs::write(dir.path().join("NAMESPACE"), namespace).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
@@ -625,7 +636,7 @@ fn namespace_export_is_not_unused() {
 /// lint it under `config`.
 fn lint_package_files(namespace: &str, files: &[(&str, &str)], config: &LintConfig) -> LintResult {
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     std::fs::write(dir.path().join("NAMESPACE"), namespace).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
@@ -885,7 +896,7 @@ fn self_qualified_internal_use_is_not_unused() {
     // (here a test) is used cross-file, so it must not flag unused. Mirrors the
     // real-world `SLOPE:::randomProblem(...)` case.
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     std::fs::write(dir.path().join("NAMESPACE"), "").unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
@@ -938,7 +949,7 @@ fn project_aware_document_resolves_cross_file() {
     use arity::rindex::provider::CompositeProvider;
 
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(r_dir.join("a.R"), "foo <- function() 1\n").unwrap();
@@ -966,7 +977,7 @@ fn project_aware_document_keeps_excluded_generated_scope() {
     use arity::rindex::provider::CompositeProvider;
 
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(
@@ -999,7 +1010,7 @@ fn project_aware_relint_reuses_unchanged_siblings() {
     use arity::rindex::provider::CompositeProvider;
 
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(r_dir.join("a.R"), "foo <- function() 1\n").unwrap();
@@ -1031,7 +1042,7 @@ fn body_edit_relint_does_not_rebuild_project_scope() {
     use arity::rindex::provider::CompositeProvider;
 
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(r_dir.join("a.R"), "foo <- function() 1\n").unwrap();
@@ -1070,7 +1081,7 @@ fn prepared_split_matches_wrapper_and_runs_on_clone() {
     use arity::rindex::provider::CompositeProvider;
 
     let dir = tempdir().expect("failed to create temp dir");
-    std::fs::write(dir.path().join("DESCRIPTION"), "Package: testpkg\n").unwrap();
+    std::fs::write(dir.path().join("DESCRIPTION"), TEST_DESCRIPTION).unwrap();
     let r_dir = dir.path().join("R");
     std::fs::create_dir(&r_dir).unwrap();
     std::fs::write(r_dir.join("a.R"), "foo <- function() 1\n").unwrap();

--- a/tests/lint_description.rs
+++ b/tests/lint_description.rs
@@ -108,6 +108,27 @@ fn a_description_outside_a_package_root_is_not_walked() {
     assert_eq!(described, vec![&root.join("DESCRIPTION")]);
 }
 
+/// A *complete* fake package under `tests/` is fixture data for a test —
+/// roxygen2 and devtools keep dozens — and its deliberately minimal
+/// `DESCRIPTION` describes nothing anybody ships.
+#[test]
+fn a_fixture_package_inside_a_package_is_not_walked() {
+    let (_dir, root) = package(COMPLETE_DESCRIPTION, "", &[("a.R", "f <- function() 1\n")]);
+    let fixture = root.join("tests").join("testthat").join("minimal");
+    std::fs::create_dir_all(fixture.join("R")).unwrap();
+    std::fs::write(fixture.join("DESCRIPTION"), "Package: minimal\n").unwrap();
+    std::fs::write(fixture.join("R").join("a.R"), "g <- function() 1\n").unwrap();
+
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    let described: Vec<&PathBuf> = result
+        .reports
+        .iter()
+        .map(|r| &r.path)
+        .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some("DESCRIPTION"))
+        .collect();
+    assert_eq!(described, vec![&root.join("DESCRIPTION")]);
+}
+
 /// ...but naming it explicitly still lints it, exactly as naming an excluded
 /// `.R` file does.
 #[test]

--- a/tests/lint_description.rs
+++ b/tests/lint_description.rs
@@ -466,3 +466,224 @@ fn check_description_document_is_clean_on_a_good_file() {
     .expect("linting should not error");
     assert!(diagnostics.is_empty(), "{diagnostics:?}");
 }
+
+// ---------------------------------------------------------------------------
+// undeclared-dependency
+//
+// An R-file rule, but a packaging one: what it reads is DESCRIPTION.
+// ---------------------------------------------------------------------------
+
+/// Rule ids reported for `R/a.R` after linting a package whose `DESCRIPTION`
+/// declares `declares` (appended to the complete fixture) and whose `R/a.R` is
+/// `source`.
+fn package_rules(declares: &str, source: &str) -> Vec<&'static str> {
+    let (_dir, root) = package(
+        &format!("{COMPLETE_DESCRIPTION}{declares}"),
+        "",
+        &[("a.R", source)],
+    );
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    result
+        .reports
+        .iter()
+        .find(|r| r.path.file_name().and_then(|n| n.to_str()) == Some("a.R"))
+        .map(|r| r.diagnostics.iter().map(|d| d.rule).collect())
+        .unwrap_or_default()
+}
+
+fn flags_undeclared(declares: &str, source: &str) -> bool {
+    package_rules(declares, source).contains(&"undeclared-dependency")
+}
+
+#[test]
+fn a_qualified_call_to_an_undeclared_package_is_flagged() {
+    assert!(flags_undeclared("", "dplyr::filter(x)\n"));
+}
+
+#[test]
+fn an_internal_access_to_an_undeclared_package_is_flagged() {
+    let rules = package_rules("", "dplyr:::internal(x)\n");
+    assert!(rules.contains(&"undeclared-dependency"));
+    // Two different facts about the same line, both worth saying.
+    assert!(rules.contains(&"internal-function"));
+}
+
+#[test]
+fn attaching_an_undeclared_package_is_flagged() {
+    assert!(flags_undeclared("", "library(dplyr)\n"));
+    assert!(flags_undeclared("", "require(dplyr)\n"));
+}
+
+/// The conditional-dependency idiom lives inside a function body, and the
+/// semantic model records attaches only at depth zero — so this rule cannot
+/// read them off the model.
+#[test]
+fn a_conditional_load_inside_a_function_is_flagged() {
+    assert!(flags_undeclared(
+        "",
+        "f <- function() {\n  if (requireNamespace(\"dplyr\", quietly = TRUE)) 1\n}\n"
+    ));
+}
+
+/// `methods` ships with R and is even attached by default, but `R CMD check`
+/// still requires a package that uses it to declare it.
+#[test]
+fn methods_must_be_declared() {
+    assert!(flags_undeclared("", "methods::new(\"A\")\n"));
+}
+
+/// Every site, not just the first: each one is separately suppressible, and one
+/// DESCRIPTION line clears them all.
+#[test]
+fn every_site_is_reported() {
+    let rules = package_rules("", "dplyr::filter(x)\ndplyr::mutate(y)\n");
+    assert_eq!(
+        rules
+            .iter()
+            .filter(|id| **id == "undeclared-dependency")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn a_declared_package_is_not_flagged() {
+    for field in ["Depends", "Imports", "Suggests", "LinkingTo", "Enhances"] {
+        let declares = format!("{field}: dplyr\n");
+        assert!(
+            !flags_undeclared(&declares, "dplyr::filter(x)\n"),
+            "declared in {field} but still flagged",
+        );
+    }
+}
+
+/// R exempts `Suggests` here too. Flagging *unconditional* use of a suggested
+/// package is a different, control-flow question.
+#[test]
+fn a_suggested_package_is_not_flagged_when_attached() {
+    assert!(!flags_undeclared("Suggests: dplyr\n", "library(dplyr)\n"));
+}
+
+/// R's base-priority set, which is *not* arity's `default_packages()`:
+/// `parallel`, `tools`, `grid`, and `compiler` ship with R but are not
+/// attached, and using them needs no declaration.
+#[test]
+fn base_priority_packages_need_no_declaration() {
+    for source in [
+        "stats::median(x)\n",
+        "parallel::mclapply(x, f)\n",
+        "tools::file_ext(p)\n",
+        "grid::unit(1, \"cm\")\n",
+        "compiler::cmpfun(f)\n",
+        "splines::ns(x)\n",
+        "utils::head(x)\n",
+    ] {
+        assert!(!flags_undeclared("", source), "{source} was flagged");
+    }
+}
+
+#[test]
+fn a_self_reference_is_not_flagged() {
+    assert!(!flags_undeclared("", "testpkg::exported()\n"));
+}
+
+/// Only `R/` is package code. R does not scan `tests/` for this check either,
+/// and a test file's dependencies belong in `Suggests`.
+#[test]
+fn a_test_file_is_not_package_code() {
+    let (_dir, root) = package(COMPLETE_DESCRIPTION, "", &[("a.R", "f <- function() 1\n")]);
+    let tests = root.join("tests").join("testthat");
+    std::fs::create_dir_all(&tests).unwrap();
+    std::fs::write(tests.join("test-a.R"), "dplyr::filter(x)\n").unwrap();
+
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    let reported: Vec<&str> = result
+        .reports
+        .iter()
+        .find(|r| r.path.file_name().and_then(|n| n.to_str()) == Some("test-a.R"))
+        .map(|r| r.diagnostics.iter().map(|d| d.rule).collect())
+        .unwrap_or_default();
+    assert!(!reported.contains(&"undeclared-dependency"), "{reported:?}");
+}
+
+/// A loose script is not a package, and there is no DESCRIPTION to consult.
+#[test]
+fn a_loose_script_is_not_flagged() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("script.R");
+    std::fs::write(&path, "dplyr::filter(x)\n").unwrap();
+
+    let result = check_paths(std::slice::from_ref(&path)).expect("lint should succeed");
+    assert_eq!(result.total_findings, 0, "{:?}", result.reports);
+}
+
+/// `library(pkg)` where `pkg` is a variable names no package statically, so
+/// matching it could only invent a finding. R's own `common_names`.
+#[test]
+fn a_package_name_placeholder_is_not_flagged() {
+    assert!(!flags_undeclared(
+        "",
+        "attach_it <- function(pkg) library(pkg)\n"
+    ));
+}
+
+/// `character.only = TRUE` says the argument is a variable, by contract.
+#[test]
+fn character_only_is_not_flagged() {
+    assert!(!flags_undeclared(
+        "",
+        "f <- function(x) library(x, character.only = TRUE)\n"
+    ));
+}
+
+/// The span is the package token alone, not the whole access.
+#[test]
+fn undeclared_dependency_spans_the_package_name() {
+    let (_dir, root) = package(COMPLETE_DESCRIPTION, "", &[("a.R", "dplyr::filter(x)\n")]);
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    let finding = result
+        .reports
+        .iter()
+        .find(|r| r.path.file_name().and_then(|n| n.to_str()) == Some("a.R"))
+        .and_then(|r| {
+            r.diagnostics
+                .iter()
+                .find(|d| d.rule == "undeclared-dependency")
+        })
+        .expect("an undeclared-dependency finding");
+    let start: usize = finding.range.start().into();
+    let end: usize = finding.range.end().into();
+    assert_eq!((start, end), (0, "dplyr".len()));
+}
+
+/// `base::library(dplyr)` is one finding on `dplyr`, not also one on `base`.
+#[test]
+fn a_qualified_load_call_reports_once() {
+    let rules = package_rules("", "base::library(dplyr)\n");
+    assert_eq!(
+        rules
+            .iter()
+            .filter(|id| **id == "undeclared-dependency")
+            .count(),
+        1
+    );
+}
+
+/// Nothing to check against: a DESCRIPTION with no `Package` field would make
+/// every dependency look undeclared.
+#[test]
+fn a_description_without_a_package_field_flags_nothing() {
+    let (_dir, root) = package(
+        "Title: Not A Package\n",
+        "",
+        &[("a.R", "dplyr::filter(x)\n")],
+    );
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    let reported: Vec<&str> = result
+        .reports
+        .iter()
+        .find(|r| r.path.file_name().and_then(|n| n.to_str()) == Some("a.R"))
+        .map(|r| r.diagnostics.iter().map(|d| d.rule).collect())
+        .unwrap_or_default();
+    assert!(!reported.contains(&"undeclared-dependency"), "{reported:?}");
+}

--- a/tests/lint_description.rs
+++ b/tests/lint_description.rs
@@ -167,6 +167,278 @@ fn a_non_lintable_explicit_path_is_still_an_error() {
 }
 
 // ---------------------------------------------------------------------------
+// description-duplicate-field
+// ---------------------------------------------------------------------------
+
+/// Lint one `DESCRIPTION` buffer and report the rule ids it produced.
+fn ids(description: &str) -> Vec<&'static str> {
+    check_description_document(
+        Path::new("DESCRIPTION"),
+        description,
+        &LintConfig::default(),
+    )
+    .expect("linting should not error")
+    .iter()
+    .map(|d| d.rule)
+    .collect()
+}
+
+/// Lint one `DESCRIPTION` buffer and report the message bodies for `rule`.
+fn messages(description: &str, rule: &str) -> Vec<String> {
+    check_description_document(
+        Path::new("DESCRIPTION"),
+        description,
+        &LintConfig::default(),
+    )
+    .expect("linting should not error")
+    .iter()
+    .filter(|d| d.rule == rule)
+    .map(|d| d.message.body.clone())
+    .collect()
+}
+
+#[test]
+fn duplicate_field_is_flagged_once_per_repeat() {
+    let text = format!("{COMPLETE_DESCRIPTION}Version: 0.2.0\n");
+    assert_eq!(
+        ids(&text)
+            .into_iter()
+            .filter(|id| *id == "description-duplicate-field")
+            .count(),
+        1
+    );
+}
+
+/// The span is the *later* name: the first occurrence is the one arity reads,
+/// so the repeat is what the author has to resolve.
+#[test]
+fn duplicate_field_spans_the_later_occurrence() {
+    let text = format!("{COMPLETE_DESCRIPTION}Version: 0.2.0\n");
+    let diagnostics =
+        check_description_document(Path::new("DESCRIPTION"), &text, &LintConfig::default())
+            .expect("linting should not error");
+    let finding = diagnostics
+        .iter()
+        .find(|d| d.rule == "description-duplicate-field")
+        .expect("a duplicate-field finding");
+    let at: usize = finding.range.start().into();
+    assert_eq!(&text[at..at + "Version".len()], "Version");
+    assert!(
+        at > text.find("Version: 0.1.0").expect("the first Version"),
+        "the finding should be on the second `Version`, not the first",
+    );
+}
+
+/// The message states which occurrence arity reads *and* which one R reads —
+/// the two disagree, and a duplicate field is where that becomes visible.
+#[test]
+fn duplicate_field_message_names_both_readings() {
+    let text = format!("{COMPLETE_DESCRIPTION}Version: 0.2.0\n");
+    let body = messages(&text, "description-duplicate-field")
+        .pop()
+        .expect("a message");
+    assert!(body.contains("Version"), "{body}");
+    assert!(body.contains("first"), "{body}");
+    assert!(body.contains("read.dcf"), "{body}");
+}
+
+/// Three occurrences are two repeats, not one.
+#[test]
+fn duplicate_field_flags_every_repeat() {
+    let text = format!("{COMPLETE_DESCRIPTION}Version: 0.2.0\nVersion: 0.3.0\n");
+    assert_eq!(
+        ids(&text)
+            .into_iter()
+            .filter(|id| *id == "description-duplicate-field")
+            .count(),
+        2
+    );
+}
+
+/// Record-blind, like every other `DESCRIPTION` reader: a stray blank line
+/// splits the file into two DCF records but does not make a repeat a new field.
+#[test]
+fn duplicate_field_sees_across_records() {
+    let text = format!("{COMPLETE_DESCRIPTION}\nVersion: 0.2.0\n");
+    assert!(ids(&text).contains(&"description-duplicate-field"));
+}
+
+#[test]
+fn distinct_fields_are_not_duplicates() {
+    assert!(!ids(COMPLETE_DESCRIPTION).contains(&"description-duplicate-field"));
+}
+
+/// Field names are case-sensitive to `read.dcf`, so these are two fields.
+#[test]
+fn a_differently_cased_field_is_not_a_duplicate() {
+    let text = format!("{COMPLETE_DESCRIPTION}version: 0.2.0\n");
+    assert!(!ids(&text).contains(&"description-duplicate-field"));
+}
+
+// ---------------------------------------------------------------------------
+// description-missing-field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_complete_description_reports_no_missing_field() {
+    assert!(!ids(COMPLETE_DESCRIPTION).contains(&"description-missing-field"));
+}
+
+#[test]
+fn missing_fields_are_reported_together_in_canonical_order() {
+    let body = messages(
+        "Package: testpkg\nVersion: 0.1.0\n",
+        "description-missing-field",
+    )
+    .pop()
+    .expect("a message");
+    assert!(
+        body.contains("`Title`, `Description`, `Author`, `Maintainer`, `License`"),
+        "{body}"
+    );
+}
+
+/// One finding, not one per field: the defect is that this DESCRIPTION is
+/// incomplete, and stacking five diagnostics on one line says it five times.
+#[test]
+fn missing_fields_are_one_finding() {
+    assert_eq!(
+        ids("Package: testpkg\n")
+            .into_iter()
+            .filter(|id| *id == "description-missing-field")
+            .count(),
+        1
+    );
+}
+
+/// `Authors@R` is how modern packages declare both, and `R CMD build` derives
+/// `Author` and `Maintainer` from it.
+#[test]
+fn authors_at_r_satisfies_author_and_maintainer() {
+    let text = "\
+Package: testpkg
+Version: 0.1.0
+Title: A Test Package
+Description: Fixture data.
+License: MIT + file LICENSE
+Authors@R: person(\"Test\", \"User\", role = c(\"aut\", \"cre\"))
+";
+    assert!(!ids(text).contains(&"description-missing-field"));
+}
+
+/// The legacy pair satisfies it too — plenty of packages still write both.
+#[test]
+fn author_and_maintainer_satisfy_the_pair() {
+    let text = "\
+Package: testpkg
+Version: 0.1.0
+Title: A Test Package
+Description: Fixture data.
+License: MIT + file LICENSE
+Author: Test User
+Maintainer: Test User <test@example.com>
+";
+    assert!(!ids(text).contains(&"description-missing-field"));
+}
+
+/// A field present but empty declares nothing — `R CMD check` says the same.
+#[test]
+fn an_empty_required_field_is_missing() {
+    let text = format!(
+        "{}Title:\n",
+        COMPLETE_DESCRIPTION.replace("Title: A Test Package\n", "")
+    );
+    assert!(ids(&text).contains(&"description-missing-field"));
+}
+
+/// A file with no fields at all is not an incomplete package description; it
+/// is not a package description.
+#[test]
+fn an_empty_file_reports_nothing() {
+    assert!(ids("").is_empty());
+    assert!(ids("\n\n").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// description-version-constraint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_constraint_with_no_operator_is_flagged() {
+    let text = format!("{COMPLETE_DESCRIPTION}Imports: dplyr (1.0.0)\n");
+    assert!(ids(&text).contains(&"description-version-constraint"));
+}
+
+#[test]
+fn an_empty_constraint_is_flagged() {
+    let text = format!("{COMPLETE_DESCRIPTION}Imports: dplyr (>=)\n");
+    assert!(ids(&text).contains(&"description-version-constraint"));
+}
+
+#[test]
+fn a_well_formed_constraint_is_not_flagged() {
+    let text = format!("{COMPLETE_DESCRIPTION}Imports: dplyr (>= 1.0.0), rlang\n");
+    assert!(!ids(&text).contains(&"description-version-constraint"));
+}
+
+/// `Depends: R (>= 4.1)` is the most common constraint in any DESCRIPTION, and
+/// the language entry is checked exactly like a package entry.
+#[test]
+fn the_r_entry_is_checked_too() {
+    let text = format!("{COMPLETE_DESCRIPTION}Depends: R (4.1)\n");
+    assert!(ids(&text).contains(&"description-version-constraint"));
+}
+
+#[test]
+fn every_dependency_field_is_checked() {
+    for field in ["Depends", "Imports", "Suggests", "LinkingTo", "Enhances"] {
+        let text = format!("{COMPLETE_DESCRIPTION}{field}: dplyr (1.0.0)\n");
+        assert!(
+            ids(&text).contains(&"description-version-constraint"),
+            "{field} was not checked",
+        );
+    }
+}
+
+/// A non-dependency field's parentheses are prose, not a constraint.
+#[test]
+fn a_non_dependency_field_is_not_parsed_as_dependencies() {
+    let text = format!("{COMPLETE_DESCRIPTION}Note: see the manual (section 2) for details\n");
+    assert!(!ids(&text).contains(&"description-version-constraint"));
+}
+
+/// The span is the whole entry, constraint included: the name alone would point
+/// away from the part that is wrong.
+#[test]
+fn version_constraint_spans_the_whole_entry() {
+    let text = format!("{COMPLETE_DESCRIPTION}Imports: dplyr (1.0.0)\n");
+    let diagnostics =
+        check_description_document(Path::new("DESCRIPTION"), &text, &LintConfig::default())
+            .expect("linting should not error");
+    let finding = diagnostics
+        .iter()
+        .find(|d| d.rule == "description-version-constraint")
+        .expect("a version-constraint finding");
+    let start: usize = finding.range.start().into();
+    let end: usize = finding.range.end().into();
+    assert_eq!(&text[start..end], "dplyr (1.0.0)");
+}
+
+// ---------------------------------------------------------------------------
+// Suppression
+// ---------------------------------------------------------------------------
+
+/// The escape hatch works in `DESCRIPTION` too: a directive line suppresses the
+/// field that follows it.
+#[test]
+fn a_directive_suppresses_a_description_finding() {
+    let text = format!(
+        "{COMPLETE_DESCRIPTION}# arity-ignore description-duplicate-field: deliberate\nVersion: 0.2.0\n"
+    );
+    assert!(!ids(&text).contains(&"description-duplicate-field"));
+}
+
+// ---------------------------------------------------------------------------
 // The single-file entry point
 // ---------------------------------------------------------------------------
 

--- a/tests/lint_description.rs
+++ b/tests/lint_description.rs
@@ -1,0 +1,196 @@
+//! Linting `DESCRIPTION`: discovery, the driver's DCF pass, and the rules that
+//! run over it.
+//!
+//! Separate from `tests/lint.rs` because the subject is a second grammar with
+//! its own driver (`run_dcf_rules`) and its own discovery policy — not because
+//! the rules are any different a kind of thing.
+
+use std::path::{Path, PathBuf};
+
+use arity::config::LintConfig;
+use arity::linter::{
+    LintError, LintResult, LintStatus, check_description_document, check_paths,
+    check_paths_with_config,
+};
+use tempfile::TempDir;
+
+/// A DESCRIPTION with every field `R CMD check` requires, so a fixture only
+/// varies what its test is actually about.
+const COMPLETE_DESCRIPTION: &str = "\
+Package: testpkg
+Version: 0.1.0
+Title: A Test Package
+Description: Fixture data for arity's own tests.
+License: MIT + file LICENSE
+Authors@R: person(\"Test\", \"User\", role = c(\"aut\", \"cre\"))
+";
+
+/// Write a package rooted at a fresh temp dir: `DESCRIPTION`, `NAMESPACE`, and
+/// one `R/` source per entry. Returns the dir (kept alive by the caller) and
+/// its path.
+fn package(description: &str, namespace: &str, files: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let root = dir.path().to_path_buf();
+    std::fs::write(root.join("DESCRIPTION"), description).unwrap();
+    std::fs::write(root.join("NAMESPACE"), namespace).unwrap();
+    std::fs::create_dir(root.join("R")).unwrap();
+    for (name, src) in files {
+        std::fs::write(root.join("R").join(name), src).unwrap();
+    }
+    (dir, root)
+}
+
+/// The report for the package's `DESCRIPTION`, which every test here wants.
+fn description_report(result: &LintResult) -> &arity::linter::LintFileReport {
+    result
+        .reports
+        .iter()
+        .find(|r| r.path.file_name().and_then(|n| n.to_str()) == Some("DESCRIPTION"))
+        .expect("a report for DESCRIPTION")
+}
+
+fn rules_reported(result: &LintResult) -> Vec<&str> {
+    description_report(result)
+        .diagnostics
+        .iter()
+        .map(|d| d.rule)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Discovery and the driver pass
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_packages_description_is_linted_by_a_directory_walk() {
+    let (_dir, root) = package(
+        COMPLETE_DESCRIPTION,
+        "export(f)\n",
+        &[("a.R", "f <- function() 1\n")],
+    );
+
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    assert_eq!(
+        result.checked_files, 2,
+        "DESCRIPTION should be counted alongside R/a.R"
+    );
+    assert_eq!(description_report(&result).status, LintStatus::Clean);
+}
+
+/// An explicitly named `DESCRIPTION` used to be a hard `NonRFilePath` error.
+#[test]
+fn an_explicitly_named_description_is_linted() {
+    let (_dir, root) = package(COMPLETE_DESCRIPTION, "", &[("a.R", "f <- function() 1\n")]);
+    let path = root.join("DESCRIPTION");
+
+    let result = check_paths(std::slice::from_ref(&path)).expect("lint should succeed");
+    assert_eq!(result.checked_files, 1);
+    assert_eq!(description_report(&result).status, LintStatus::Clean);
+}
+
+/// A file named `DESCRIPTION` that does not sit at a package root is somebody
+/// else's data — a fixture, a vendored copy, a scraped corpus — and linting it
+/// would report on a file the project does not own.
+#[test]
+fn a_description_outside_a_package_root_is_not_walked() {
+    let (_dir, root) = package(COMPLETE_DESCRIPTION, "", &[("a.R", "f <- function() 1\n")]);
+    let fixtures = root.join("inst").join("extdata");
+    std::fs::create_dir_all(&fixtures).unwrap();
+    std::fs::write(fixtures.join("DESCRIPTION"), "this is not a DESCRIPTION\n").unwrap();
+
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    let described: Vec<&PathBuf> = result
+        .reports
+        .iter()
+        .map(|r| &r.path)
+        .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some("DESCRIPTION"))
+        .collect();
+    assert_eq!(described, vec![&root.join("DESCRIPTION")]);
+}
+
+/// ...but naming it explicitly still lints it, exactly as naming an excluded
+/// `.R` file does.
+#[test]
+fn an_explicitly_named_description_outside_a_package_root_is_linted() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("DESCRIPTION");
+    std::fs::write(&path, COMPLETE_DESCRIPTION).unwrap();
+
+    let result = check_paths(std::slice::from_ref(&path)).expect("lint should succeed");
+    assert_eq!(result.checked_files, 1);
+}
+
+/// A malformed `DESCRIPTION` blocks its rules but is never swallowed: the DCF
+/// parser's diagnostics surface as `syntax-error` findings, exactly as the R
+/// parser's do.
+#[test]
+fn a_malformed_description_reports_syntax_errors() {
+    let (_dir, root) = package(
+        "Package: testpkg\nthis line is neither a field nor a continuation\n",
+        "",
+        &[("a.R", "f <- function() 1\n")],
+    );
+
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    let report = description_report(&result);
+    assert_eq!(report.status, LintStatus::ParseDiagnostics { count: 1 });
+    assert_eq!(rules_reported(&result), vec!["syntax-error"]);
+}
+
+/// `syntax-error` is not a rule, so it is not subject to `select` — a broken
+/// `DESCRIPTION` surfaces even when only one R rule was asked for.
+#[test]
+fn description_syntax_errors_survive_select() {
+    let (_dir, root) = package(
+        "Package: testpkg\nthis line is neither a field nor a continuation\n",
+        "",
+        &[("a.R", "f <- function() 1\n")],
+    );
+    let config = LintConfig {
+        select: Some(vec!["browser".to_string()]),
+        ..LintConfig::default()
+    };
+
+    let result =
+        check_paths_with_config(std::slice::from_ref(&root), &config).expect("lint should succeed");
+    assert_eq!(rules_reported(&result), vec!["syntax-error"]);
+}
+
+#[test]
+fn a_non_lintable_explicit_path_is_still_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("notes.txt");
+    std::fs::write(&path, "hello\n").unwrap();
+
+    let err = check_paths(std::slice::from_ref(&path)).expect_err("should reject the path");
+    assert_eq!(err, LintError::NonRFilePath { path });
+}
+
+// ---------------------------------------------------------------------------
+// The single-file entry point
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_description_document_reports_parse_errors() {
+    let diagnostics = check_description_document(
+        Path::new("DESCRIPTION"),
+        "  orphan continuation\n",
+        &LintConfig::default(),
+    )
+    .expect("linting should not error");
+    assert_eq!(
+        diagnostics.iter().map(|d| d.rule).collect::<Vec<_>>(),
+        vec!["syntax-error"]
+    );
+}
+
+#[test]
+fn check_description_document_is_clean_on_a_good_file() {
+    let diagnostics = check_description_document(
+        Path::new("DESCRIPTION"),
+        COMPLETE_DESCRIPTION,
+        &LintConfig::default(),
+    )
+    .expect("linting should not error");
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}

--- a/tests/lint_description.rs
+++ b/tests/lint_description.rs
@@ -886,6 +886,42 @@ fn only_imports_is_checked() {
     }
 }
 
+/// Usage is folded over every analyzed member under the package root, and a
+/// `tests/` file is one — so whether a test-only dependency is flagged depends
+/// on which files the run covers. Pinned in both directions because the rule's
+/// own documentation states it.
+#[test]
+fn a_test_only_dependency_counts_as_use_when_tests_are_in_the_run() {
+    let (_dir, root) = package(&imports("dplyr"), "export(f)\n", NOTHING);
+    let testthat = root.join("tests").join("testthat");
+    std::fs::create_dir_all(&testthat).unwrap();
+    std::fs::write(
+        testthat.join("test-a.R"),
+        "test_that(\"f\", { dplyr::filter(x) })\n",
+    )
+    .unwrap();
+
+    let whole = check_paths_with_config(std::slice::from_ref(&root), &unused_dependency_only())
+        .expect("lint should succeed");
+    assert!(
+        !rules_reported(&whole).contains(&"unused-dependency"),
+        "a walk of the package covers `tests/`, so the use there counts",
+    );
+
+    // The same package, linted as R sources plus its `DESCRIPTION`: nothing in
+    // the run reaches `dplyr`, and the run is still complete, so it is flagged.
+    let r_only = check_paths_with_config(
+        &[root.join("R"), root.join("DESCRIPTION")],
+        &unused_dependency_only(),
+    )
+    .expect("lint should succeed");
+    assert!(
+        rules_reported(&r_only).contains(&"unused-dependency"),
+        "{:?}",
+        r_only.reports,
+    );
+}
+
 #[test]
 fn the_r_entry_is_never_a_dependency() {
     let description = format!("{COMPLETE_DESCRIPTION}Imports: R (>= 4.1)\n");

--- a/tests/lint_description.rs
+++ b/tests/lint_description.rs
@@ -49,7 +49,7 @@ fn description_report(result: &LintResult) -> &arity::linter::LintFileReport {
         .expect("a report for DESCRIPTION")
 }
 
-fn rules_reported(result: &LintResult) -> Vec<&str> {
+fn rules_reported(result: &LintResult) -> Vec<&'static str> {
     description_report(result)
         .diagnostics
         .iter()
@@ -686,4 +686,262 @@ fn a_description_without_a_package_field_flags_nothing() {
         .map(|r| r.diagnostics.iter().map(|d| d.rule).collect())
         .unwrap_or_default();
     assert!(!reported.contains(&"undeclared-dependency"), "{reported:?}");
+}
+
+// ---------------------------------------------------------------------------
+// unused-dependency
+//
+// Default-off, so every test selects it. It reports on *absence*, which is why
+// most of these tests are about the reasons it must stay quiet.
+// ---------------------------------------------------------------------------
+
+fn unused_dependency_only() -> LintConfig {
+    LintConfig {
+        select: Some(vec!["unused-dependency".to_string()]),
+        ..LintConfig::default()
+    }
+}
+
+/// Lint a whole package and report the rule ids on its `DESCRIPTION`.
+fn unused_in(description: &str, namespace: &str, files: &[(&str, &str)]) -> Vec<&'static str> {
+    let (_dir, root) = package(description, namespace, files);
+    let result = check_paths_with_config(std::slice::from_ref(&root), &unused_dependency_only())
+        .expect("lint should succeed");
+    rules_reported(&result)
+}
+
+/// `COMPLETE_DESCRIPTION` plus an `Imports:` line.
+fn imports(line: &str) -> String {
+    format!("{COMPLETE_DESCRIPTION}Imports: {line}\n")
+}
+
+const NOTHING: &[(&str, &str)] = &[("a.R", "f <- function() 1\n")];
+
+#[test]
+fn an_import_nothing_reaches_is_flagged() {
+    assert!(unused_in(&imports("dplyr"), "export(f)\n", NOTHING).contains(&"unused-dependency"));
+}
+
+#[test]
+fn every_unused_entry_is_flagged() {
+    let reported = unused_in(&imports("dplyr,\n    rlang"), "export(f)\n", NOTHING);
+    assert_eq!(
+        reported
+            .iter()
+            .filter(|id| **id == "unused-dependency")
+            .count(),
+        2
+    );
+}
+
+/// The span is the name, not the version constraint: the constraint is not
+/// what is unused.
+#[test]
+fn unused_dependency_spans_the_name_only() {
+    let description = imports("dplyr (>= 1.0.0)");
+    let (_dir, root) = package(&description, "export(f)\n", NOTHING);
+    let result = check_paths_with_config(std::slice::from_ref(&root), &unused_dependency_only())
+        .expect("lint should succeed");
+    let finding = description_report(&result)
+        .diagnostics
+        .iter()
+        .find(|d| d.rule == "unused-dependency")
+        .expect("an unused-dependency finding");
+    let start: usize = finding.range.start().into();
+    let end: usize = finding.range.end().into();
+    assert_eq!(&description[start..end], "dplyr");
+}
+
+// --- one negative per usage signal ---
+
+#[test]
+fn a_qualified_call_counts_as_use() {
+    assert!(
+        !unused_in(
+            &imports("dplyr"),
+            "export(f)\n",
+            &[("a.R", "f <- function() dplyr::filter(x)\n")]
+        )
+        .contains(&"unused-dependency")
+    );
+}
+
+/// The conditional-dependency idiom, inside a function body. Reading usage off
+/// the semantic model's attach set would miss it and report the most careful
+/// way to depend on a package as unused.
+#[test]
+fn a_conditional_load_inside_a_function_counts_as_use() {
+    for body in [
+        "if (requireNamespace(\"dplyr\", quietly = TRUE)) 1\n",
+        "loadNamespace(\"dplyr\")\n",
+    ] {
+        let source = format!("f <- function() {{\n  {body}}}\n");
+        assert!(
+            !unused_in(&imports("dplyr"), "export(f)\n", &[("a.R", &source)])
+                .contains(&"unused-dependency"),
+            "{body} was not counted as use",
+        );
+    }
+}
+
+#[test]
+fn a_namespace_import_counts_as_use() {
+    for directive in [
+        "import(dplyr)",
+        "importFrom(dplyr, filter)",
+        "importClassesFrom(dplyr, X)",
+        "importMethodsFrom(dplyr, show)",
+    ] {
+        let namespace = format!("export(f)\n{directive}\n");
+        assert!(
+            !unused_in(&imports("dplyr"), &namespace, NOTHING).contains(&"unused-dependency"),
+            "{directive} was not counted as use",
+        );
+    }
+}
+
+/// A roxygen tag counts even when NAMESPACE has not been regenerated yet —
+/// mid-`document()` is exactly when a maintainer runs the linter.
+#[test]
+fn a_roxygen_import_tag_counts_as_use() {
+    assert!(
+        !unused_in(
+            &imports("dplyr"),
+            "export(f)\n",
+            &[("a.R", "#' @importFrom dplyr filter\nf <- function() 1\n")]
+        )
+        .contains(&"unused-dependency")
+    );
+}
+
+/// `Imports: Rcpp` + `LinkingTo: Rcpp` with no R-side reference is the
+/// canonical Rcpp skeleton: the entry exists so the shared library loads.
+#[test]
+fn a_linking_to_package_is_exempt() {
+    let description = format!("{COMPLETE_DESCRIPTION}Imports: Rcpp\nLinkingTo: Rcpp\n");
+    assert!(!unused_in(&description, "export(f)\n", NOTHING).contains(&"unused-dependency"));
+}
+
+/// An S4 class needs `methods` with nothing naming it. R's own `uses_methods`.
+#[test]
+fn methods_is_exempt_for_an_s4_package() {
+    assert!(
+        !unused_in(
+            &imports("methods"),
+            "export(f)\n",
+            &[("a.R", "setClass(\"A\", representation(x = \"numeric\"))\n")]
+        )
+        .contains(&"unused-dependency")
+    );
+}
+
+/// A dynamic use names the package as a plain string, which is enough to stay
+/// quiet — this rule would rather miss a real finding than invent one.
+#[test]
+fn a_string_mention_silences_the_finding() {
+    assert!(
+        !unused_in(
+            &imports("dplyr"),
+            "export(f)\n",
+            &[(
+                "a.R",
+                "f <- function() do.call(\"::\", list(\"dplyr\", \"filter\"))\n"
+            )]
+        )
+        .contains(&"unused-dependency")
+    );
+}
+
+// --- fields other than Imports ---
+
+#[test]
+fn only_imports_is_checked() {
+    for field in ["Depends", "Suggests", "LinkingTo", "Enhances"] {
+        let description = format!("{COMPLETE_DESCRIPTION}{field}: dplyr\n");
+        assert!(
+            !unused_in(&description, "export(f)\n", NOTHING).contains(&"unused-dependency"),
+            "{field} should not be checked",
+        );
+    }
+}
+
+#[test]
+fn the_r_entry_is_never_a_dependency() {
+    let description = format!("{COMPLETE_DESCRIPTION}Imports: R (>= 4.1)\n");
+    assert!(!unused_in(&description, "export(f)\n", NOTHING).contains(&"unused-dependency"));
+}
+
+#[test]
+fn a_self_import_is_not_flagged() {
+    assert!(!unused_in(&imports("testpkg"), "export(f)\n", NOTHING).contains(&"unused-dependency"));
+}
+
+// --- the completeness guard ---
+
+#[test]
+fn the_rule_is_off_by_default() {
+    let (_dir, root) = package(&imports("dplyr"), "export(f)\n", NOTHING);
+    let result = check_paths(std::slice::from_ref(&root)).expect("lint should succeed");
+    assert!(!rules_reported(&result).contains(&"unused-dependency"));
+}
+
+/// Linting one file of a package must not declare every *other* file's imports
+/// unused. It stays silent for the right reason: the driver pulls the whole
+/// expected `R/` set in as scope-only members, so the run is still complete and
+/// `dplyr` is correctly seen as used.
+#[test]
+fn linting_one_file_still_sees_the_whole_package() {
+    let (_dir, root) = package(
+        &imports("dplyr"),
+        "export(f)\n",
+        &[
+            ("a.R", "f <- function() 1\n"),
+            ("b.R", "g <- function() dplyr::filter(x)\n"),
+        ],
+    );
+    let result = check_paths_with_config(
+        std::slice::from_ref(&root.join("R").join("a.R")),
+        &unused_dependency_only(),
+    )
+    .expect("lint should succeed");
+    assert_eq!(result.total_findings, 0, "{:?}", result.reports);
+}
+
+/// A parse error anywhere in `R/` means the run has not seen everything — the
+/// only `dplyr::` in the package could be in the file that failed.
+#[test]
+fn a_parse_error_in_the_package_silences_the_rule() {
+    let reported = unused_in(
+        &imports("dplyr"),
+        "export(f)\n",
+        &[("a.R", "f <- function() 1\n"), ("b.R", "f <- function(\n")],
+    );
+    assert!(!reported.contains(&"unused-dependency"), "{reported:?}");
+}
+
+/// No NAMESPACE means the `import()` half of the usage set is simply absent, so
+/// a package mid-`document()` is not lectured.
+#[test]
+fn a_package_without_a_namespace_is_silent() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    std::fs::write(root.join("DESCRIPTION"), imports("dplyr")).unwrap();
+    std::fs::create_dir(root.join("R")).unwrap();
+    std::fs::write(root.join("R").join("a.R"), "f <- function() 1\n").unwrap();
+
+    let result = check_paths_with_config(std::slice::from_ref(&root), &unused_dependency_only())
+        .expect("lint should succeed");
+    assert!(!rules_reported(&result).contains(&"unused-dependency"));
+}
+
+/// A `DESCRIPTION` linted on its own has no package around it to check against.
+#[test]
+fn a_lone_description_is_silent() {
+    let diagnostics = check_description_document(
+        Path::new("DESCRIPTION"),
+        &imports("dplyr"),
+        &unused_dependency_only(),
+    )
+    .expect("linting should not error");
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
 }

--- a/tests/rule_docs.rs
+++ b/tests/rule_docs.rs
@@ -4,10 +4,7 @@
 //! the same `render_rule_doc` sections into the single `reference/rules.md`
 //! page in the mdBook source tree.
 
-use std::path::Path;
-
-use arity::linter::check_document;
-use arity::linter::docs::{example_lint_config, render_rule_doc, render_rules_page};
+use arity::linter::docs::{lint_example, render_rule_doc, render_rules_page};
 use arity::linter::rules::{all_rules, rules_by_category};
 
 /// Pin the rendered reference section for every documented rule. Any change to
@@ -19,7 +16,7 @@ fn rule_docs_render() {
         if rule.examples().is_empty() {
             continue;
         }
-        insta::assert_snapshot!(rule.id().replace('-', "_"), render_rule_doc(rule.as_ref()));
+        insta::assert_snapshot!(rule.id().replace('-', "_"), render_rule_doc(&rule));
     }
 }
 
@@ -95,9 +92,9 @@ fn every_rule_is_documented() {
 fn documented_examples_actually_trigger() {
     for rule in all_rules() {
         for example in rule.examples() {
-            let config = example_lint_config(rule.as_ref());
-            let diagnostics = check_document(Path::new("example.R"), example.source, &config)
-                .expect("linting a documented example should not error");
+            // The same call the reference page makes, so this check cannot
+            // drift from what is actually rendered.
+            let diagnostics = lint_example(&rule, example);
             assert!(
                 diagnostics.iter().any(|d| d.rule == rule.id()),
                 "example for rule `{}` produced no finding of that rule:\n{}",

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -7,8 +7,9 @@ use arity::incremental::{
 };
 use arity::parser::Edit;
 use arity::project::{
-    DefKind, Project, ProjectMember, external_resolution, package_facts_for, project_classes,
-    project_defs, project_reads, reverse_source_edges, visible_symbols, workspace_project,
+    DefKind, Project, ProjectMember, external_resolution, package_facts_for, package_usage,
+    project_classes, project_defs, project_reads, reverse_source_edges, visible_symbols,
+    workspace_project,
 };
 use arity::rindex::provider::IndexedProvider;
 use arity::rindex::remote::RemoteExports;
@@ -1767,6 +1768,68 @@ fn description_collate_edit_reaches_the_project() {
         after.iter().all(|c| !c.complete),
         "an un-analyzed collated source makes the package incomplete"
     );
+}
+
+/// The backdating firewall under `unused-dependency`. That rule reports on
+/// *absence*, so it folds every member's package references — and if that fold
+/// re-ran on every keystroke, an opt-in audit rule would cost the LSP a project
+/// walk per character.
+#[test]
+fn a_body_edit_spares_the_package_usage_fold() {
+    let (mut db, m, _dir) = description_package(DESCRIPTION_BASE);
+    let project = workspace_project(&db);
+    let _ = package_usage(&db, project);
+
+    db.clear_query_log();
+    // A body edit: the file still names no package and still exports `foo`.
+    db.set_file_text(
+        m,
+        "foo <- function() 1 + 1
+",
+    );
+    let project = workspace_project(&db);
+    let _ = package_usage(&db, project);
+
+    let counts = count_by_kind(&db.query_log());
+    assert_eq!(
+        counts.get(&QueryKind::PackageReferences),
+        Some(&1),
+        "the text changed, so the per-file references must be re-derived"
+    );
+    assert_eq!(
+        counts.get(&QueryKind::PackageUsage),
+        None,
+        "the references compare equal, so they must backdate and spare the fold"
+    );
+}
+
+/// The negative control: adding a `pkg::` does change the fold's input, so it
+/// must propagate. Without this, "nothing re-runs" could mean nothing is wired.
+#[test]
+fn a_new_qualified_call_reaches_the_package_usage_fold() {
+    let (mut db, m, _dir) = description_package(DESCRIPTION_BASE);
+    let project = workspace_project(&db);
+    assert!(
+        !package_usage(&db, project)[&_dir.path().to_path_buf()]
+            .used
+            .contains("dplyr")
+    );
+
+    db.clear_query_log();
+    db.set_file_text(
+        m,
+        "foo <- function() dplyr::filter(x)
+",
+    );
+    let project = workspace_project(&db);
+    let usage = package_usage(&db, project);
+
+    assert_eq!(
+        count_by_kind(&db.query_log()).get(&QueryKind::PackageUsage),
+        Some(&1),
+        "a new package reference is a fact the fold consumes and must propagate"
+    );
+    assert!(usage[&_dir.path().to_path_buf()].used.contains("dplyr"));
 }
 
 #[test]

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -7,8 +7,8 @@ use arity::incremental::{
 };
 use arity::parser::Edit;
 use arity::project::{
-    DefKind, Project, ProjectMember, external_resolution, project_classes, project_defs,
-    project_reads, reverse_source_edges, visible_symbols, workspace_project,
+    DefKind, Project, ProjectMember, external_resolution, package_facts_for, project_classes,
+    project_defs, project_reads, reverse_source_edges, visible_symbols, workspace_project,
 };
 use arity::rindex::provider::IndexedProvider;
 use arity::rindex::remote::RemoteExports;
@@ -1804,6 +1804,23 @@ fn refresh_descriptions_skips_write_when_unchanged() {
         None,
         "an unchanged DESCRIPTION refresh must write nothing"
     );
+}
+
+#[test]
+fn package_facts_resolve_for_a_member_without_disk() {
+    // What the lint rules read instead of walking to the package root and
+    // re-reading DESCRIPTION per file, per question. Deleting the file proves
+    // the lookup goes through the tracked input, not disk.
+    let (db, _m, dir) = description_package(DESCRIPTION_BASE);
+    let member = dir.path().join("R/foo.R");
+    std::fs::remove_file(dir.path().join("DESCRIPTION")).expect("remove");
+
+    let facts = package_facts_for(&db, &member).expect("the member's package is tracked");
+    assert_eq!(facts.package.as_deref(), Some("foo"));
+    assert_eq!(facts.attached_packages(), ["stats".to_string()].into());
+
+    // A file outside any package has none.
+    assert!(package_facts_for(&db, Path::new("/elsewhere/loose.R")).is_none());
 }
 
 #[test]

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -1807,6 +1807,33 @@ fn refresh_descriptions_skips_write_when_unchanged() {
 }
 
 #[test]
+fn an_untouched_metadata_refresh_reports_no_write() {
+    // The watcher fires on any `DESCRIPTION`/`NAMESPACE` event, including saves
+    // that changed nothing. The refreshers report whether they actually wrote,
+    // so the lint thread can skip a re-lint that would find nothing new.
+    let (mut db, _m, dir) = description_package(DESCRIPTION_BASE);
+
+    assert!(
+        !db.refresh_package_graph(),
+        "identical on-disk metadata must not write"
+    );
+    assert!(
+        !db.refresh_description(dir.path()),
+        "an identical DESCRIPTION must not write"
+    );
+
+    std::fs::write(
+        dir.path().join("DESCRIPTION"),
+        DESCRIPTION_BASE.replace("Title: A Package", "Title: Renamed"),
+    )
+    .expect("DESCRIPTION");
+    assert!(
+        db.refresh_description(dir.path()),
+        "a real edit must write, even when it changes no fact"
+    );
+}
+
+#[test]
 fn description_facts_are_tracked_per_root() {
     // The facts really are derived from the tracked input, and `R` never
     // reaches the dependency list.

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -449,7 +449,7 @@ fn project_ab(db: &IncrementalDatabase, a: SourceFile, b: SourceFile) -> Project
             package_root: Some(PathBuf::from("/pkg")),
         },
     ];
-    Project::new(db, members, Vec::new(), Vec::new())
+    Project::new(db, members, Vec::new(), Vec::new(), Vec::new())
 }
 
 /// A two-script project where `a.R` sources `b.R`. No package root, so the only
@@ -474,7 +474,7 @@ fn project_scripts(db: &IncrementalDatabase, a: SourceFile, b: SourceFile) -> Pr
             package_root: None,
         },
     ];
-    Project::new(db, members, Vec::new(), Vec::new())
+    Project::new(db, members, Vec::new(), Vec::new(), Vec::new())
 }
 
 #[test]
@@ -1188,7 +1188,7 @@ fn project_one<'db>(db: &'db IncrementalDatabase, file: SourceFile, path: &str) 
         path: PathBuf::from(path),
         package_root: None,
     }];
-    Project::new(db, members, Vec::new(), Vec::new())
+    Project::new(db, members, Vec::new(), Vec::new(), Vec::new())
 }
 
 /// A harvested package index for `name` exporting `exports`.
@@ -1826,6 +1826,78 @@ fn description_facts_are_tracked_per_root() {
         !facts.declared_packages().contains("R"),
         "`R` names the language; an attach set containing it would suppress \
          every diagnostic in the package"
+    );
+}
+
+#[test]
+fn depends_attaches_but_imports_does_not() {
+    // The R semantics the whole stage hangs on. `Depends: pkg` puts pkg on the
+    // search path, so a bare export of it resolves. `Imports: pkg` does not —
+    // R reaches an imported package only through `pkg::` or a NAMESPACE
+    // `importFrom`/`import`, so resolving it here would accept code that fails
+    // under `R CMD check`.
+    let describe = |field: &str| format!("Package: foo\n{field}: helperpkg\n");
+    let (mut db, m, dir) = description_package(&describe("Depends"));
+    std::fs::write(dir.path().join("R/foo.R"), "foo <- function() helper(1)\n").expect("foo.R");
+    db.set_file_text(m, "foo <- function() helper(1)\n");
+    let manifest = db.set_library_index(IndexedProvider::from_indices([index_pkg(
+        "helperpkg",
+        &["helper"],
+    )]));
+
+    {
+        let project = workspace_project(&db);
+        let res = external_resolution(&db, manifest, project, m);
+        assert!(
+            res.unresolved.is_empty(),
+            "a Depends package is attached, so its bare export resolves: {:?}",
+            res.unresolved
+        );
+    }
+
+    // The same package under `Imports` must leave the bare name unresolved.
+    std::fs::write(dir.path().join("DESCRIPTION"), describe("Imports")).expect("DESCRIPTION");
+    db.refresh_package_graph();
+    let project = workspace_project(&db);
+    let res = external_resolution(&db, manifest, project, m);
+    assert!(
+        res.unresolved.contains("helper"),
+        "an Imports package is not attached, so a bare name stays unresolved: {:?}",
+        res.unresolved
+    );
+}
+
+#[test]
+fn an_unindexed_depends_suppresses_the_file() {
+    // The other edge of the same gate, and a real behavior change: a `Depends`
+    // we cannot enumerate could define any unresolved name, so the whole file
+    // is suppressed — exactly as an unindexed `library()` call already does.
+    let (mut db, m, dir) = description_package("Package: foo\nDepends: nosuchpkgzz\n");
+    let body = "foo <- function() mystery(1)\n";
+    std::fs::write(dir.path().join("R/foo.R"), body).expect("foo.R");
+    db.set_file_text(m, body);
+    let manifest = db.set_library_index(IndexedProvider::empty());
+
+    {
+        let project = workspace_project(&db);
+        let res = external_resolution(&db, manifest, project, m);
+        assert!(
+            res.unresolved.is_empty(),
+            "an unindexed Depends could define the name, so the file is suppressed: {:?}",
+            res.unresolved
+        );
+    }
+
+    // Control: with no `Depends` at all, the very same name is reported. Without
+    // this the assertion above would also hold if nothing resolved anything.
+    std::fs::write(dir.path().join("DESCRIPTION"), "Package: foo\n").expect("DESCRIPTION");
+    db.refresh_package_graph();
+    let project = workspace_project(&db);
+    let res = external_resolution(&db, manifest, project, m);
+    assert!(
+        res.unresolved.contains("mystery"),
+        "with nothing attached the undefined name must be reported: {:?}",
+        res.unresolved
     );
 }
 

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use arity::incremental::{
-    IncrementalDatabase, QueryKind, SourceFile, file_def_sites, line_index, top_level_events,
+    IncrementalDatabase, QueryKind, SourceFile, description_facts, file_def_sites, line_index,
+    top_level_events,
 };
 use arity::parser::Edit;
 use arity::project::{
@@ -1679,6 +1680,152 @@ fn workspace_project_is_pure_namespace_not_reread_on_keystroke() {
         refreshed,
         vec![(root.to_path_buf(), "export(bar)\n".to_string())],
         "refresh_package_graph must pick up the on-disk NAMESPACE change"
+    );
+}
+
+/// A package on disk with a `DESCRIPTION`, one `R/` member, and a NAMESPACE,
+/// seeded into a fresh database. Returns the db, the member input, and the root.
+fn description_package(description: &str) -> (IncrementalDatabase, SourceFile, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::create_dir(root.join("R")).expect("R/");
+    std::fs::write(root.join("DESCRIPTION"), description).expect("DESCRIPTION");
+    std::fs::write(root.join("NAMESPACE"), "export(foo)\n").expect("NAMESPACE");
+    let member_path = root.join("R/foo.R");
+    std::fs::write(&member_path, "foo <- function() 1\n").expect("foo.R");
+
+    let mut db = IncrementalDatabase::default();
+    let m = db.upsert_file(&member_path, "foo <- function() 1\n".to_string());
+    db.set_workspace_members(vec![m], vec![root.to_path_buf()]);
+    (db, m, dir)
+}
+
+const DESCRIPTION_BASE: &str = "Package: foo\n\
+     Title: A Package\n\
+     Depends: R (>= 4.1), stats\n\
+     Imports: dplyr\n\
+     Collate: foo.R\n";
+
+#[test]
+fn description_prose_edit_backdates_and_spares_the_project() {
+    // THE headline guarantee of making DESCRIPTION a text input with an `Eq`
+    // facts projection: an edit that changes no *fact* re-runs the parse and
+    // stops there. Storing facts directly in `PackageGraph` would instead make
+    // this a full project-graph rebuild, on every prose keystroke.
+    let (mut db, _m, dir) = description_package(DESCRIPTION_BASE);
+    let _ = workspace_project(&db);
+
+    db.clear_query_log();
+    std::fs::write(
+        dir.path().join("DESCRIPTION"),
+        DESCRIPTION_BASE.replace("Title: A Package", "Title: A Rather Nice Package"),
+    )
+    .expect("DESCRIPTION");
+    db.refresh_package_graph();
+    let _ = workspace_project(&db);
+
+    let counts = count_by_kind(&db.query_log());
+    assert_eq!(
+        counts.get(&QueryKind::DescriptionFacts),
+        Some(&1),
+        "the text changed, so the facts must be re-derived"
+    );
+    assert_eq!(
+        counts.get(&QueryKind::WorkspaceProject),
+        None,
+        "the facts compare equal, so they must backdate and spare the project"
+    );
+}
+
+#[test]
+fn description_collate_edit_reaches_the_project() {
+    // The negative control for the test above: a `Collate:` edit changes a fact
+    // the project graph consumes, so it must propagate. Without this, "nothing
+    // re-runs" could just as well mean the dependency was never wired up.
+    let (mut db, _m, dir) = description_package(DESCRIPTION_BASE);
+    let before = workspace_project(&db).collations(&db).clone();
+    assert!(
+        before.iter().all(|c| c.complete),
+        "`Collate: foo.R` matches the analyzed member, so the package is complete"
+    );
+
+    db.clear_query_log();
+    std::fs::write(
+        dir.path().join("DESCRIPTION"),
+        DESCRIPTION_BASE.replace("Collate: foo.R", "Collate: foo.R generated.R"),
+    )
+    .expect("DESCRIPTION");
+    db.refresh_package_graph();
+    let after = workspace_project(&db).collations(&db).clone();
+
+    assert_eq!(
+        count_by_kind(&db.query_log()).get(&QueryKind::WorkspaceProject),
+        Some(&1),
+        "a Collate change is a fact the project consumes and must propagate"
+    );
+    assert!(
+        after.iter().all(|c| !c.complete),
+        "an un-analyzed collated source makes the package incomplete"
+    );
+}
+
+#[test]
+fn r_keystroke_does_not_revalidate_description_facts() {
+    // The durability guard. `DescriptionFile.text` is written at MEDIUM and a
+    // keystroke is a LOW write, so a body edit must not touch the DCF subgraph
+    // at all — not even to revalidate it.
+    let (mut db, m, _dir) = description_package(DESCRIPTION_BASE);
+    let _ = workspace_project(&db);
+
+    db.clear_query_log();
+    db.set_file_text(m, "foo <- function() 2\n");
+    let _ = workspace_project(&db);
+
+    assert_eq!(
+        count_by_kind(&db.query_log()).get(&QueryKind::DescriptionFacts),
+        None,
+        "a body edit must never re-derive DESCRIPTION facts"
+    );
+}
+
+#[test]
+fn refresh_descriptions_skips_write_when_unchanged() {
+    // The conditional setter, as for every other input: re-reading identical
+    // bytes must not bump the revision.
+    let (mut db, _m, _dir) = description_package(DESCRIPTION_BASE);
+    let _ = workspace_project(&db);
+
+    db.clear_query_log();
+    db.refresh_package_graph();
+    let _ = workspace_project(&db);
+
+    assert_eq!(
+        count_by_kind(&db.query_log()).get(&QueryKind::DescriptionFacts),
+        None,
+        "an unchanged DESCRIPTION refresh must write nothing"
+    );
+}
+
+#[test]
+fn description_facts_are_tracked_per_root() {
+    // The facts really are derived from the tracked input, and `R` never
+    // reaches the dependency list.
+    let (db, _m, dir) = description_package(DESCRIPTION_BASE);
+    let file = db
+        .lookup_description(dir.path())
+        .expect("the package root has a tracked DESCRIPTION");
+    let facts = description_facts(&db, file);
+
+    assert_eq!(facts.package.as_deref(), Some("foo"));
+    assert_eq!(facts.attached_packages(), ["stats".to_string()].into());
+    assert_eq!(
+        facts.declared_packages(),
+        ["dplyr".to_string(), "stats".to_string()].into()
+    );
+    assert!(
+        !facts.declared_packages().contains("R"),
+        "`R` names the language; an attach set containing it would suppress \
+         every diagnostic in the package"
     );
 }
 

--- a/tests/salsa_incremental.rs
+++ b/tests/salsa_incremental.rs
@@ -1902,6 +1902,71 @@ fn an_unindexed_depends_suppresses_the_file() {
 }
 
 #[test]
+fn wildcard_import_clears_once_the_package_is_indexed() {
+    // The roadmap item: `import(pkg)` used to suppress the whole file
+    // unconditionally. It now goes through the same enumerability gate as an
+    // attached package, so the suppression lifts as soon as the index (or the
+    // sidecar) can enumerate pkg — and a genuine typo in that file is reported.
+    let (mut db, m, dir) = description_package("Package: foo\n");
+    std::fs::write(dir.path().join("NAMESPACE"), "import(helperpkg)\n").expect("NAMESPACE");
+    let body = "foo <- function() helper(mystery)\n";
+    std::fs::write(dir.path().join("R/foo.R"), body).expect("foo.R");
+    db.set_file_text(m, body);
+    db.refresh_package_graph();
+
+    // Unindexed: we cannot enumerate helperpkg, so the file stays suppressed.
+    {
+        let manifest = db.set_library_index(IndexedProvider::empty());
+        let project = workspace_project(&db);
+        let res = external_resolution(&db, manifest, project, m);
+        assert!(
+            res.unresolved.is_empty(),
+            "an unenumerable wildcard import must still suppress: {:?}",
+            res.unresolved
+        );
+    }
+
+    // Indexed: `helper` resolves through the import, and `mystery` — which the
+    // whole-file suppression used to hide — is finally reported.
+    let manifest = db.set_library_index(IndexedProvider::from_indices([index_pkg(
+        "helperpkg",
+        &["helper"],
+    )]));
+    let project = workspace_project(&db);
+    let res = external_resolution(&db, manifest, project, m);
+    assert!(
+        !res.unresolved.contains("helper"),
+        "import(helperpkg) puts its exports in scope: {:?}",
+        res.unresolved
+    );
+    assert!(
+        res.unresolved.contains("mystery"),
+        "with the import enumerable, a real typo must surface: {:?}",
+        res.unresolved
+    );
+}
+
+#[test]
+fn dynamic_source_still_suppresses() {
+    // The control for the poison lift: `resolution_incomplete` keeps its one
+    // remaining meaning, and a dynamic `source()` still suppresses the file.
+    let mut db = IncrementalDatabase::default();
+    let path = "/proj/a.R";
+    let file = db.upsert_file(
+        Path::new(path),
+        "source(paste0(dir, '/x.R'))\nfoo <- function() mystery(1)\n".to_string(),
+    );
+    let manifest = db.set_library_index(IndexedProvider::empty());
+    let project = project_one(&db, file, path);
+    let res = external_resolution(&db, manifest, project, file);
+    assert!(
+        res.unresolved.is_empty(),
+        "a dynamic source() could supply any name, so the file stays suppressed: {:?}",
+        res.unresolved
+    );
+}
+
+#[test]
 fn refresh_package_graph_skips_write_when_unchanged() {
     // The conditional setter: refreshing with identical on-disk metadata must not
     // bump the revision, so `workspace_project` is not re-run.

--- a/tests/snapshots/rule_docs__description_duplicate_field.snap
+++ b/tests/snapshots/rule_docs__description_duplicate_field.snap
@@ -1,0 +1,33 @@
+---
+source: tests/rule_docs.rs
+expression: render_rule_doc(&rule)
+---
+### `description-duplicate-field`
+
+Flag a `DESCRIPTION` field declared more than once.
+
+A repeated field is a silent mistake: nothing errors, and the file keeps whichever value the reader picks—except the readers disagree. R's `read.dcf` takes the **last** occurrence; arity takes the **first**. A duplicated `Version` therefore means R and arity are describing two different packages, and every tool downstream of either inherits the split.
+
+The finding is reported on the *later* occurrence, since the earlier one is what arity already read. Duplicates are detected across DCF records, so a stray blank line does not hide one.
+
+There is no autofix: removing a duplicate means choosing a value, and this rule exists precisely because it is not settled which value is already in effect.
+
+This rule is **enabled by default**.
+
+A field declared twice, which arity and `read.dcf` read differently:
+
+```text
+Package: mypkg
+Version: 0.1.0
+License: MIT + file LICENSE
+Version: 0.2.0
+```
+
+```text
+warning: description-duplicate-field
+ --> DESCRIPTION:4:1
+  |
+4 | Version: 0.2.0
+  | ^^^^^^^ `Version` is already declared on line 2; arity reads the first occurrence and R's `read.dcf` reads the last, so the two disagree about this file
+  = help: Keep one `Version` field and delete the other.
+```

--- a/tests/snapshots/rule_docs__description_missing_field.snap
+++ b/tests/snapshots/rule_docs__description_missing_field.snap
@@ -1,0 +1,33 @@
+---
+source: tests/rule_docs.rs
+expression: render_rule_doc(&rule)
+---
+### `description-missing-field`
+
+Flag a `DESCRIPTION` missing a field R requires.
+
+`R CMD build` refuses a package whose `DESCRIPTION` omits `Package`, `Version`, `Title`, `Description`, `Author`, `Maintainer`, or `License`. `Authors@R` satisfies `Author` and `Maintainer`, since `R CMD build` derives both from it. A field that is present but empty declares nothing and counts as missing.
+
+Every missing field is reported as one finding rather than one each: the defect is that the file is incomplete, and it takes one decision—and one suppression—to settle.
+
+A file with no fields at all is left alone; that is not an incomplete package description.
+
+There is no autofix: each of these fields needs a value only the author has.
+
+This rule is **enabled by default**.
+
+A `DESCRIPTION` that `R CMD build` would reject:
+
+```text
+Package: mypkg
+Version: 0.1.0
+```
+
+```text
+warning: description-missing-field
+ --> DESCRIPTION:1:1
+  |
+1 | Package: mypkg
+  | ^^^^^^^ DESCRIPTION is missing the required fields `Title`, `Description`, `Author`, `Maintainer`, `License`
+  = help: Add the fields `Title`, `Description`, `Author`, `Maintainer`, `License`, or declare `Authors@R` in place of `Author` and `Maintainer`.
+```

--- a/tests/snapshots/rule_docs__description_version_constraint.snap
+++ b/tests/snapshots/rule_docs__description_version_constraint.snap
@@ -1,0 +1,38 @@
+---
+source: tests/rule_docs.rs
+expression: render_rule_doc(&rule)
+---
+### `description-version-constraint`
+
+Flag a dependency entry whose parenthesized part is not a version constraint.
+
+R reads `pkg (>= 1.0.0)`: an operator and a version. Anything else—`dplyr (1.0.0)`, `dplyr (>=)`, `dplyr (latest)`—states no bound at all, and R's dependency check enforces nothing. The line reads as a requirement and behaves as none, so the package installs against exactly the versions its author meant to exclude.
+
+Checked in all five dependency fields, `R` included: `Depends: R (>= 4.1)` is the most common constraint in any `DESCRIPTION`.
+
+There is no autofix. `dplyr (1.0.0)` most likely means `>=`, but it could mean `==` or `>`, and guessing would invent a requirement the author never wrote.
+
+This rule is **enabled by default**.
+
+A version requirement R will not enforce:
+
+```text
+Package: mypkg
+Depends: R (4.1)
+Imports: dplyr (1.0.0)
+```
+
+```text
+warning: description-version-constraint
+ --> DESCRIPTION:2:10
+  |
+2 | Depends: R (4.1)
+  |          ^^^^^^^ the version constraint on `R` states no bound, so R enforces nothing here
+  = help: Write a comparison operator and a version, as in `(>= 1.0.0)`.
+warning: description-version-constraint
+ --> DESCRIPTION:3:10
+  |
+3 | Imports: dplyr (1.0.0)
+  |          ^^^^^^^^^^^^^ the version constraint on `dplyr` states no bound, so R enforces nothing here
+  = help: Write a comparison operator and a version, as in `(>= 1.0.0)`.
+```

--- a/tests/snapshots/rule_docs__undeclared_dependency.snap
+++ b/tests/snapshots/rule_docs__undeclared_dependency.snap
@@ -1,0 +1,34 @@
+---
+source: tests/rule_docs.rs
+expression: render_rule_doc(&rule)
+---
+### `undeclared-dependency`
+
+Flag package code that reaches a package its `DESCRIPTION` never declares.
+
+`dplyr::filter()` in `R/` works on the author's machine because `dplyr` happens to be installed there; on a clean machine it is a load-time error, and `R CMD check` reports it. Declaring the dependency is what causes it to be installed, so leaving it out is a bug that only ever surfaces somewhere else.
+
+The rule matches `pkg::name`, `pkg:::name`, and the package argument of `library`, `require`, `requireNamespace`, and `loadNamespace`—at any depth, since the conditional-dependency idiom lives inside a function body.
+
+The exempt set is R's own: everything declared in any of `Depends`, `Imports`, `Suggests`, `LinkingTo`, or `Enhances`, the package's own name, and the packages R ships at base priority—except `methods` and `stats4`, which `R CMD check` still expects a package to declare. Only files directly in `R/` are checked: a test's or a vignette's dependencies belong in `Suggests`, and R does not scan those directories for this check either.
+
+There is no autofix. A fix is an edit to the file the finding is in, and the repair here is a line in `DESCRIPTION`.
+
+This rule is **enabled by default**.
+
+In `R/` of a package whose `DESCRIPTION` declares only `Imports: rlang`:
+
+```r
+summarize <- function(data) {
+  dplyr::group_by(data, id)
+}
+```
+
+```text
+warning: undeclared-dependency
+ --> example.R:2:3
+  |
+2 |   dplyr::group_by(data, id)
+  |   ^^^^^ package `dplyr` is used here but is not declared in DESCRIPTION
+  = help: Add `dplyr` to `Imports:` in DESCRIPTION.
+```

--- a/tests/snapshots/rule_docs__unused_dependency.snap
+++ b/tests/snapshots/rule_docs__unused_dependency.snap
@@ -10,7 +10,9 @@ An `Imports` entry promises that installing this package installs that one, so a
 
 A package counts as reached by `pkg::`, `pkg:::`, a `library`, `require`, `requireNamespace`, or `loadNamespace` call at any depth, a NAMESPACE `import()`/`importFrom()`/`importClassesFrom()`/`importMethodsFrom()`, or a roxygen `@import`/`@importFrom` tag. Exempt on top of that: anything also in `LinkingTo` (the Rcpp skeleton), `methods` when the package defines an S4 or reference class, and any package whose name appears as a plain string (a dynamic `do.call("::", …)` or `system.file(package = …)`).
 
-Only `Imports` is checked. `Depends` is an API decision the package's own code may never name; `Suggests` is for tests, vignettes, and examples, which this analysis does not cover; `LinkingTo` and `Enhances` are invisible to R-source analysis. A package used *only* from `tests/` or a vignette **is** flagged—it belongs in `Suggests`.
+Only `Imports` is checked. `Depends` is an API decision the package's own code may never name; `Suggests` is for tests, vignettes, and examples, reached from outside the package's own code; `LinkingTo` and `Enhances` are invisible to R-source analysis.
+
+Usage is folded over every R file the run analyzed under the package root, so a package reached only from `tests/`, `inst/`, or `data-raw/` counts as used when those files are in the run (`arity lint .`) and is reported when they are not (`arity lint R/`). A vignette's R code is never analyzed either way, so a dependency used only there is reported—it belongs in `Suggests`.
 
 It reports on *absence*, and a wrong finding would have a maintainer delete a dependency their package needs, so it stays silent unless the run analyzed the package's whole `R/` source set and read its NAMESPACE—which is also why it is off by default.
 

--- a/tests/snapshots/rule_docs__unused_dependency.snap
+++ b/tests/snapshots/rule_docs__unused_dependency.snap
@@ -1,0 +1,36 @@
+---
+source: tests/rule_docs.rs
+expression: render_rule_doc(&rule)
+---
+### `unused-dependency`
+
+Flag an `Imports:` entry that nothing in the package reaches.
+
+An `Imports` entry promises that installing this package installs that one, so an entry no code reaches costs every user a download, a build, and a constraint to satisfy for nothing. `R CMD check` reports it too.
+
+A package counts as reached by `pkg::`, `pkg:::`, a `library`, `require`, `requireNamespace`, or `loadNamespace` call at any depth, a NAMESPACE `import()`/`importFrom()`/`importClassesFrom()`/`importMethodsFrom()`, or a roxygen `@import`/`@importFrom` tag. Exempt on top of that: anything also in `LinkingTo` (the Rcpp skeleton), `methods` when the package defines an S4 or reference class, and any package whose name appears as a plain string (a dynamic `do.call("::", …)` or `system.file(package = …)`).
+
+Only `Imports` is checked. `Depends` is an API decision the package's own code may never name; `Suggests` is for tests, vignettes, and examples, which this analysis does not cover; `LinkingTo` and `Enhances` are invisible to R-source analysis. A package used *only* from `tests/` or a vignette **is** flagged—it belongs in `Suggests`.
+
+It reports on *absence*, and a wrong finding would have a maintainer delete a dependency their package needs, so it stays silent unless the run analyzed the package's whole `R/` source set and read its NAMESPACE—which is also why it is off by default.
+
+There is no autofix: removing an entry from a comma-separated list is not a local edit, and this is not a claim a tool should act on destructively.
+
+This rule is **disabled by default**; enable it with `select`.
+
+In a package whose only R source is `f <- function() rlang::abort("no")`:
+
+```text
+Package: mypkg
+Version: 0.1.0
+Imports: rlang, tibble
+```
+
+```text
+warning: unused-dependency
+ --> DESCRIPTION:3:17
+  |
+3 | Imports: rlang, tibble
+  |                 ^^^^^^ `tibble` is declared in `Imports:` but nothing in the package uses it
+  = help: Remove `tibble` from `Imports:`, or move it to `Suggests:` if only tests, vignettes, or examples need it.
+```


### PR DESCRIPTION
**What and why**

Teaches arity to read, analyze, and lint `DESCRIPTION` — stages 1–3 of the
DESCRIPTION roadmap in `TODO.md`. Until now `DESCRIPTION` was scraped by an
ad-hoc `parse_dcf` for a handful of facts, so arity could not report anything
about the file that decides what an R package *is*, nor notice when a package's
declared dependencies and its code disagree.

Three stages, each ticked off in `TODO.md`:

1. **A principled DCF parser** (`crates/arity-parser/src/dcf/`) — a second
   `rowan::Language` alongside the R grammar: lossless, spanned, record-aware,
   with diagnostics on the usual side channel. It lives in the published parser
   crate so a dprint plugin can reach it at stage 5.
2. **DESCRIPTION as an analysis input** — a salsa input holding *text*, with a
   range-free `DescriptionFacts` projection over it, so a prose edit backdates
   instead of rebuilding the project graph.
3. **Lint rules** — five of them, below.

**Approach**

*Two grammars, one catalogue.* A `DcfRule` runs over a parsed `DESCRIPTION` the
way `Rule` runs over R, with the same single-shared-walk discipline
(`run_dcf_rules`). Both register in the **same** `rules_by_category` via
`AnyRule`, so rule IDs stay one namespace and `all_rule_ids`, `select`/`ignore`,
and the reference page are still derived from one list. A parallel DCF registry
was rejected: merging two per-category lists back together to render one
`## Correctness` section *is* a second source of truth for catalogue order.
`ResolvedRules` splits the two dispatch tables exactly once, in `with_config`,
so a run over R files never pays for the DCF table. `linter::render` and
`to_lsp_diagnostic` needed no change.

*The rules.* A new `Packaging` category — the one category spanning both
grammars, since an undeclared dependency and an unused one are the same defect
seen from two sides:

| Rule | Fires in | Default |
| --- | --- | --- |
| `undeclared-dependency` | `R/*.R` | on |
| `unused-dependency` | `DESCRIPTION` | **off** |
| `description-missing-field` | `DESCRIPTION` | on |
| `description-duplicate-field` | `DESCRIPTION` | on |
| `description-version-constraint` | `DESCRIPTION` | on |

None ships an autofix. Each repair needs a value or a decision only the author
has, and for `unused-dependency` a fix would also mean editing a
comma-separated list — which is stage 5's job, where re-emitting the field
minus one entry becomes correct by construction.

*`R CMD check` is the oracle, not a comment.* The exempt set for
`undeclared-dependency` was read off `tools:::.check_packages_used` rather than
assumed: R's base-priority packages minus `methods` and `stats4`. That is
deliberately **not** `semantic::symbols::default_packages()`, which answers what
a fresh session *attaches* and differs in both directions — `parallel` and
`tools` ship unattached, `methods` is attached and still has to be declared.
`tests/deps_oracle.rs` (`task deps-oracle`) pins both lists against R, so a new
base package in a future release fails a test instead of quietly becoming a
false positive.

*`unused-dependency` is the risky one, and is treated as such.* It reports on
*absence*, so a wrong finding would talk a maintainer into deleting a dependency
their package needs — one that still installs locally and fails on a clean
machine. Hence default-off; a completeness guard (`PackageUsage::complete`: the
whole `R/` set analyzed, a NAMESPACE read, at least one source); and exemptions
for a `LinkingTo` co-declaration (the Rcpp skeleton), `methods` under S4, and
any package named as a plain string (a dynamic `do.call("::", …)`). Flipping it
on is gated on a `linter-investigation` sweep, not on this PR.

*Incrementality.* `PackageReferences` (per file) and the `package_usage` fold
(per package root) are both range-free `Eq` firewalls, so a body edit backdates
and neither re-runs — guarded in `tests/salsa_incremental.rs` with negative
controls, so "nothing re-runs" cannot mean "nothing is wired". `PackageReferences`
records load calls at **any depth**: `requireNamespace()` inside a function body
is the conditional-dependency idiom, and `SemanticModel::loaded_packages` is
top-level-only because it models attachment, a narrower fact.

*Discovery.* A walked `DESCRIPTION` must sit at a package root that is not
itself inside another package. The first half skips `inst/extdata` fixtures; the
second skips the complete miniature packages roxygen2 and devtools keep under
`tests/`, which a corpus sweep turned up immediately — their DESCRIPTIONs are
data for a test, describing nothing anybody ships. An explicitly named one is
always linted, and reading is never gated on the rule set, since `syntax-error`
is not a rule.

**Verification beyond the test suite**

Swept 15 real packages (tidyverse, r-lib, data.table, Rcpp): zero packaging
findings. Then injected an unused `Imports` entry into tibble and deleted a used
one from purrr — 1 and 43 findings respectively — so the silence is the rules
being right, not the guards being stuck off.

**Deliberately not here** (recorded in `TODO.md`): the first-vs-last duplicate
field flip (`description-duplicate-field` makes it *visible*, which is the
prerequisite); `library-in-package`, which is wrong even when the package *is*
declared and so needs its own ID; `unconditional-suggest`, a control-flow
question over `ctx.cfg` rather than a name-set one. Stages 4 (LSP) and 5
(formatting) are their own roadmap items.

**Checklist**

- [x] Added or updated tests (test-first; a bug fix has a failing fixture that now passes)
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt -- --check` is clean
- [x] Reviewed changed snapshots (`cargo insta review`), if any
- [x] Commits follow Conventional Commits
