### PR TITLE
chore(release): v0.22.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,26 +1,36 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "940dbb8aa8f8b1a4c7e39a6937c8c1b7d511a081",
+  "baseline-sha": "bdf224de85a1dd4977d79b8675d7ec2945d50162",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.21.0",
-      "tag": "v0.21.0"
+      "version": "0.22.0",
+      "tag": "v0.22.0",
+      "dependencies": [
+        "crates/arity-formatter",
+        "crates/arity-parser"
+      ]
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.6.0",
-      "tag": "arity-formatter-v0.6.0"
+      "version": "0.7.0",
+      "tag": "arity-formatter-v0.7.0",
+      "dependencies": [
+        "crates/arity-parser"
+      ]
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.2",
-      "tag": "arity-parser-v0.5.2"
+      "version": "0.5.3",
+      "tag": "arity-parser-v0.5.3"
     },
     {
       "path": "editors/code",
-      "version": "0.21.0",
-      "tag": "arity-code-v0.21.0"
+      "version": "0.22.0",
+      "tag": "arity-code-v0.22.0",
+      "dependencies": [
+        "."
+      ]
     },
     {
       "path": "editors/zed",
@@ -31,23 +41,33 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.21.0",
-      "tag": "v0.21.0"
+      "version": "0.22.0",
+      "tag": "v0.22.0",
+      "dependencies": [
+        "crates/arity-formatter",
+        "crates/arity-parser"
+      ]
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.6.0",
-      "tag": "arity-formatter-v0.6.0"
+      "version": "0.7.0",
+      "tag": "arity-formatter-v0.7.0",
+      "dependencies": [
+        "crates/arity-parser"
+      ]
+    },
+    {
+      "path": "crates/arity-parser",
+      "version": "0.5.3",
+      "tag": "arity-parser-v0.5.3"
     },
     {
       "path": "editors/code",
-      "version": "0.21.0",
-      "tag": "arity-code-v0.21.0"
-    },
-    {
-      "path": "editors/zed",
-      "version": "0.2.0",
-      "tag": "arity-zed-v0.2.0"
+      "version": "0.22.0",
+      "tag": "arity-code-v0.22.0",
+      "dependencies": [
+        "."
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.22.0](https://github.com/jolars/arity/compare/v0.21.0...v0.22.0) (2026-08-31)
+
+### Features
+- verify formatter preserves syntax ([`b144f7d`](https://github.com/jolars/arity/commit/b144f7dc58e945b12c1484822b524ed403338bb7))
+
+### Bug Fixes
+- **formatter:** preserve else after comments ([`bdf224d`](https://github.com/jolars/arity/commit/bdf224de85a1dd4977d79b8675d7ec2945d50162)), fixes [#129](https://github.com/jolars/arity/issues/129)
+- **formatter:** ignore comment trailing whitespace ([`4d924d0`](https://github.com/jolars/arity/commit/4d924d050a8d043903118113d139597fef14f0ae)), fixes [#128](https://github.com/jolars/arity/issues/128)
+- **formatter:** keep bare if consequences ([`bd63cc8`](https://github.com/jolars/arity/commit/bd63cc8ff9976b4d9697d9229db0ed0909ceacb7)), fixes [#125](https://github.com/jolars/arity/issues/125)
+- **formatter:** preserve comment order ([`44626da`](https://github.com/jolars/arity/commit/44626dad0cc4da45700fa2a7ffda05c89e8da375)), fixes [#123](https://github.com/jolars/arity/issues/123)
+
+### Dependencies
+- updated crates/arity-formatter to v0.7.0
+- updated crates/arity-parser to v0.5.3
+
 ## [0.21.0](https://github.com/jolars/arity/compare/v0.20.0...v0.21.0) (2026-08-26)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arity-parser",
  "insta",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -219,7 +219,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-link",
@@ -357,9 +357,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -775,12 +775,13 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -922,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1105,6 +1106,15 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2118,6 +2128,12 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.6.0" }
-arity-parser = { path = "crates/arity-parser", version = "0.5.2" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.7.0" }
+arity-parser = { path = "crates/arity-parser", version = "0.5.3" }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"
 crossbeam-channel = "0.5.16"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.7.0](https://github.com/jolars/arity/compare/arity-formatter-v0.6.0...arity-formatter-v0.7.0) (2026-08-31)
+
+### Features
+- **formatter:** add verified formatting ([`a740ade`](https://github.com/jolars/arity/commit/a740aded663c232670bf094b78b46596fe8e7c23))
+
+### Bug Fixes
+- **formatter:** preserve else after comments ([`bdf224d`](https://github.com/jolars/arity/commit/bdf224de85a1dd4977d79b8675d7ec2945d50162)), fixes [#129](https://github.com/jolars/arity/issues/129)
+- **formatter:** ignore comment trailing whitespace ([`4d924d0`](https://github.com/jolars/arity/commit/4d924d050a8d043903118113d139597fef14f0ae)), fixes [#128](https://github.com/jolars/arity/issues/128)
+- **formatter:** keep bare if consequences ([`bd63cc8`](https://github.com/jolars/arity/commit/bd63cc8ff9976b4d9697d9229db0ed0909ceacb7)), fixes [#125](https://github.com/jolars/arity/issues/125)
+- **formatter:** preserve comment order ([`44626da`](https://github.com/jolars/arity/commit/44626dad0cc4da45700fa2a7ffda05c89e8da375)), fixes [#123](https://github.com/jolars/arity/issues/123)
+
+### Dependencies
+- updated crates/arity-parser to v0.5.3
+
 ## [0.6.0](https://github.com/jolars/arity/compare/arity-formatter-v0.5.0...arity-formatter-v0.6.0) (2026-08-26)
 
 ### Features

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.5.2" }
+arity-parser = { path = "../arity-parser", version = "0.5.3" }
 rowan = "0.17.0"
 schemars = { version = "1.2.2", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.3](https://github.com/jolars/arity/compare/arity-parser-v0.5.2...arity-parser-v0.5.3) (2026-08-31)
+
+### Bug Fixes
+- **parser:** attach bodies after comments ([`0de7517`](https://github.com/jolars/arity/commit/0de751795955e852db67e989f0e2b9e162d2e9dc))
+
 ## [0.5.2](https://github.com/jolars/arity/compare/arity-parser-v0.5.1...arity-parser-v0.5.2) (2026-08-21)
 
 ### Bug Fixes

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.22.0](https://github.com/jolars/arity/compare/arity-code-v0.21.0...arity-code-v0.22.0) (2026-08-31)
+
+### Dependencies
+- updated arity to v0.22.0
+
 ## [0.21.0](https://github.com/jolars/arity/compare/arity-code-v0.20.0...arity-code-v0.21.0) (2026-08-26)
 
 ### Bug Fixes

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -66,12 +66,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -310,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -352,9 +353,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -821,6 +822,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         arity = pkgs.rustPlatform.buildRustPackage {
           pname = "arity";
-          version = "0.21.0";
+          version = "0.22.0";
 
           src = ./.;
 

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.21.0",
-    "@arity-cli/linux-arm64-gnu": "0.21.0",
-    "@arity-cli/linux-x64-musl": "0.21.0",
-    "@arity-cli/linux-arm64-musl": "0.21.0",
-    "@arity-cli/darwin-x64": "0.21.0",
-    "@arity-cli/darwin-arm64": "0.21.0",
-    "@arity-cli/win32-x64": "0.21.0",
-    "@arity-cli/win32-arm64": "0.21.0"
+    "@arity-cli/linux-x64-gnu": "0.22.0",
+    "@arity-cli/linux-arm64-gnu": "0.22.0",
+    "@arity-cli/linux-x64-musl": "0.22.0",
+    "@arity-cli/linux-arm64-musl": "0.22.0",
+    "@arity-cli/darwin-x64": "0.22.0",
+    "@arity-cli/darwin-arm64": "0.22.0",
+    "@arity-cli/win32-x64": "0.22.0",
+    "@arity-cli/win32-arm64": "0.22.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.22.0](https://github.com/jolars/arity/compare/v0.21.0...v0.22.0) (2026-08-31)

### Features
- verify formatter preserves syntax ([`b144f7d`](https://github.com/jolars/arity/commit/b144f7dc58e945b12c1484822b524ed403338bb7))

### Bug Fixes
- **formatter:** preserve else after comments ([`bdf224d`](https://github.com/jolars/arity/commit/bdf224de85a1dd4977d79b8675d7ec2945d50162)), fixes [#129](https://github.com/jolars/arity/issues/129)
- **formatter:** ignore comment trailing whitespace ([`4d924d0`](https://github.com/jolars/arity/commit/4d924d050a8d043903118113d139597fef14f0ae)), fixes [#128](https://github.com/jolars/arity/issues/128)
- **formatter:** keep bare if consequences ([`bd63cc8`](https://github.com/jolars/arity/commit/bd63cc8ff9976b4d9697d9229db0ed0909ceacb7)), fixes [#125](https://github.com/jolars/arity/issues/125)
- **formatter:** preserve comment order ([`44626da`](https://github.com/jolars/arity/commit/44626dad0cc4da45700fa2a7ffda05c89e8da375)), fixes [#123](https://github.com/jolars/arity/issues/123)

### Dependencies
- updated crates/arity-formatter to v0.7.0
- updated crates/arity-parser to v0.5.3

## [crates/arity-formatter: 0.7.0](https://github.com/jolars/arity/compare/arity-formatter-v0.6.0...arity-formatter-v0.7.0) (2026-08-31)

### Features
- **formatter:** add verified formatting ([`a740ade`](https://github.com/jolars/arity/commit/a740aded663c232670bf094b78b46596fe8e7c23))

### Bug Fixes
- **formatter:** preserve else after comments ([`bdf224d`](https://github.com/jolars/arity/commit/bdf224de85a1dd4977d79b8675d7ec2945d50162)), fixes [#129](https://github.com/jolars/arity/issues/129)
- **formatter:** ignore comment trailing whitespace ([`4d924d0`](https://github.com/jolars/arity/commit/4d924d050a8d043903118113d139597fef14f0ae)), fixes [#128](https://github.com/jolars/arity/issues/128)
- **formatter:** keep bare if consequences ([`bd63cc8`](https://github.com/jolars/arity/commit/bd63cc8ff9976b4d9697d9229db0ed0909ceacb7)), fixes [#125](https://github.com/jolars/arity/issues/125)
- **formatter:** preserve comment order ([`44626da`](https://github.com/jolars/arity/commit/44626dad0cc4da45700fa2a7ffda05c89e8da375)), fixes [#123](https://github.com/jolars/arity/issues/123)

### Dependencies
- updated crates/arity-parser to v0.5.3

## [crates/arity-parser: 0.5.3](https://github.com/jolars/arity/compare/arity-parser-v0.5.2...arity-parser-v0.5.3) (2026-08-31)

### Bug Fixes
- **parser:** attach bodies after comments ([`0de7517`](https://github.com/jolars/arity/commit/0de751795955e852db67e989f0e2b9e162d2e9dc))

## [editors/code: 0.22.0](https://github.com/jolars/arity/compare/arity-code-v0.21.0...arity-code-v0.22.0) (2026-08-31)

### Dependencies
- updated arity to v0.22.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).