### PR TITLE
chore(release): v0.21.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,16 +1,16 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "9c92a000a6612344d4a249b0ade525c989ed45b9",
+  "baseline-sha": "940dbb8aa8f8b1a4c7e39a6937c8c1b7d511a081",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.20.0",
-      "tag": "v0.20.0"
+      "version": "0.21.0",
+      "tag": "v0.21.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.5.0",
-      "tag": "arity-formatter-v0.5.0"
+      "version": "0.6.0",
+      "tag": "arity-formatter-v0.6.0"
     },
     {
       "path": "crates/arity-parser",
@@ -19,30 +19,35 @@
     },
     {
       "path": "editors/code",
-      "version": "0.20.0",
-      "tag": "arity-code-v0.20.0"
+      "version": "0.21.0",
+      "tag": "arity-code-v0.21.0"
+    },
+    {
+      "path": "editors/zed",
+      "version": "0.2.0",
+      "tag": "arity-zed-v0.2.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.20.0",
-      "tag": "v0.20.0"
+      "version": "0.21.0",
+      "tag": "v0.21.0"
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.5.0",
-      "tag": "arity-formatter-v0.5.0"
-    },
-    {
-      "path": "crates/arity-parser",
-      "version": "0.5.2",
-      "tag": "arity-parser-v0.5.2"
+      "version": "0.6.0",
+      "tag": "arity-formatter-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.20.0",
-      "tag": "arity-code-v0.20.0"
+      "version": "0.21.0",
+      "tag": "arity-code-v0.21.0"
+    },
+    {
+      "path": "editors/zed",
+      "version": "0.2.0",
+      "tag": "arity-zed-v0.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.21.0](https://github.com/jolars/arity/compare/v0.20.0...v0.21.0) (2026-08-26)
+
+### Features
+- **format:** report outdated directives ([`eaa48e2`](https://github.com/jolars/arity/commit/eaa48e2791da1f88751dd0a2078135fa6e71a02c))
+- **lsp:** refresh cached config ([`6d82ca0`](https://github.com/jolars/arity/commit/6d82ca064d060cf3c5226f947e68bf3ae4b5bfb8))
+- **format:** align trailing comments ([`58d854c`](https://github.com/jolars/arity/commit/58d854c510c5ff90963bafcecd68d13b8f68ac89))
+
+### Bug Fixes
+- **lint:** gate local promise arguments ([`2ec3e8b`](https://github.com/jolars/arity/commit/2ec3e8b9fab3ec41ff5b06e8c1a52b6f7a7b6265))
+- **format:** preserve commas before comments ([`d529b97`](https://github.com/jolars/arity/commit/d529b97a951f0b00d37d0a0798e3d04f33d8c125)), closes [#117](https://github.com/jolars/arity/issues/117)
+
+### Performance Improvements
+- **lint:** reuse analyzed source for rendering ([`6cab16e`](https://github.com/jolars/arity/commit/6cab16eab1ca8d891b6a53cd9ddce17f930646cc))
+
+### Dependencies
+- updated crates/arity-formatter to v0.6.0
+
 ## [0.20.0](https://github.com/jolars/arity/compare/v0.19.1...v0.20.0) (2026-08-21)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arity-parser",
  "insta",
@@ -483,7 +483,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -545,9 +545,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lsp-server"
@@ -1309,7 +1309,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1486,7 +1486,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1520,7 +1520,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1556,7 +1556,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1567,7 +1567,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1591,7 +1591,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1762,7 +1762,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,7 +38,7 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.5.0" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.6.0" }
 arity-parser = { path = "crates/arity-parser", version = "0.5.2" }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/arity/compare/arity-formatter-v0.5.0...arity-formatter-v0.6.0) (2026-08-26)
+
+### Features
+- **format:** report outdated directives ([`eaa48e2`](https://github.com/jolars/arity/commit/eaa48e2791da1f88751dd0a2078135fa6e71a02c))
+- **formatter:** format tribble calls as tables ([`cd62e90`](https://github.com/jolars/arity/commit/cd62e903ba5adc87aedc3fa9170eae680b01231a))
+- **format:** align trailing comments ([`58d854c`](https://github.com/jolars/arity/commit/58d854c510c5ff90963bafcecd68d13b8f68ac89))
+
+### Bug Fixes
+- **formatter:** align Quarto annotations ([`12e8695`](https://github.com/jolars/arity/commit/12e869526cb0bfbeb8561265e4002d6462d18e88))
+- **formatter:** preserve Quarto annotations ([`02678e5`](https://github.com/jolars/arity/commit/02678e5dea41bd2819a8f547b4b7441603e52165))
+- **format:** preserve commas before comments ([`d529b97`](https://github.com/jolars/arity/commit/d529b97a951f0b00d37d0a0798e3d04f33d8c125)), closes [#117](https://github.com/jolars/arity/issues/117)
+
 ## [0.5.0](https://github.com/jolars/arity/compare/arity-formatter-v0.4.1...arity-formatter-v0.5.0) (2026-08-21)
 
 ### Features

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.21.0](https://github.com/jolars/arity/compare/arity-code-v0.20.0...arity-code-v0.21.0) (2026-08-26)
+
+### Bug Fixes
+- **editors:** pin `@types/vscode` and update arity version ([`0f6ee17`](https://github.com/jolars/arity/commit/0f6ee173b815acebc52116327df1b7dbf12e77fe))
+
+### Dependencies
+- updated arity to v0.21.0
+
 ## [0.20.0](https://github.com/jolars/arity/compare/arity-code-v0.19.1...arity-code-v0.20.0) (2026-08-21)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/CHANGELOG.md
+++ b/editors/zed/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.2.0](https://github.com/jolars/arity/compare/arity-zed-v0.1.0...arity-zed-v0.2.0) (2026-08-26)
+
+### Features
+- **editors:** add zed extension ([`d69cd4d`](https://github.com/jolars/arity/commit/d69cd4df2f130922260af04aa29d313cc707563a))

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "zed_arity"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_arity"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "arity-language-server"
 name = "Arity"
 description = "Language server, formatter, and linter for R"
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Johan Larsson <johan@jolars.co>"]
 repository = "https://github.com/jolars/arity"

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.20.0",
-    "@arity-cli/linux-arm64-gnu": "0.20.0",
-    "@arity-cli/linux-x64-musl": "0.20.0",
-    "@arity-cli/linux-arm64-musl": "0.20.0",
-    "@arity-cli/darwin-x64": "0.20.0",
-    "@arity-cli/darwin-arm64": "0.20.0",
-    "@arity-cli/win32-x64": "0.20.0",
-    "@arity-cli/win32-arm64": "0.20.0"
+    "@arity-cli/linux-x64-gnu": "0.21.0",
+    "@arity-cli/linux-arm64-gnu": "0.21.0",
+    "@arity-cli/linux-x64-musl": "0.21.0",
+    "@arity-cli/linux-arm64-musl": "0.21.0",
+    "@arity-cli/darwin-x64": "0.21.0",
+    "@arity-cli/darwin-arm64": "0.21.0",
+    "@arity-cli/win32-x64": "0.21.0",
+    "@arity-cli/win32-arm64": "0.21.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.21.0](https://github.com/jolars/arity/compare/v0.20.0...v0.21.0) (2026-08-26)

### Features
- **format:** report outdated directives ([`eaa48e2`](https://github.com/jolars/arity/commit/eaa48e2791da1f88751dd0a2078135fa6e71a02c))
- **lsp:** refresh cached config ([`6d82ca0`](https://github.com/jolars/arity/commit/6d82ca064d060cf3c5226f947e68bf3ae4b5bfb8))
- **format:** align trailing comments ([`58d854c`](https://github.com/jolars/arity/commit/58d854c510c5ff90963bafcecd68d13b8f68ac89))

### Bug Fixes
- **lint:** gate local promise arguments ([`2ec3e8b`](https://github.com/jolars/arity/commit/2ec3e8b9fab3ec41ff5b06e8c1a52b6f7a7b6265))
- **format:** preserve commas before comments ([`d529b97`](https://github.com/jolars/arity/commit/d529b97a951f0b00d37d0a0798e3d04f33d8c125)), closes [#117](https://github.com/jolars/arity/issues/117)

### Performance Improvements
- **lint:** reuse analyzed source for rendering ([`6cab16e`](https://github.com/jolars/arity/commit/6cab16eab1ca8d891b6a53cd9ddce17f930646cc))

### Dependencies
- updated crates/arity-formatter to v0.6.0

## [crates/arity-formatter: 0.6.0](https://github.com/jolars/arity/compare/arity-formatter-v0.5.0...arity-formatter-v0.6.0) (2026-08-26)

### Features
- **format:** report outdated directives ([`eaa48e2`](https://github.com/jolars/arity/commit/eaa48e2791da1f88751dd0a2078135fa6e71a02c))
- **formatter:** format tribble calls as tables ([`cd62e90`](https://github.com/jolars/arity/commit/cd62e903ba5adc87aedc3fa9170eae680b01231a))
- **format:** align trailing comments ([`58d854c`](https://github.com/jolars/arity/commit/58d854c510c5ff90963bafcecd68d13b8f68ac89))

### Bug Fixes
- **formatter:** align Quarto annotations ([`12e8695`](https://github.com/jolars/arity/commit/12e869526cb0bfbeb8561265e4002d6462d18e88))
- **formatter:** preserve Quarto annotations ([`02678e5`](https://github.com/jolars/arity/commit/02678e5dea41bd2819a8f547b4b7441603e52165))
- **format:** preserve commas before comments ([`d529b97`](https://github.com/jolars/arity/commit/d529b97a951f0b00d37d0a0798e3d04f33d8c125)), closes [#117](https://github.com/jolars/arity/issues/117)

## [editors/code: 0.21.0](https://github.com/jolars/arity/compare/arity-code-v0.20.0...arity-code-v0.21.0) (2026-08-26)

### Bug Fixes
- **editors:** pin `@types/vscode` and update arity version ([`0f6ee17`](https://github.com/jolars/arity/commit/0f6ee173b815acebc52116327df1b7dbf12e77fe))

### Dependencies
- updated arity to v0.21.0

## [editors/zed: 0.2.0](https://github.com/jolars/arity/compare/arity-zed-v0.1.0...arity-zed-v0.2.0) (2026-08-26)

### Features
- **editors:** add zed extension ([`d69cd4d`](https://github.com/jolars/arity/commit/d69cd4df2f130922260af04aa29d313cc707563a))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).