### PR TITLE
chore(release): v0.23.0 (+3 more)

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "bdf224de85a1dd4977d79b8675d7ec2945d50162",
+  "baseline-sha": "d082c9d35a50feeee9c6b1e0328749b9af749bc6",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.22.0",
-      "tag": "v0.22.0",
+      "version": "0.23.0",
+      "tag": "v0.23.0",
       "dependencies": [
         "crates/arity-formatter",
         "crates/arity-parser"
@@ -13,21 +13,21 @@
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.7.0",
-      "tag": "arity-formatter-v0.7.0",
+      "version": "0.7.1",
+      "tag": "arity-formatter-v0.7.1",
       "dependencies": [
         "crates/arity-parser"
       ]
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.3",
-      "tag": "arity-parser-v0.5.3"
+      "version": "0.6.0",
+      "tag": "arity-parser-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.22.0",
-      "tag": "arity-code-v0.22.0",
+      "version": "0.23.0",
+      "tag": "arity-code-v0.23.0",
       "dependencies": [
         "."
       ]
@@ -41,8 +41,8 @@
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "0.22.0",
-      "tag": "v0.22.0",
+      "version": "0.23.0",
+      "tag": "v0.23.0",
       "dependencies": [
         "crates/arity-formatter",
         "crates/arity-parser"
@@ -50,21 +50,21 @@
     },
     {
       "path": "crates/arity-formatter",
-      "version": "0.7.0",
-      "tag": "arity-formatter-v0.7.0",
+      "version": "0.7.1",
+      "tag": "arity-formatter-v0.7.1",
       "dependencies": [
         "crates/arity-parser"
       ]
     },
     {
       "path": "crates/arity-parser",
-      "version": "0.5.3",
-      "tag": "arity-parser-v0.5.3"
+      "version": "0.6.0",
+      "tag": "arity-parser-v0.6.0"
     },
     {
       "path": "editors/code",
-      "version": "0.22.0",
-      "tag": "arity-code-v0.22.0",
+      "version": "0.23.0",
+      "tag": "arity-code-v0.23.0",
       "dependencies": [
         "."
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.23.0](https://github.com/jolars/arity/compare/v0.22.0...v0.23.0) (2026-09-07)
+
+### Features
+- **lint:** add boolean-arithmetic rule ([`da1045b`](https://github.com/jolars/arity/commit/da1045be08bd19256103fb6b979f571cbef392e8))
+- **parser:** expose function formals ([`9333512`](https://github.com/jolars/arity/commit/93335128b924b8f98a57100dfe8a0cda0b83dcbd))
+- **rindex:** use typed NAMESPACE syntax ([`677902e`](https://github.com/jolars/arity/commit/677902e5e59abb2d76d2046b78f5dc37006c8245))
+- **config:** publish schema ([`7180652`](https://github.com/jolars/arity/commit/7180652f028a203e43ea2527fdd064fa3301a44f))
+- **lint:** add description text format rule ([`080b46c`](https://github.com/jolars/arity/commit/080b46ceeabc5dedea1907fb96f7a646fa1434b5))
+
+### Bug Fixes
+- bump `rust-version` to 1.89 and CI job ([`6683330`](https://github.com/jolars/arity/commit/6683330fe806effe4ecd0eee4b5dfbda040c3aef))
+
+### Dependencies
+- updated crates/arity-formatter to v0.7.1
+- updated crates/arity-parser to v0.6.0
+
 ## [0.22.0](https://github.com/jolars/arity/compare/v0.21.0...v0.22.0) (2026-08-31)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "arity"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "annotate-snippets",
  "arity-formatter",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "arity-formatter"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arity-parser",
  "insta",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "arity-parser"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "air_r_parser",
  "criterion",
@@ -446,9 +446,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -533,7 +533,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -637,18 +637,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -656,27 +656,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+checksum = "03e8bd762f7479489c70ed6c768ddca99d7296857de437a68dcb2a94365b3fae"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -729,7 +729,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -856,9 +856,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "a596f1b20ed2cc5ecac41a164aaebc7258057060f06c0cf7a2ba3991ee7990fb"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.1"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
@@ -1590,9 +1590,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -1715,7 +1715,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1830,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "log",
  "once_cell",
@@ -1909,7 +1909,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1943,7 +1943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1979,7 +1979,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2070,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smol_str"
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2234,7 +2234,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2259,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2393,9 +2393,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
  "base64",
  "log",
@@ -2409,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
 dependencies = [
  "base64",
  "http",
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2499,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2509,22 +2509,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2775,7 +2775,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Johan Larsson <johan@jolars.co>"]
 
 [package]
 name = "arity"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -38,8 +38,8 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets = "0.12.16"
-arity-formatter = { path = "crates/arity-formatter", version = "0.7.0" }
-arity-parser = { path = "crates/arity-parser", version = "0.5.3" }
+arity-formatter = { path = "crates/arity-formatter", version = "0.7.1" }
+arity-parser = { path = "crates/arity-parser", version = "0.6.0" }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"
 crossbeam-channel = "0.5.16"

--- a/crates/arity-formatter/CHANGELOG.md
+++ b/crates/arity-formatter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.1](https://github.com/jolars/arity/compare/arity-formatter-v0.7.0...arity-formatter-v0.7.1) (2026-09-07)
+
+### Dependencies
+- updated crates/arity-parser to v0.6.0
+
 ## [0.7.0](https://github.com/jolars/arity/compare/arity-formatter-v0.6.0...arity-formatter-v0.7.0) (2026-08-31)
 
 ### Features

--- a/crates/arity-formatter/Cargo.toml
+++ b/crates/arity-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-formatter"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"
@@ -15,7 +15,7 @@ keywords = ["r", "formatter", "tidyverse"]
 categories = ["development-tools", "text-processing"]
 
 [dependencies]
-arity-parser = { path = "../arity-parser", version = "0.5.3" }
+arity-parser = { path = "../arity-parser", version = "0.6.0" }
 rowan = "0.17.0"
 schemars = { version = "1.2.2", optional = true }
 serde = { version = "1.0.229", features = ["derive"], optional = true }

--- a/crates/arity-parser/CHANGELOG.md
+++ b/crates/arity-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/arity/compare/arity-parser-v0.5.3...arity-parser-v0.6.0) (2026-09-07)
+
+### Features
+- **parser:** expose function formals ([`9333512`](https://github.com/jolars/arity/commit/93335128b924b8f98a57100dfe8a0cda0b83dcbd))
+- **parser:** add NAMESPACE syntax surface ([`d26d8c4`](https://github.com/jolars/arity/commit/d26d8c441be6aab08000a581c4c4780fa524977c))
+
 ## [0.5.3](https://github.com/jolars/arity/compare/arity-parser-v0.5.2...arity-parser-v0.5.3) (2026-08-31)
 
 ### Bug Fixes

--- a/crates/arity-parser/Cargo.toml
+++ b/crates/arity-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arity-parser"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/editors/code/CHANGELOG.md
+++ b/editors/code/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.23.0](https://github.com/jolars/arity/compare/arity-code-v0.22.0...arity-code-v0.23.0) (2026-09-07)
+
+### Dependencies
+- updated arity to v0.23.0
+
 ## [0.22.0](https://github.com/jolars/arity/compare/arity-code-v0.21.0...arity-code-v0.22.0) (2026-08-31)
 
 ### Dependencies

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "arity",
   "displayName": "Arity",
   "description": "R language server, formatter, and linter",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "publisher": "jolars",
   "license": "MIT",
   "icon": "icon.png",

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.1"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -453,7 +453,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -483,9 +483,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "spdx"
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -820,7 +820,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         arity = pkgs.rustPlatform.buildRustPackage {
           pname = "arity";
-          version = "0.22.0";
+          version = "0.23.0";
 
           src = ./.;
 

--- a/npm/arity-cli/package.json
+++ b/npm/arity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arity-cli",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "commonjs",
   "description": "A language server, formatter, and linter for R",
   "keywords": [
@@ -29,13 +29,13 @@
     "node": ">=20"
   },
   "optionalDependencies": {
-    "@arity-cli/linux-x64-gnu": "0.22.0",
-    "@arity-cli/linux-arm64-gnu": "0.22.0",
-    "@arity-cli/linux-x64-musl": "0.22.0",
-    "@arity-cli/linux-arm64-musl": "0.22.0",
-    "@arity-cli/darwin-x64": "0.22.0",
-    "@arity-cli/darwin-arm64": "0.22.0",
-    "@arity-cli/win32-x64": "0.22.0",
-    "@arity-cli/win32-arm64": "0.22.0"
+    "@arity-cli/linux-x64-gnu": "0.23.0",
+    "@arity-cli/linux-arm64-gnu": "0.23.0",
+    "@arity-cli/linux-x64-musl": "0.23.0",
+    "@arity-cli/linux-arm64-musl": "0.23.0",
+    "@arity-cli/darwin-x64": "0.23.0",
+    "@arity-cli/darwin-arm64": "0.23.0",
+    "@arity-cli/win32-x64": "0.23.0",
+    "@arity-cli/win32-arm64": "0.23.0"
   }
 }


### PR DESCRIPTION
## [arity: 0.23.0](https://github.com/jolars/arity/compare/v0.22.0...v0.23.0) (2026-09-07)

### Features
- **lint:** add boolean-arithmetic rule ([`da1045b`](https://github.com/jolars/arity/commit/da1045be08bd19256103fb6b979f571cbef392e8))
- **parser:** expose function formals ([`9333512`](https://github.com/jolars/arity/commit/93335128b924b8f98a57100dfe8a0cda0b83dcbd))
- **rindex:** use typed NAMESPACE syntax ([`677902e`](https://github.com/jolars/arity/commit/677902e5e59abb2d76d2046b78f5dc37006c8245))
- **config:** publish schema ([`7180652`](https://github.com/jolars/arity/commit/7180652f028a203e43ea2527fdd064fa3301a44f))
- **lint:** add description text format rule ([`080b46c`](https://github.com/jolars/arity/commit/080b46ceeabc5dedea1907fb96f7a646fa1434b5))

### Bug Fixes
- bump `rust-version` to 1.89 and CI job ([`6683330`](https://github.com/jolars/arity/commit/6683330fe806effe4ecd0eee4b5dfbda040c3aef))

### Dependencies
- updated crates/arity-formatter to v0.7.1
- updated crates/arity-parser to v0.6.0

## [crates/arity-formatter: 0.7.1](https://github.com/jolars/arity/compare/arity-formatter-v0.7.0...arity-formatter-v0.7.1) (2026-09-07)

### Dependencies
- updated crates/arity-parser to v0.6.0

## [crates/arity-parser: 0.6.0](https://github.com/jolars/arity/compare/arity-parser-v0.5.3...arity-parser-v0.6.0) (2026-09-07)

### Features
- **parser:** expose function formals ([`9333512`](https://github.com/jolars/arity/commit/93335128b924b8f98a57100dfe8a0cda0b83dcbd))
- **parser:** add NAMESPACE syntax surface ([`d26d8c4`](https://github.com/jolars/arity/commit/d26d8c441be6aab08000a581c4c4780fa524977c))

## [editors/code: 0.23.0](https://github.com/jolars/arity/compare/arity-code-v0.22.0...arity-code-v0.23.0) (2026-09-07)

### Dependencies
- updated arity to v0.23.0

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).