### PR TITLE
chore(release): v0.19.1 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "5e1e2157e685ed9661e7bfca2981eca64831563d",
+  "baseline-sha": "f12344cb140631f79ab568933d1d48a4639e6abb",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.19.0",
-      "tag": "v0.19.0"
+      "version": "0.19.1",
+      "tag": "v0.19.1"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.4.0",
-      "tag": "arity-formatter-v0.4.0"
+      "version": "0.4.1",
+      "tag": "arity-formatter-v0.4.1"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.0",
-      "tag": "arity-parser-v0.5.0"
+      "version": "0.5.1",
+      "tag": "arity-parser-v0.5.1"
     },
     {
       "path": "editors/code",
-      "version": "0.19.0",
-      "tag": "arity-code-v0.19.0"
+      "version": "0.19.1",
+      "tag": "arity-code-v0.19.1"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.19.0",
-      "tag": "v0.19.0"
+      "version": "0.19.1",
+      "tag": "v0.19.1"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.4.0",
-      "tag": "arity-formatter-v0.4.0"
+      "version": "0.4.1",
+      "tag": "arity-formatter-v0.4.1"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.0",
-      "tag": "arity-parser-v0.5.0"
+      "version": "0.5.1",
+      "tag": "arity-parser-v0.5.1"
     },
     {
       "path": "editors/code",
-      "version": "0.19.0",
-      "tag": "arity-code-v0.19.0"
+      "version": "0.19.1",
+      "tag": "arity-code-v0.19.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.19.1](https://github.com/jolars/arity/compare/v0.19.0...v0.19.1) (2026-08-17)
+
+### Bug Fixes
+- **roxygen:** classify Rd block macros by name ([`49f2f40`](https://github.com/jolars/arity/commit/49f2f40771d38496a46af29d6326515c28838dd3)), closes [#106](https://github.com/jolars/arity/issues/106)
+- accept non-ASCII letters in syntactic R names ([`2c29b2f`](https://github.com/jolars/arity/commit/2c29b2f94215dac1adfe86ea1643ba7b935f5dc6)), refs [#108](https://github.com/jolars/arity/issues/108)
+
+### Performance Improvements
+- **linter:** seed the project scope once, not per document ([`f12344c`](https://github.com/jolars/arity/commit/f12344cb140631f79ab568933d1d48a4639e6abb))
+- **project:** share the per-file facts instead of copying them twice ([`ebb1d4f`](https://github.com/jolars/arity/commit/ebb1d4f127896240f966547e0352fbf71be19ee1))
+- **linter:** hand the salsa database teardown to the pool ([`210f8fc`](https://github.com/jolars/arity/commit/210f8fc92641e7fa4527330115f792abeae25bca))
+- **linter:** read the prologue's files in parallel ([`938367b`](https://github.com/jolars/arity/commit/938367b9b9a8220bcab7a75a0769bad5fe747db7))
+- **project:** stop reading DESCRIPTION twice per package root ([`262e460`](https://github.com/jolars/arity/commit/262e4604580582aa84da808e08a8243da28bfdf8))
+- **project:** walk to a package root once per directory ([`7b75a3c`](https://github.com/jolars/arity/commit/7b75a3c1461350bc319f3d5c4339bb6d556eee19))
+- **project:** share one NAMESPACE's sets across a package's members ([`21d1738`](https://github.com/jolars/arity/commit/21d17383ae01521439dcc90563633743a2efd8d5))
+- **project:** answer the file-set relations from one shared member set ([`2777621`](https://github.com/jolars/arity/commit/277762165fe6fc748d780d1593205e095cca898f))
+- **project:** derive visibility from shared layers, not per-member sets ([`36005a0`](https://github.com/jolars/arity/commit/36005a0fd114dc228433756d40187f40f14944fa))
+- **project:** fold a package clique once, not per ordered pair ([`e1ecf4e`](https://github.com/jolars/arity/commit/e1ecf4ec9b8023ecb93d0c49a6247e6fce0524bb))
+- **linter:** warm every fold input before the parallel passes ([`6c0ee06`](https://github.com/jolars/arity/commit/6c0ee06e87905f069a5a6766e0f47be241ea76b9))
+- **lsp,incremental:** verify edit slices without applying them ([`7654bbd`](https://github.com/jolars/arity/commit/7654bbd6276891d09bbbc9ab458addc9621f9543))
+- **text,lsp:** back document text with Arc<str> ([`e80c63a`](https://github.com/jolars/arity/commit/e80c63ac068635b33723ca50d534e646da6ed306))
+- **rindex:** load the lint index lazily, per package ([`f472c69`](https://github.com/jolars/arity/commit/f472c69ecbd1fd3239004d976cd4b24c73e4c66a))
+- **linter:** find a directive's comment by offset ([`0151f48`](https://github.com/jolars/arity/commit/0151f48471e6936e673629d52542e8ca95d66774))
+
+### Dependencies
+- updated crates/arity-formatter to v0.4.1
+- updated crates/arity-parser to v0.5.1
+
 ## [0.19.0](https://github.com/jolars/arity/compare/v0.18.0...v0.19.0) (2026-08-14)
 
 The most prominent feature of this release is that Arity now handles the `DESCRIPTION`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -172,7 +172,7 @@ dependencies = [
  "salsa",
  "serde",
  "serde_json",
- "similar 3.1.2",
+ "similar 3.2.0",
  "smol_str",
  "tempfile",
  "toml",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arity-parser",
  "insta",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+checksum = "4f66ca1f7aca2474dc10c942eb22feffc897735f54cd1db90138c2fddb490987"
 dependencies = [
  "bstr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.4.0" }
-arity-parser = { path = "crates/arity-parser", version = "0.5.0" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.4.1" }
+arity-parser = { path = "crates/arity-parser", version = "0.5.1" }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"
 crossbeam-channel = "0.5.16"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.1](https://github.com/jolars/arity/compare/arity-formatter-v0.4.0...arity-formatter-v0.4.1) (2026-08-17)
+
+### Bug Fixes
+- **roxygen:** classify Rd block macros by name ([`49f2f40`](https://github.com/jolars/arity/commit/49f2f40771d38496a46af29d6326515c28838dd3)), closes [#106](https://github.com/jolars/arity/issues/106)
+
+### Dependencies
+- updated crates/arity-parser to v0.5.1
+
 ## [0.4.0](https://github.com/jolars/arity/compare/arity-formatter-v0.3.1...arity-formatter-v0.4.0) (2026-08-14)
 
 ### Breaking changes

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.5.0" }
+arity-parser = { path = "../arity-parser", version = "0.5.1" }
 rowan = "0.17.0"
 schemars = { version = "1.2.2", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.5.1](https://github.com/jolars/arity/compare/arity-parser-v0.5.0...arity-parser-v0.5.1) (2026-08-17)
+
+### Bug Fixes
+- **parser:** stop unterminated `%` at the line end ([`96ef35b`](https://github.com/jolars/arity/commit/96ef35b5ef61721ba27a08652eb7061a13ad1d31)), closes [#107](https://github.com/jolars/arity/issues/107)
+- **roxygen:** classify Rd block macros by name ([`49f2f40`](https://github.com/jolars/arity/commit/49f2f40771d38496a46af29d6326515c28838dd3)), closes [#106](https://github.com/jolars/arity/issues/106)
+- **parser:** lex non-ASCII letters as identifiers ([`e9a8974`](https://github.com/jolars/arity/commit/e9a8974f8c8e88a50e62f2d4c4be2e60644c4966)), closes [#108](https://github.com/jolars/arity/issues/108)
+- **parser:** diagnose invalid function formal lists ([`6b63efe`](https://github.com/jolars/arity/commit/6b63efe459bc703aefba1079346aecc2d462b1cd)), closes [#109](https://github.com/jolars/arity/issues/109)
+
+### Performance Improvements
+- **parser:** verify a staged chain without rebuilding it ([`35976b9`](https://github.com/jolars/arity/commit/35976b97e4979e16f6ea965cb2b7990f61735545))
+- **parser:** borrow token text from the input ([`b439507`](https://github.com/jolars/arity/commit/b4395070a10e3ac9e64ff2057800a9efac1295a8))
+
 ## [0.5.0](https://github.com/jolars/arity/compare/arity-parser-v0.4.0...arity-parser-v0.5.0) (2026-08-14)
 
 ### Breaking changes

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.19.1](https://github.com/jolars/arity/compare/arity-code-v0.19.0...arity-code-v0.19.1) (2026-08-17)
+
+### Dependencies
+- updated arity to v0.19.1
+
 ## [0.19.0](https://github.com/jolars/arity/compare/arity-code-v0.18.0...arity-code-v0.19.0) (2026-08-14)
 
 ### Features

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.19.0",
-    "@arity-cli/linux-arm64-gnu": "0.19.0",
-    "@arity-cli/linux-x64-musl": "0.19.0",
-    "@arity-cli/linux-arm64-musl": "0.19.0",
-    "@arity-cli/darwin-x64": "0.19.0",
-    "@arity-cli/darwin-arm64": "0.19.0",
-    "@arity-cli/win32-x64": "0.19.0",
-    "@arity-cli/win32-arm64": "0.19.0"
+    "@arity-cli/linux-x64-gnu": "0.19.1",
+    "@arity-cli/linux-arm64-gnu": "0.19.1",
+    "@arity-cli/linux-x64-musl": "0.19.1",
+    "@arity-cli/linux-arm64-musl": "0.19.1",
+    "@arity-cli/darwin-x64": "0.19.1",
+    "@arity-cli/darwin-arm64": "0.19.1",
+    "@arity-cli/win32-x64": "0.19.1",
+    "@arity-cli/win32-arm64": "0.19.1"
   }
 }


### PR DESCRIPTION
## [arity: 0.19.1](https://github.com/jolars/arity/compare/v0.19.0...v0.19.1) (2026-08-17)

### Bug Fixes
- **roxygen:** classify Rd block macros by name ([`49f2f40`](https://github.com/jolars/arity/commit/49f2f40771d38496a46af29d6326515c28838dd3)), closes [#106](https://github.com/jolars/arity/issues/106)
- accept non-ASCII letters in syntactic R names ([`2c29b2f`](https://github.com/jolars/arity/commit/2c29b2f94215dac1adfe86ea1643ba7b935f5dc6)), refs [#108](https://github.com/jolars/arity/issues/108)

### Performance Improvements
- **linter:** seed the project scope once, not per document ([`f12344c`](https://github.com/jolars/arity/commit/f12344cb140631f79ab568933d1d48a4639e6abb))
- **project:** share the per-file facts instead of copying them twice ([`ebb1d4f`](https://github.com/jolars/arity/commit/ebb1d4f127896240f966547e0352fbf71be19ee1))
- **linter:** hand the salsa database teardown to the pool ([`210f8fc`](https://github.com/jolars/arity/commit/210f8fc92641e7fa4527330115f792abeae25bca))
- **linter:** read the prologue's files in parallel ([`938367b`](https://github.com/jolars/arity/commit/938367b9b9a8220bcab7a75a0769bad5fe747db7))
- **project:** stop reading DESCRIPTION twice per package root ([`262e460`](https://github.com/jolars/arity/commit/262e4604580582aa84da808e08a8243da28bfdf8))
- **project:** walk to a package root once per directory ([`7b75a3c`](https://github.com/jolars/arity/commit/7b75a3c1461350bc319f3d5c4339bb6d556eee19))
- **project:** share one NAMESPACE's sets across a package's members ([`21d1738`](https://github.com/jolars/arity/commit/21d17383ae01521439dcc90563633743a2efd8d5))
- **project:** answer the file-set relations from one shared member set ([`2777621`](https://github.com/jolars/arity/commit/277762165fe6fc748d780d1593205e095cca898f))
- **project:** derive visibility from shared layers, not per-member sets ([`36005a0`](https://github.com/jolars/arity/commit/36005a0fd114dc228433756d40187f40f14944fa))
- **project:** fold a package clique once, not per ordered pair ([`e1ecf4e`](https://github.com/jolars/arity/commit/e1ecf4ec9b8023ecb93d0c49a6247e6fce0524bb))
- **linter:** warm every fold input before the parallel passes ([`6c0ee06`](https://github.com/jolars/arity/commit/6c0ee06e87905f069a5a6766e0f47be241ea76b9))
- **lsp,incremental:** verify edit slices without applying them ([`7654bbd`](https://github.com/jolars/arity/commit/7654bbd6276891d09bbbc9ab458addc9621f9543))
- **text,lsp:** back document text with Arc<str> ([`e80c63a`](https://github.com/jolars/arity/commit/e80c63ac068635b33723ca50d534e646da6ed306))
- **rindex:** load the lint index lazily, per package ([`f472c69`](https://github.com/jolars/arity/commit/f472c69ecbd1fd3239004d976cd4b24c73e4c66a))
- **linter:** find a directive's comment by offset ([`0151f48`](https://github.com/jolars/arity/commit/0151f48471e6936e673629d52542e8ca95d66774))

### Dependencies
- updated crates/arity-formatter to v0.4.1
- updated crates/arity-parser to v0.5.1

## [crates/arity-formatter: 0.4.1](https://github.com/jolars/arity/compare/arity-formatter-v0.4.0...arity-formatter-v0.4.1) (2026-08-17)

### Bug Fixes
- **roxygen:** classify Rd block macros by name ([`49f2f40`](https://github.com/jolars/arity/commit/49f2f40771d38496a46af29d6326515c28838dd3)), closes [#106](https://github.com/jolars/arity/issues/106)

### Dependencies
- updated crates/arity-parser to v0.5.1

## [crates/arity-parser: 0.5.1](https://github.com/jolars/arity/compare/arity-parser-v0.5.0...arity-parser-v0.5.1) (2026-08-17)

### Bug Fixes
- **parser:** stop unterminated `%` at the line end ([`96ef35b`](https://github.com/jolars/arity/commit/96ef35b5ef61721ba27a08652eb7061a13ad1d31)), closes [#107](https://github.com/jolars/arity/issues/107)
- **roxygen:** classify Rd block macros by name ([`49f2f40`](https://github.com/jolars/arity/commit/49f2f40771d38496a46af29d6326515c28838dd3)), closes [#106](https://github.com/jolars/arity/issues/106)
- **parser:** lex non-ASCII letters as identifiers ([`e9a8974`](https://github.com/jolars/arity/commit/e9a8974f8c8e88a50e62f2d4c4be2e60644c4966)), closes [#108](https://github.com/jolars/arity/issues/108)
- **parser:** diagnose invalid function formal lists ([`6b63efe`](https://github.com/jolars/arity/commit/6b63efe459bc703aefba1079346aecc2d462b1cd)), closes [#109](https://github.com/jolars/arity/issues/109)

### Performance Improvements
- **parser:** verify a staged chain without rebuilding it ([`35976b9`](https://github.com/jolars/arity/commit/35976b97e4979e16f6ea965cb2b7990f61735545))
- **parser:** borrow token text from the input ([`b439507`](https://github.com/jolars/arity/commit/b4395070a10e3ac9e64ff2057800a9efac1295a8))

## [editors/code: 0.19.1](https://github.com/jolars/arity/compare/arity-code-v0.19.0...arity-code-v0.19.1) (2026-08-17)

### Dependencies
- updated arity to v0.19.1

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).