### PR TITLE
chore(release): v0.20.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,48 +1,48 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "f12344cb140631f79ab568933d1d48a4639e6abb",
+  "baseline-sha": "9c92a000a6612344d4a249b0ade525c989ed45b9",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.19.1",
-      "tag": "v0.19.1"
+      "version": "0.20.0",
+      "tag": "v0.20.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.4.1",
-      "tag": "arity-formatter-v0.4.1"
+      "version": "0.5.0",
+      "tag": "arity-formatter-v0.5.0"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.1",
-      "tag": "arity-parser-v0.5.1"
+      "version": "0.5.2",
+      "tag": "arity-parser-v0.5.2"
     },
     {
       "path": "editors/code",
-      "version": "0.19.1",
-      "tag": "arity-code-v0.19.1"
+      "version": "0.20.0",
+      "tag": "arity-code-v0.20.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.19.1",
-      "tag": "v0.19.1"
+      "version": "0.20.0",
+      "tag": "v0.20.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.4.1",
-      "tag": "arity-formatter-v0.4.1"
+      "version": "0.5.0",
+      "tag": "arity-formatter-v0.5.0"
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.1",
-      "tag": "arity-parser-v0.5.1"
+      "version": "0.5.2",
+      "tag": "arity-parser-v0.5.2"
     },
     {
       "path": "editors/code",
-      "version": "0.19.1",
-      "tag": "arity-code-v0.19.1"
+      "version": "0.20.0",
+      "tag": "arity-code-v0.20.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.20.0](https://github.com/jolars/arity/compare/v0.19.1...v0.20.0) (2026-08-21)
+
+### Features
+- **lint:** add description encoding rule ([`f4f0ba3`](https://github.com/jolars/arity/commit/f4f0ba39327a572ba3f2a795826abb99ec5e4638))
+- **lint:** flag unknown DESCRIPTION fields ([`1f52925`](https://github.com/jolars/arity/commit/1f5292522a89c028fa5a320c6227b788061a648e))
+- **roxygen:** honor projector markdown default ([`533fc49`](https://github.com/jolars/arity/commit/533fc496f54cae49697ad8d8a5c1ee692a934367))
+- **lint:** add pipe-return rule ([`18ab02a`](https://github.com/jolars/arity/commit/18ab02abe0eb0f2f6581b0cd4d6a09ea80682313))
+- **lint:** add base call rewrites ([`a04dd36`](https://github.com/jolars/arity/commit/a04dd3624509780de2aa6152cb0e6d69983221ce))
+- **lint:** flag assignments in return ([`72f7a77`](https://github.com/jolars/arity/commit/72f7a770f558530b85e1a4cecfff6223845970d0))
+- **lint:** add all-equal rule ([`eebc4f7`](https://github.com/jolars/arity/commit/eebc4f73506f0f043ff341ce6365025d51a3c649))
+- **lint:** add sprintf rule ([`a04b37c`](https://github.com/jolars/arity/commit/a04b37c2148dd4c973cbb38277ff4bfdcb311fa7))
+- **lint:** add rep-times-ignored rule ([`efcf3ca`](https://github.com/jolars/arity/commit/efcf3ca9f2805bbec571046ac309b1559c0e27f3))
+- **lint:** add missing-argument rule ([`594d564`](https://github.com/jolars/arity/commit/594d56474c2bafc13d3a609f43acb9a311ca5fa5))
+- **lint:** detect NaN and NULL comparisons ([`88da964`](https://github.com/jolars/arity/commit/88da9641af33fe1e82131286533d3f4bdd5eddff))
+
+### Bug Fixes
+- **lsp:** skip discovery on unchanged membership reseed ([`9c92a00`](https://github.com/jolars/arity/commit/9c92a000a6612344d4a249b0ade525c989ed45b9))
+- **lsp:** complete dependency names without faulting index in ([`b31b7db`](https://github.com/jolars/arity/commit/b31b7dbf235c488586604a1fc805353c33459dc0))
+- **lsp:** reload package index on cache root or meta change ([`79a86c3`](https://github.com/jolars/arity/commit/79a86c3a5eb976f2a375b7fa6f14bc8291091936))
+- **rindex:** derive package views from a single read ([`92608d5`](https://github.com/jolars/arity/commit/92608d5d97ce3a742e96c1ede8b6cc203585ddfb))
+- **lsp:** stop leaking project snapshots per metadata change ([`8cf322f`](https://github.com/jolars/arity/commit/8cf322fc027b4d2376bbe745004d34e7a23b3194)), fixes [#116](https://github.com/jolars/arity/issues/116)
+- **lsp:** record query log only during observation ([`9959129`](https://github.com/jolars/arity/commit/995912972850d056e71fbfa1964f0abb144ef68f))
+- **parser:** match read.dcf duplicate lookup ([`55f7b68`](https://github.com/jolars/arity/commit/55f7b6881fa5111c05307cb6250e99e65b5d7a37))
+- **parser:** match read.dcf empty-line folding ([`7ce1789`](https://github.com/jolars/arity/commit/7ce17894fc73e6b5b2c7e5f7075180f331494d44))
+- **lint:** recognize string-based reads ([`b2b7a23`](https://github.com/jolars/arity/commit/b2b7a238d40b9e8194c1533b8847fd8da25689a1)), closes [#115](https://github.com/jolars/arity/issues/115)
+- **parser:** span ordinary roxygen comments ([`592a5fe`](https://github.com/jolars/arity/commit/592a5fe17db1756fd6a8dde0d70236d102fa1cff))
+- **lint:** address future corpus false positives ([`5615b43`](https://github.com/jolars/arity/commit/5615b436a38e72c5148463cc98552026847a0261))
+
+### Performance Improvements
+- **lsp:** load package index lazily, once per cache root ([`de39edf`](https://github.com/jolars/arity/commit/de39edf9a291c7482a66171cea24982976721807))
+- **format:** bound formatting line diffs ([`c3f9bc5`](https://github.com/jolars/arity/commit/c3f9bc5ec0353d5e4f43cfb11fd19f82f0cb5593))
+
+### Dependencies
+- updated crates/arity-formatter to v0.5.0
+- updated crates/arity-parser to v0.5.2
+
 ## [0.19.1](https://github.com/jolars/arity/compare/v0.19.0...v0.19.1) (2026-08-17)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "arity-parser",
  "insta",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -396,9 +396,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -679,9 +679,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embedded-io"
@@ -1294,18 +1294,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.19.1"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.4.1" }
-arity-parser = { path = "crates/arity-parser", version = "0.5.1" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.5.0" }
+arity-parser = { path = "crates/arity-parser", version = "0.5.2" }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"
 crossbeam-channel = "0.5.16"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/arity/compare/arity-formatter-v0.4.1...arity-formatter-v0.5.0) (2026-08-21)
+
+### Features
+- **lint:** flag unknown DESCRIPTION fields ([`1f52925`](https://github.com/jolars/arity/commit/1f5292522a89c028fa5a320c6227b788061a648e))
+
+### Bug Fixes
+- **parser:** match read.dcf duplicate lookup ([`55f7b68`](https://github.com/jolars/arity/commit/55f7b6881fa5111c05307cb6250e99e65b5d7a37))
+- **parser:** match read.dcf empty-line folding ([`7ce1789`](https://github.com/jolars/arity/commit/7ce17894fc73e6b5b2c7e5f7075180f331494d44))
+- **parser:** span ordinary roxygen comments ([`592a5fe`](https://github.com/jolars/arity/commit/592a5fe17db1756fd6a8dde0d70236d102fa1cff))
+
+### Dependencies
+- updated crates/arity-parser to v0.5.2
+
 ## [0.4.1](https://github.com/jolars/arity/compare/arity-formatter-v0.4.0...arity-formatter-v0.4.1) (2026-08-17)
 
 ### Bug Fixes

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.5.1" }
+arity-parser = { path = "../arity-parser", version = "0.5.2" }
 rowan = "0.17.0"
 schemars = { version = "1.2.2", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.2](https://github.com/jolars/arity/compare/arity-parser-v0.5.1...arity-parser-v0.5.2) (2026-08-21)
+
+### Bug Fixes
+- **parser:** match read.dcf duplicate lookup ([`55f7b68`](https://github.com/jolars/arity/commit/55f7b6881fa5111c05307cb6250e99e65b5d7a37))
+- **parser:** match read.dcf empty-line folding ([`7ce1789`](https://github.com/jolars/arity/commit/7ce17894fc73e6b5b2c7e5f7075180f331494d44))
+- **parser:** span ordinary roxygen comments ([`592a5fe`](https://github.com/jolars/arity/commit/592a5fe17db1756fd6a8dde0d70236d102fa1cff))
+- **lint:** address future corpus false positives ([`5615b43`](https://github.com/jolars/arity/commit/5615b436a38e72c5148463cc98552026847a0261))
+- **parser:** reject return in native pipes ([`197a091`](https://github.com/jolars/arity/commit/197a0917736ad76ee1d8253ed688d260dcf5765c))
+
 ## [0.5.1](https://github.com/jolars/arity/compare/arity-parser-v0.5.0...arity-parser-v0.5.1) (2026-08-17)
 
 ### Bug Fixes

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.20.0](https://github.com/jolars/arity/compare/arity-code-v0.19.1...arity-code-v0.20.0) (2026-08-21)
+
+### Dependencies
+- updated arity to v0.20.0
+
 ## [0.19.1](https://github.com/jolars/arity/compare/arity-code-v0.19.0...arity-code-v0.19.1) (2026-08-17)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.19.1",
-    "@arity-cli/linux-arm64-gnu": "0.19.1",
-    "@arity-cli/linux-x64-musl": "0.19.1",
-    "@arity-cli/linux-arm64-musl": "0.19.1",
-    "@arity-cli/darwin-x64": "0.19.1",
-    "@arity-cli/darwin-arm64": "0.19.1",
-    "@arity-cli/win32-x64": "0.19.1",
-    "@arity-cli/win32-arm64": "0.19.1"
+    "@arity-cli/linux-x64-gnu": "0.20.0",
+    "@arity-cli/linux-arm64-gnu": "0.20.0",
+    "@arity-cli/linux-x64-musl": "0.20.0",
+    "@arity-cli/linux-arm64-musl": "0.20.0",
+    "@arity-cli/darwin-x64": "0.20.0",
+    "@arity-cli/darwin-arm64": "0.20.0",
+    "@arity-cli/win32-x64": "0.20.0",
+    "@arity-cli/win32-arm64": "0.20.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.20.0](https://github.com/jolars/arity/compare/v0.19.1...v0.20.0) (2026-08-21)

### Features
- **lint:** add description encoding rule ([`f4f0ba3`](https://github.com/jolars/arity/commit/f4f0ba39327a572ba3f2a795826abb99ec5e4638))
- **lint:** flag unknown DESCRIPTION fields ([`1f52925`](https://github.com/jolars/arity/commit/1f5292522a89c028fa5a320c6227b788061a648e))
- **roxygen:** honor projector markdown default ([`533fc49`](https://github.com/jolars/arity/commit/533fc496f54cae49697ad8d8a5c1ee692a934367))
- **lint:** add pipe-return rule ([`18ab02a`](https://github.com/jolars/arity/commit/18ab02abe0eb0f2f6581b0cd4d6a09ea80682313))
- **lint:** add base call rewrites ([`a04dd36`](https://github.com/jolars/arity/commit/a04dd3624509780de2aa6152cb0e6d69983221ce))
- **lint:** flag assignments in return ([`72f7a77`](https://github.com/jolars/arity/commit/72f7a770f558530b85e1a4cecfff6223845970d0))
- **lint:** add all-equal rule ([`eebc4f7`](https://github.com/jolars/arity/commit/eebc4f73506f0f043ff341ce6365025d51a3c649))
- **lint:** add sprintf rule ([`a04b37c`](https://github.com/jolars/arity/commit/a04b37c2148dd4c973cbb38277ff4bfdcb311fa7))
- **lint:** add rep-times-ignored rule ([`efcf3ca`](https://github.com/jolars/arity/commit/efcf3ca9f2805bbec571046ac309b1559c0e27f3))
- **lint:** add missing-argument rule ([`594d564`](https://github.com/jolars/arity/commit/594d56474c2bafc13d3a609f43acb9a311ca5fa5))
- **lint:** detect NaN and NULL comparisons ([`88da964`](https://github.com/jolars/arity/commit/88da9641af33fe1e82131286533d3f4bdd5eddff))

### Bug Fixes
- **lsp:** skip discovery on unchanged membership reseed ([`9c92a00`](https://github.com/jolars/arity/commit/9c92a000a6612344d4a249b0ade525c989ed45b9))
- **lsp:** complete dependency names without faulting index in ([`b31b7db`](https://github.com/jolars/arity/commit/b31b7dbf235c488586604a1fc805353c33459dc0))
- **lsp:** reload package index on cache root or meta change ([`79a86c3`](https://github.com/jolars/arity/commit/79a86c3a5eb976f2a375b7fa6f14bc8291091936))
- **rindex:** derive package views from a single read ([`92608d5`](https://github.com/jolars/arity/commit/92608d5d97ce3a742e96c1ede8b6cc203585ddfb))
- **lsp:** stop leaking project snapshots per metadata change ([`8cf322f`](https://github.com/jolars/arity/commit/8cf322fc027b4d2376bbe745004d34e7a23b3194)), fixes [#116](https://github.com/jolars/arity/issues/116)
- **lsp:** record query log only during observation ([`9959129`](https://github.com/jolars/arity/commit/995912972850d056e71fbfa1964f0abb144ef68f))
- **parser:** match read.dcf duplicate lookup ([`55f7b68`](https://github.com/jolars/arity/commit/55f7b6881fa5111c05307cb6250e99e65b5d7a37))
- **parser:** match read.dcf empty-line folding ([`7ce1789`](https://github.com/jolars/arity/commit/7ce17894fc73e6b5b2c7e5f7075180f331494d44))
- **lint:** recognize string-based reads ([`b2b7a23`](https://github.com/jolars/arity/commit/b2b7a238d40b9e8194c1533b8847fd8da25689a1)), closes [#115](https://github.com/jolars/arity/issues/115)
- **parser:** span ordinary roxygen comments ([`592a5fe`](https://github.com/jolars/arity/commit/592a5fe17db1756fd6a8dde0d70236d102fa1cff))
- **lint:** address future corpus false positives ([`5615b43`](https://github.com/jolars/arity/commit/5615b436a38e72c5148463cc98552026847a0261))

### Performance Improvements
- **lsp:** load package index lazily, once per cache root ([`de39edf`](https://github.com/jolars/arity/commit/de39edf9a291c7482a66171cea24982976721807))
- **format:** bound formatting line diffs ([`c3f9bc5`](https://github.com/jolars/arity/commit/c3f9bc5ec0353d5e4f43cfb11fd19f82f0cb5593))

### Dependencies
- updated crates/arity-formatter to v0.5.0
- updated crates/arity-parser to v0.5.2

## [crates/arity-formatter: 0.5.0](https://github.com/jolars/arity/compare/arity-formatter-v0.4.1...arity-formatter-v0.5.0) (2026-08-21)

### Features
- **lint:** flag unknown DESCRIPTION fields ([`1f52925`](https://github.com/jolars/arity/commit/1f5292522a89c028fa5a320c6227b788061a648e))

### Bug Fixes
- **parser:** match read.dcf duplicate lookup ([`55f7b68`](https://github.com/jolars/arity/commit/55f7b6881fa5111c05307cb6250e99e65b5d7a37))
- **parser:** match read.dcf empty-line folding ([`7ce1789`](https://github.com/jolars/arity/commit/7ce17894fc73e6b5b2c7e5f7075180f331494d44))
- **parser:** span ordinary roxygen comments ([`592a5fe`](https://github.com/jolars/arity/commit/592a5fe17db1756fd6a8dde0d70236d102fa1cff))

### Dependencies
- updated crates/arity-parser to v0.5.2

## [crates/arity-parser: 0.5.2](https://github.com/jolars/arity/compare/arity-parser-v0.5.1...arity-parser-v0.5.2) (2026-08-21)

### Bug Fixes
- **parser:** match read.dcf duplicate lookup ([`55f7b68`](https://github.com/jolars/arity/commit/55f7b6881fa5111c05307cb6250e99e65b5d7a37))
- **parser:** match read.dcf empty-line folding ([`7ce1789`](https://github.com/jolars/arity/commit/7ce17894fc73e6b5b2c7e5f7075180f331494d44))
- **parser:** span ordinary roxygen comments ([`592a5fe`](https://github.com/jolars/arity/commit/592a5fe17db1756fd6a8dde0d70236d102fa1cff))
- **lint:** address future corpus false positives ([`5615b43`](https://github.com/jolars/arity/commit/5615b436a38e72c5148463cc98552026847a0261))
- **parser:** reject return in native pipes ([`197a091`](https://github.com/jolars/arity/commit/197a0917736ad76ee1d8253ed688d260dcf5765c))

## [editors/code: 0.20.0](https://github.com/jolars/arity/compare/arity-code-v0.19.1...arity-code-v0.20.0) (2026-08-21)

### Dependencies
- updated arity to v0.20.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).